### PR TITLE
Address review findings (spaday)

### DIFF
--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -2,10 +2,6 @@ import * as wasm from "../../dist/pkg/spaday";
 
 export * as wasm from "../../dist/pkg/spaday";
 
-export const placeholder = "";
-
-export const foo = () => wasm.foo();
-
 /** Diff two JSON-encoded component trees, returning the JSON-encoded patch. */
 export const diff = (oldTree: string, newTree: string): string =>
   wasm.diff(oldTree, newTree);

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -31,9 +31,15 @@ export function mount(container: Element, tree: Node): Element {
   return el;
 }
 
-/** Apply a tree patch (from the core `diff`) to a mounted root, mutating the DOM in place. */
-export function applyPatch(root: Element, patch: { ops: Op[] }): void {
-  for (const op of patch.ops) applyOp(root, op);
+/**
+ * Apply a tree patch (from the core `diff`) to a mounted root, mutating the DOM in place. Returns the
+ * current root — a root-level `Replace` swaps the element, so callers must keep the returned value
+ * (the original `root` reference would be left detached).
+ */
+export function applyPatch(root: Element, patch: { ops: Op[] }): Element {
+  let current = root;
+  for (const op of patch.ops) current = applyOp(current, op);
+  return current;
 }
 
 function build(node: Node): Element {
@@ -115,7 +121,7 @@ function resolve(root: Element, path: Path): Element {
   return el;
 }
 
-function applyOp(root: Element, op: Op): void {
+function applyOp(root: Element, op: Op): Element {
   if ("SetProp" in op) {
     setProp(
       resolve(root, op.SetProp.path),
@@ -137,7 +143,11 @@ function applyOp(root: Element, op: Op): void {
     moving.remove();
     insertInSlot(parent, slot, to, moving);
   } else if ("Replace" in op) {
-    resolve(root, op.Replace.path).replaceWith(build(op.Replace.node));
+    const target = resolve(root, op.Replace.path);
+    const replacement = build(op.Replace.node);
+    target.replaceWith(replacement);
+    if (op.Replace.path.length === 0) return replacement; // the root element itself was swapped
   }
   // SetEvent / RemoveEvent / SetKey: events bind with the action DSL; keys are diff-engine metadata.
+  return root;
 }

--- a/js/tests/runtime.spec.js
+++ b/js/tests/runtime.spec.js
@@ -84,6 +84,39 @@ test("Replace swaps a subtree on tag change", async ({ page }) => {
   expect(html).toBe("<div><b>y</b></div>");
 });
 
+test("a root-level Replace returns the new root (caller's old ref goes stale)", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, applyPatch } = window.__spaday;
+    const c = document.createElement("div");
+    const root = mount(c, {
+      tag: "section",
+      props: { textContent: { Str: "x" } },
+    });
+    const newRoot = applyPatch(root, {
+      ops: [
+        {
+          Replace: {
+            path: [],
+            node: { tag: "article", props: { textContent: { Str: "y" } } },
+          },
+        },
+      ],
+    });
+    return {
+      html: c.innerHTML,
+      newTag: newRoot.tagName.toLowerCase(),
+      oldDetached: root.parentNode === null, // the original root was swapped out
+      newInDom: newRoot.parentNode === c,
+    };
+  });
+  expect(result.html).toBe("<article>y</article>");
+  expect(result.newTag).toBe("article");
+  expect(result.oldDetached).toBe(true);
+  expect(result.newInDom).toBe(true);
+});
+
 test("a keyed reorder patch moves live elements (incremental == full render)", async ({
   page,
 }) => {

--- a/spaday/examples/dashboard.py
+++ b/spaday/examples/dashboard.py
@@ -39,7 +39,8 @@ from spaday.components.webawesome import WaButton, WaOption, WaSelect, WaSwitch
 
 HERE = Path(__file__).parent
 JS = HERE.parent.parent / "js"
-TYPES = ["line", "area", "candlestick", "bar", "histogram"]
+# value-shaped series only — the ticker emits {time, value}; candlestick/bar need OHLC points
+TYPES = ["line", "area", "histogram"]
 
 
 class Chart(BaseModel):


### PR DESCRIPTION
Actioning the spaday ultrareview:

- **HIGH:** `applyPatch` returned `void`, but a root-level `Replace` (`path: []`) swaps the element and left the caller's `root` reference detached — subsequent patches mutated the wrong (orphaned) node. `applyPatch` now returns the current root (threaded through `applyOp`), and a new browser test covers `Replace` at `path: []` (prior coverage only replaced a child).
- **Med:** the dashboard exposed `candlestick`/`bar`, but `ChartSource` only emits `{time, value}`; OHLC series require `open/high/low/close` and would break the live demo. Limited the demo to value-shaped series (`line`/`area`/`histogram`).
- **Low:** removed the scaffold template exports (`placeholder`, `foo`) from the public JS entry.

Verified: `playwright test` 6 (runtime), `pytest` 18, ruff/prettier clean.