### PR TITLE
Action DSL in the Rust core + the full Phase 2 action set, dark mode, and shell polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
 name = "spaday_js"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "serde-wasm-bindgen",
  "spaday",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +60,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +88,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -153,6 +195,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "spaday"
 version = "0.1.0"
 dependencies = [
@@ -197,6 +256,7 @@ dependencies = [
 name = "spaday_js"
 version = "0.1.0"
 dependencies = [
+ "serde-wasm-bindgen",
  "spaday",
  "wasm-bindgen",
 ]

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -14,3 +14,4 @@ crate-type = ["cdylib"]
 [dependencies]
 spaday = { path = "../rust", version = "*" }
 wasm-bindgen = "=0.2.121"
+serde-wasm-bindgen = "0.6"

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -14,4 +14,5 @@ crate-type = ["cdylib"]
 [dependencies]
 spaday = { path = "../rust", version = "*" }
 wasm-bindgen = "=0.2.121"
+serde = "1"
 serde-wasm-bindgen = "0.6"

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -17,6 +17,8 @@ extern "C" {
     fn event_value(this: &Host) -> JsValue;
     #[wasm_bindgen(method)]
     fn emit(this: &Host, event: &str, detail: JsValue);
+    #[wasm_bindgen(method, js_name = sendPatch)]
+    fn send_patch(this: &Host, model: &str, field: &str, value: JsValue);
 }
 
 /// Interpret a serialized action (the core's DSL wire form) against the DOM primitives in `host`.
@@ -31,7 +33,7 @@ pub fn interpret(action: &str, host: &Host) -> Result<(), JsError> {
 }
 
 fn run(action: &spaday::Action, host: &Host) {
-    use spaday::Action::{Emit, Sequence, SetProp, Toggle};
+    use spaday::Action::{Emit, SendPatch, Sequence, SetProp, Toggle};
     match action {
         SetProp {
             target,
@@ -58,6 +60,13 @@ fn run(action: &spaday::Action, host: &Host) {
                 .as_ref()
                 .map_or(JsValue::UNDEFINED, |e| eval(e, host));
             host.emit(event, d);
+        }
+        SendPatch {
+            model,
+            field,
+            value,
+        } => {
+            host.send_patch(model, field, eval(value, host));
         }
     }
 }

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -1,9 +1,100 @@
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn foo() -> u32 {
-    // do something
-    1 + 1
+extern "C" {
+    /// The DOM primitives the browser supplies so the (DOM-free) core interpreter can run. The
+    /// interpreter decides *what* to do; this thin host does the actual DOM poking.
+    pub type Host;
+    #[wasm_bindgen(method, js_name = currentTarget)]
+    fn current_target(this: &Host) -> JsValue;
+    #[wasm_bindgen(method, js_name = queryId)]
+    fn query_id(this: &Host, id: &str) -> JsValue;
+    #[wasm_bindgen(method, js_name = getProp)]
+    fn get_prop(this: &Host, el: &JsValue, name: &str) -> JsValue;
+    #[wasm_bindgen(method, js_name = setProp)]
+    fn set_prop(this: &Host, el: &JsValue, name: &str, value: JsValue);
+    #[wasm_bindgen(method, js_name = eventValue)]
+    fn event_value(this: &Host) -> JsValue;
+    #[wasm_bindgen(method)]
+    fn emit(this: &Host, event: &str, detail: JsValue);
+}
+
+/// Interpret a serialized action (the core's DSL wire form) against the DOM primitives in `host`.
+///
+/// Behavior is data: the action is parsed + validated by the shared core, then evaluated here with no
+/// `eval`. This is the browser-side half of the action DSL — the same model the Python binding authors.
+#[wasm_bindgen]
+pub fn interpret(action: &str, host: &Host) -> Result<(), JsError> {
+    let action = spaday::parse_action(action).map_err(|e| JsError::new(&e))?;
+    run(&action, host);
+    Ok(())
+}
+
+fn run(action: &spaday::Action, host: &Host) {
+    use spaday::Action::{Emit, Sequence, SetProp, Toggle};
+    match action {
+        SetProp {
+            target,
+            prop,
+            value,
+        } => {
+            if let Some(el) = resolve(target, host) {
+                host.set_prop(&el, prop, eval(value, host));
+            }
+        }
+        Toggle { target, prop } => {
+            if let Some(el) = resolve(target, host) {
+                let next = !truthy(&host.get_prop(&el, prop));
+                host.set_prop(&el, prop, JsValue::from_bool(next));
+            }
+        }
+        Sequence { actions } => {
+            for a in actions {
+                run(a, host);
+            }
+        }
+        Emit { event, detail } => {
+            let d = detail
+                .as_ref()
+                .map_or(JsValue::UNDEFINED, |e| eval(e, host));
+            host.emit(event, d);
+        }
+    }
+}
+
+fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
+    use spaday::Expr::{Event, Lit, Not};
+    match expr {
+        Lit { value } => serde_wasm_bindgen::to_value(value).unwrap_or(JsValue::UNDEFINED),
+        Event => host.event_value(),
+        Not { of } => JsValue::from_bool(!truthy(&eval(of, host))),
+    }
+}
+
+fn resolve(target: &spaday::Ref, host: &Host) -> Option<JsValue> {
+    use spaday::Ref::{Id, This};
+    let el = match target {
+        This => host.current_target(),
+        Id { id } => host.query_id(id),
+    };
+    (!el.is_null() && !el.is_undefined()).then_some(el)
+}
+
+/// JS truthiness for the values the DSL deals in (bool / number / string / null).
+fn truthy(v: &JsValue) -> bool {
+    if let Some(b) = v.as_bool() {
+        return b;
+    }
+    if v.is_null() || v.is_undefined() {
+        return false;
+    }
+    if let Some(n) = v.as_f64() {
+        return n != 0.0;
+    }
+    if let Some(s) = v.as_string() {
+        return !s.is_empty();
+    }
+    true
 }
 
 /// Diff two JSON-encoded component trees, returning the JSON-encoded patch.

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -19,6 +20,10 @@ extern "C" {
     fn emit(this: &Host, event: &str, detail: JsValue);
     #[wasm_bindgen(method, js_name = sendPatch)]
     fn send_patch(this: &Host, model: &str, field: &str, value: JsValue);
+    #[wasm_bindgen(method, js_name = callEndpoint)]
+    fn call_endpoint(this: &Host, method: &str, url: &str, body: JsValue);
+    #[wasm_bindgen(method, js_name = callNamed)]
+    fn call_named(this: &Host, handler: &str);
 }
 
 /// Interpret a serialized action (the core's DSL wire form) against the DOM primitives in `host`.
@@ -33,7 +38,7 @@ pub fn interpret(action: &str, host: &Host) -> Result<(), JsError> {
 }
 
 fn run(action: &spaday::Action, host: &Host) {
-    use spaday::Action::{Emit, If, SendPatch, Sequence, SetProp, Toggle};
+    use spaday::Action::{CallEndpoint, Emit, If, NamedJs, SendPatch, Sequence, SetProp, Toggle};
     match action {
         SetProp {
             target,
@@ -75,13 +80,22 @@ fn run(action: &spaday::Action, host: &Host) {
                 run(e, host);
             }
         }
+        CallEndpoint { method, url, body } => {
+            let b = body.as_ref().map_or(JsValue::UNDEFINED, |e| eval(e, host));
+            host.call_endpoint(method, url, b);
+        }
+        NamedJs { handler } => host.call_named(handler),
     }
 }
 
 fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
     use spaday::Expr::{Event, Lit, Not, Prop};
     match expr {
-        Lit { value } => serde_wasm_bindgen::to_value(value).unwrap_or(JsValue::UNDEFINED),
+        // json_compatible: JSON objects become plain JS objects (not Maps), so they round-trip through
+        // `JSON.stringify` (e.g. a CallEndpoint body) and set cleanly as props.
+        Lit { value } => value
+            .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+            .unwrap_or(JsValue::UNDEFINED),
         Event => host.event_value(),
         Not { of } => JsValue::from_bool(!truthy(&eval(of, host))),
         Prop { target, name } => {

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -33,7 +33,7 @@ pub fn interpret(action: &str, host: &Host) -> Result<(), JsError> {
 }
 
 fn run(action: &spaday::Action, host: &Host) {
-    use spaday::Action::{Emit, SendPatch, Sequence, SetProp, Toggle};
+    use spaday::Action::{Emit, If, SendPatch, Sequence, SetProp, Toggle};
     match action {
         SetProp {
             target,
@@ -68,15 +68,25 @@ fn run(action: &spaday::Action, host: &Host) {
         } => {
             host.send_patch(model, field, eval(value, host));
         }
+        If { cond, then, els } => {
+            if truthy(&eval(cond, host)) {
+                run(then, host);
+            } else if let Some(e) = els {
+                run(e, host);
+            }
+        }
     }
 }
 
 fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
-    use spaday::Expr::{Event, Lit, Not};
+    use spaday::Expr::{Event, Lit, Not, Prop};
     match expr {
         Lit { value } => serde_wasm_bindgen::to_value(value).unwrap_or(JsValue::UNDEFINED),
         Event => host.event_value(),
         Not { of } => JsValue::from_bool(!truthy(&eval(of, host))),
+        Prop { target, name } => {
+            resolve(target, host).map_or(JsValue::NULL, |el| host.get_prop(&el, name))
+        }
     }
 }
 

--- a/js/src/ts/actions.ts
+++ b/js/src/ts/actions.ts
@@ -1,15 +1,12 @@
-// The action-DSL interpreter: declarative actions (authored in Python, carried as serialized data)
-// executed in the browser on DOM events — no per-interaction round-trip to Python. Behavior is data,
-// not code: the interpreter dispatches on each action's `kind` and evaluates expressions structurally;
-// there is no `eval`, so actions are safe to ship to untrusted, multi-tenant clients.
+// The browser-side half of the action DSL. The interpreter logic — dispatch on each action and
+// evaluate its expressions — lives in the Rust core (compiled into the `js` wasm crate); this module
+// is the thin DOM host it calls back into. So behavior authored in Python runs client-side with no
+// round-trip and no `eval`, and Python and the browser share one model.
 //
-// The Rust core currently carries actions opaquely; moving these types + this interpreter into the
-// shared core (wasm) so Python and the browser evaluate with one implementation is the next step.
+// Requires the wasm to be initialized first (see `init` from the package entry).
 
+import { interpret as wasmInterpret } from "../../dist/pkg/spaday";
 import { setProp } from "./runtime";
-
-/* eslint-disable @typescript-eslint/no-explicit-any -- actions are dynamic, untagged JSON data */
-type Json = any;
 
 /** The context an action runs in: the DOM event and the element the listener is bound to. */
 export interface ActionContext {
@@ -17,14 +14,9 @@ export interface ActionContext {
   currentTarget: Element;
 }
 
-function resolveRef(ref: Json, ctx: ActionContext): Element | null {
-  if (!ref || typeof ref !== "object") return null;
-  if (ref.ref === "this") return ctx.currentTarget;
-  if (ref.ref === "id") {
-    const root = ctx.currentTarget.getRootNode() as ParentNode;
-    return root.querySelector("#" + CSS.escape(ref.id));
-  }
-  return null;
+/** Run one action (the core's plain DSL wire form) against the DOM in the given event context. */
+export function interpret(action: unknown, ctx: ActionContext): void {
+  wasmInterpret(JSON.stringify(action), host(ctx));
 }
 
 function readProp(el: Element, name: string): unknown {
@@ -32,51 +24,26 @@ function readProp(el: Element, name: string): unknown {
   return el.hasAttribute(name) ? el.getAttribute(name) : null;
 }
 
-function evalExpr(expr: Json, ctx: ActionContext): unknown {
-  if (expr == null || typeof expr !== "object") return expr; // a bare literal
-  switch (expr.expr) {
-    case "lit":
-      return expr.value;
-    case "event": {
+// The DOM primitives the wasm interpreter calls back into (mirrors the `Host` extern in the js crate).
+function host(ctx: ActionContext) {
+  return {
+    currentTarget: () => ctx.currentTarget,
+    queryId: (id: string) =>
+      (ctx.currentTarget.getRootNode() as ParentNode).querySelector(
+        "#" + CSS.escape(id),
+      ),
+    getProp: (el: Element, name: string) => readProp(el, name),
+    setProp: (el: Element, name: string, value: unknown) =>
+      setProp(el, name, value),
+    eventValue: () => {
       const target = ctx.event.target as Record<string, unknown> | null;
       if (target && typeof target.checked === "boolean") return target.checked;
       if (target && "value" in target) return target.value;
       return (ctx.event as CustomEvent).detail;
-    }
-    case "not":
-      return !evalExpr(expr.of, ctx);
-    default:
-      return undefined;
-  }
-}
-
-/** Execute one action (already untagged) against the DOM in the given event context. */
-export function interpret(action: Json, ctx: ActionContext): void {
-  if (!action || typeof action !== "object") return;
-  switch (action.kind) {
-    case "set": {
-      const el = resolveRef(action.target, ctx);
-      if (el) setProp(el, action.prop, evalExpr(action.value, ctx));
-      break;
-    }
-    case "toggle": {
-      const el = resolveRef(action.target, ctx);
-      if (el) setProp(el, action.prop, !readProp(el, action.prop));
-      break;
-    }
-    case "seq":
-      for (const sub of action.actions ?? []) interpret(sub, ctx);
-      break;
-    case "emit":
+    },
+    emit: (event: string, detail: unknown) =>
       ctx.currentTarget.dispatchEvent(
-        new CustomEvent(action.event, {
-          detail:
-            action.detail != null ? evalExpr(action.detail, ctx) : undefined,
-          bubbles: true,
-        }),
-      );
-      break;
-    default:
-      break;
-  }
+        new CustomEvent(event, { detail, bubbles: true }),
+      ),
+  };
 }

--- a/js/src/ts/actions.ts
+++ b/js/src/ts/actions.ts
@@ -47,5 +47,13 @@ function host(ctx: ActionContext) {
       ctx.currentTarget.dispatchEvent(
         new CustomEvent(event, { detail, bubbles: true }),
       ),
+    // SendPatch is surfaced as a bubbling intent the app routes to its wire (e.g. a transports edit).
+    sendPatch: (model: string, field: string, value: unknown) =>
+      ctx.currentTarget.dispatchEvent(
+        new CustomEvent("spaday:patch", {
+          detail: { model, field, value },
+          bubbles: true,
+        }),
+      ),
   };
 }

--- a/js/src/ts/actions.ts
+++ b/js/src/ts/actions.ts
@@ -6,6 +6,7 @@
 // Requires the wasm to be initialized first (see `init` from the package entry).
 
 import { interpret as wasmInterpret } from "../../dist/pkg/spaday";
+import { getHandler } from "./handlers";
 import { setProp } from "./runtime";
 import { assertReady } from "./wasm-ready";
 
@@ -55,5 +56,18 @@ function host(ctx: ActionContext) {
           bubbles: true,
         }),
       ),
+    // CallEndpoint: the one intentional server round-trip (fire-and-forget JSON fetch).
+    callEndpoint: (method: string, url: string, body: unknown) =>
+      void fetch(url, {
+        method,
+        headers:
+          body === undefined
+            ? undefined
+            : { "content-type": "application/json" },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      }),
+    // NamedJs escape hatch: invoke a pre-registered handler by name (no eval).
+    callNamed: (handler: string) =>
+      getHandler(handler)?.(ctx.event, ctx.currentTarget),
   };
 }

--- a/js/src/ts/actions.ts
+++ b/js/src/ts/actions.ts
@@ -7,6 +7,7 @@
 
 import { interpret as wasmInterpret } from "../../dist/pkg/spaday";
 import { setProp } from "./runtime";
+import { assertReady } from "./wasm-ready";
 
 /** The context an action runs in: the DOM event and the element the listener is bound to. */
 export interface ActionContext {
@@ -16,6 +17,7 @@ export interface ActionContext {
 
 /** Run one action (the core's plain DSL wire form) against the DOM in the given event context. */
 export function interpret(action: unknown, ctx: ActionContext): void {
+  assertReady(); // clear error if an action fires before the wasm core is initialized
   wasmInterpret(JSON.stringify(action), host(ctx));
 }
 

--- a/js/src/ts/handlers.ts
+++ b/js/src/ts/handlers.ts
@@ -1,0 +1,16 @@
+// A registry of named JS handlers for the `NamedJs` action — the action DSL's escape hatch. The app
+// pre-registers handlers by name (so there is no arbitrary `eval`); the interpreter invokes them by
+// name for the rare case the declarative actions can't express.
+
+export type NamedHandler = (event: Event, currentTarget: Element) => void;
+
+const handlers = new Map<string, NamedHandler>();
+
+/** Register a JS handler that a `NamedJs("name")` action can invoke. */
+export function registerHandler(name: string, fn: NamedHandler): void {
+  handlers.set(name, fn);
+}
+
+export function getHandler(name: string): NamedHandler | undefined {
+  return handlers.get(name);
+}

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -7,7 +7,8 @@ export * as wasm from "../../dist/pkg/spaday";
 
 /**
  * Initialize the wasm core (required before the action interpreter runs in the browser). Pass the
- * `spaday_bg.wasm` URL, e.g. `await init("/js/dist/pkg/spaday_bg.wasm")`, before interacting.
+ * `spaday_bg.wasm` URL, e.g. `await init({ module_or_path: "/js/dist/pkg/spaday_bg.wasm" })`, before
+ * interacting.
  */
 export async function init(
   moduleOrPath?: Parameters<typeof wasmInit>[0],

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -1,10 +1,20 @@
+import wasmInit from "../../dist/pkg/spaday";
 import * as wasm from "../../dist/pkg/spaday";
+
+import { markReady } from "./wasm-ready";
 
 export * as wasm from "../../dist/pkg/spaday";
 
-// Initialize the wasm core (required before the action interpreter runs in the browser). Pass the
-// `spaday_bg.wasm` URL, e.g. `await init("/js/dist/pkg/spaday_bg.wasm")`, before `mount`.
-export { default as init } from "../../dist/pkg/spaday";
+/**
+ * Initialize the wasm core (required before the action interpreter runs in the browser). Pass the
+ * `spaday_bg.wasm` URL, e.g. `await init("/js/dist/pkg/spaday_bg.wasm")`, before interacting.
+ */
+export async function init(
+  moduleOrPath?: Parameters<typeof wasmInit>[0],
+): Promise<void> {
+  await wasmInit(moduleOrPath);
+  markReady();
+}
 
 /** Diff two JSON-encoded component trees, returning the JSON-encoded patch. */
 export const diff = (oldTree: string, newTree: string): string =>

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -37,6 +37,10 @@ export type { Node } from "./runtime";
 export { interpret } from "./actions";
 export type { ActionContext } from "./actions";
 
+// Register a named JS handler for the `NamedJs` action (the DSL's no-eval escape hatch).
+export { registerHandler } from "./handlers";
+export type { NamedHandler } from "./handlers";
+
 // High-level layout/shell primitives — defines the spa-* custom elements on import.
 export { SHELL_TAGS } from "./shell";
 

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -2,6 +2,10 @@ import * as wasm from "../../dist/pkg/spaday";
 
 export * as wasm from "../../dist/pkg/spaday";
 
+// Initialize the wasm core (required before the action interpreter runs in the browser). Pass the
+// `spaday_bg.wasm` URL, e.g. `await init("/js/dist/pkg/spaday_bg.wasm")`, before `mount`.
+export { default as init } from "../../dist/pkg/spaday";
+
 /** Diff two JSON-encoded component trees, returning the JSON-encoded patch. */
 export const diff = (oldTree: string, newTree: string): string =>
   wasm.diff(oldTree, newTree);

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -3,8 +3,8 @@
 //
 // This is the consumer of the diff engine: the server (Python) computes a patch with the shared Rust
 // `diff`; the browser applies it here against live DOM, so a `wa-switch`'s internal state survives an
-// update instead of being re-created. Event handlers are bound later (with the action DSL); this
-// layer renders structure and props.
+// update instead of being re-created. It renders structure + props and binds the action-DSL event
+// handlers, rebinding/detaching them as incremental `SetEvent`/`RemoveEvent` patches arrive.
 
 import { interpret } from "./actions";
 import { untag, Value } from "./value";
@@ -43,6 +43,30 @@ export function applyPatch(root: Element, patch: { ops: Op[] }): Element {
   return current;
 }
 
+// Live action listeners per element, so an incremental patch can update them: the diff engine emits
+// `SetEvent` when an action is added/changed and `RemoveEvent` when one is removed on an existing node.
+const listeners = new WeakMap<Element, Map<string, EventListener>>();
+
+function bindEvent(el: Element, name: string, action: unknown): void {
+  let map = listeners.get(el);
+  if (!map) listeners.set(el, (map = new Map()));
+  const existing = map.get(name);
+  if (existing) el.removeEventListener(name, existing); // replace, don't stack
+  const handler: EventListener = (event) =>
+    interpret(action, { event, currentTarget: el });
+  el.addEventListener(name, handler);
+  map.set(name, handler);
+}
+
+function unbindEvent(el: Element, name: string): void {
+  const map = listeners.get(el);
+  const handler = map?.get(name);
+  if (handler) {
+    el.removeEventListener(name, handler);
+    map!.delete(name);
+  }
+}
+
 function build(node: Node): Element {
   const el = document.createElement(node.tag);
   for (const [name, value] of Object.entries(node.props ?? {})) {
@@ -52,10 +76,7 @@ function build(node: Node): Element {
     for (const child of children) appendInSlot(el, slot, build(child));
   }
   for (const [name, action] of Object.entries(node.events ?? {})) {
-    // actions ride the wire as the core's own DSL form (plain JSON), not a tagged Value
-    el.addEventListener(name, (event) =>
-      interpret(action, { event, currentTarget: el }),
-    );
+    bindEvent(el, name, action); // actions ride the wire as the core's DSL form (plain JSON)
   }
   return el;
 }
@@ -137,6 +158,12 @@ function applyOp(root: Element, op: Op): Element {
     );
   } else if ("RemoveProp" in op) {
     removeProp(resolve(root, op.RemoveProp.path), op.RemoveProp.name);
+  } else if ("SetEvent" in op) {
+    const { path, name, action } = op.SetEvent;
+    bindEvent(resolve(root, path), name, action);
+  } else if ("RemoveEvent" in op) {
+    const { path, name } = op.RemoveEvent;
+    unbindEvent(resolve(root, path), name);
   } else if ("InsertChild" in op) {
     const { path, slot, index, node } = op.InsertChild;
     insertInSlot(resolve(root, path), slot, index, build(node));
@@ -155,6 +182,6 @@ function applyOp(root: Element, op: Op): Element {
     target.replaceWith(replacement);
     if (op.Replace.path.length === 0) return replacement; // the root element itself was swapped
   }
-  // SetEvent / RemoveEvent / SetKey: events bind with the action DSL; keys are diff-engine metadata.
+  // SetKey is diff-engine metadata (the key lives in the tree, not on the DOM element).
   return root;
 }

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -52,9 +52,9 @@ function build(node: Node): Element {
     for (const child of children) appendInSlot(el, slot, build(child));
   }
   for (const [name, action] of Object.entries(node.events ?? {})) {
-    const a = untag(action as Value);
+    // actions ride the wire as the core's own DSL form (plain JSON), not a tagged Value
     el.addEventListener(name, (event) =>
-      interpret(a, { event, currentTarget: el }),
+      interpret(action, { event, currentTarget: el }),
     );
   }
   return el;

--- a/js/src/ts/shell.ts
+++ b/js/src/ts/shell.ts
@@ -4,25 +4,27 @@
 // with one default `<slot>` and a `:host` style; structure comes from how you nest them
 // (App › Nav / Body › Gutter + Main / Footer), spacing from Stack/Row/Toolbar.
 //
-// First cut: pure structural containers, tuned with CSS custom properties (`--spa-gap`,
-// `--spa-gutter-width`, `--spa-border`, …) that fall back to sensible defaults. No props/attributes
-// yet; importing this module (side effect, via the runtime entry) defines the elements.
+// Surfaces/borders/muted-text fall back to **WebAwesome theme tokens**, so the shell follows the active
+// light/dark theme automatically (with a plain default when WebAwesome isn't present). A few layout
+// attributes — `gap` / `align` / `justify` / `width` — map to the corresponding CSS custom properties.
+// Importing this module (side effect, via the runtime entry) defines the elements.
 
-const BORDER = "var(--spa-border, #e6e6e6)";
-const SURFACE = "var(--spa-surface, #fff)";
-const SURFACE_2 = "var(--spa-surface-2, #fafafa)";
-const MUTED = "var(--spa-muted, #666)";
+const BORDER = "var(--spa-border, var(--wa-color-surface-border, #e6e6e6))";
+const SURFACE = "var(--spa-surface, var(--wa-color-surface-default, #fff))";
+const SURFACE_2 =
+  "var(--spa-surface-2, var(--wa-color-surface-lowered, #fafafa))";
+const MUTED = "var(--spa-muted, var(--wa-color-text-quiet, #666))";
 
 /** tag → the element's `:host` layout style. Each gets a shadow root with this style + a default slot. */
 const SHELL: Record<string, string> = {
   // page frame: nav (top) / body (fills) / footer (bottom), stacked
   "spa-app": ":host{display:flex;flex-direction:column;min-height:100vh}",
   // top app bar
-  "spa-nav": `:host{display:flex;align-items:center;gap:1rem;padding:.75rem 1.25rem;border-bottom:1px solid ${BORDER};background:${SURFACE}}`,
+  "spa-nav": `:host{display:flex;align-items:center;gap:var(--spa-gap, 1rem);padding:.75rem 1.25rem;border-bottom:1px solid ${BORDER};background:${SURFACE}}`,
   // middle region: gutters + main, side by side
   "spa-body": ":host{display:flex;flex:1;min-height:0}",
   // a sidebar; place before or after main to get a left/right gutter
-  "spa-gutter": `:host{display:flex;flex-direction:column;gap:.5rem;flex:none;width:var(--spa-gutter-width, 220px);padding:1rem;border-right:1px solid ${BORDER};background:${SURFACE_2}}`,
+  "spa-gutter": `:host{display:flex;flex-direction:column;gap:var(--spa-gap, .5rem);flex:none;width:var(--spa-gutter-width, 220px);padding:1rem;border-right:1px solid ${BORDER};background:${SURFACE_2}}`,
   // primary content region
   "spa-main":
     ":host{display:block;flex:1;min-width:0;padding:1.5rem;overflow:auto}",
@@ -30,15 +32,26 @@ const SHELL: Record<string, string> = {
   "spa-footer": `:host{padding:.6rem 1.25rem;border-top:1px solid ${BORDER};background:${SURFACE};font-size:.8rem;color:${MUTED}}`,
   // generic vertical group
   "spa-stack":
-    ":host{display:flex;flex-direction:column;gap:var(--spa-gap, .75rem)}",
+    ":host{display:flex;flex-direction:column;gap:var(--spa-gap, .75rem);align-items:var(--spa-align, stretch)}",
   // generic horizontal group
-  "spa-row": ":host{display:flex;align-items:center;gap:var(--spa-gap, 1rem)}",
+  "spa-row":
+    ":host{display:flex;align-items:var(--spa-align, center);justify-content:var(--spa-justify, flex-start);gap:var(--spa-gap, 1rem)}",
   // a contained strip of actions/controls
-  "spa-toolbar": `:host{display:flex;align-items:center;gap:.5rem;padding:.5rem .6rem;background:${SURFACE_2};border:1px solid ${BORDER};border-radius:8px}`,
+  "spa-toolbar": `:host{display:flex;align-items:var(--spa-align, center);gap:var(--spa-gap, .5rem);padding:.5rem .6rem;background:${SURFACE_2};border:1px solid ${BORDER};border-radius:8px}`,
 };
 
 /** The shell element tags, defined on import. */
 export const SHELL_TAGS = Object.keys(SHELL);
+
+// Layout attributes → the CSS custom property they drive. Setting e.g. `gap="2rem"` on a shell element
+// sets `--spa-gap` on its host, which the `:host` style above reads (an element ignores vars it doesn't
+// use, so the same set is safe on every tag).
+const ATTR_VARS: Record<string, string> = {
+  gap: "--spa-gap",
+  align: "--spa-align",
+  justify: "--spa-justify",
+  width: "--spa-gutter-width",
+};
 
 // WebAwesome's `wa-button` host is `inline-block`; as a flex item in these containers it blockifies to
 // `block` and its internal base part overflows the host (overlapping neighbors). Forcing `inline-flex`
@@ -54,12 +67,25 @@ if (typeof customElements !== "undefined") {
     customElements.define(
       tag,
       class extends HTMLElement {
+        static get observedAttributes(): string[] {
+          return Object.keys(ATTR_VARS);
+        }
         constructor() {
           super();
           const root = this.attachShadow({ mode: "open" });
           const style = document.createElement("style");
           style.textContent = css + SLOTTED_FIX;
           root.append(style, document.createElement("slot"));
+        }
+        attributeChangedCallback(
+          name: string,
+          _old: string | null,
+          value: string | null,
+        ): void {
+          const prop = ATTR_VARS[name];
+          if (!prop) return;
+          if (value == null) this.style.removeProperty(prop);
+          else this.style.setProperty(prop, value);
         }
       },
     );

--- a/js/src/ts/wasm-ready.ts
+++ b/js/src/ts/wasm-ready.ts
@@ -1,0 +1,18 @@
+// Tracks whether the wasm core has been initialized. The action interpreter runs in wasm, so an event
+// firing before `init()` would otherwise fail with a cryptic wasm-bindgen error; this lets it fail with
+// a clear, actionable message instead. `init` (the package entry) flips the flag on success.
+
+let ready = false;
+
+export function markReady(): void {
+  ready = true;
+}
+
+export function assertReady(): void {
+  if (!ready) {
+    throw new Error(
+      'spaday: the wasm core is not initialized — `await init("…/spaday_bg.wasm")` before interacting ' +
+        "with components that carry actions.",
+    );
+  }
+}

--- a/js/src/ts/wasm-ready.ts
+++ b/js/src/ts/wasm-ready.ts
@@ -11,8 +11,8 @@ export function markReady(): void {
 export function assertReady(): void {
   if (!ready) {
     throw new Error(
-      'spaday: the wasm core is not initialized — `await init("…/spaday_bg.wasm")` before interacting ' +
-        "with components that carry actions.",
+      'spaday: the wasm core is not initialized — `await init({ module_or_path: "…/spaday_bg.wasm" })` ' +
+        "before interacting with components that carry actions.",
     );
   }
 }

--- a/js/src/ts/wrappers/lightweight-chart.ts
+++ b/js/src/ts/wrappers/lightweight-chart.ts
@@ -11,6 +11,7 @@ import {
   AreaSeries,
   BarSeries,
   CandlestickSeries,
+  ColorType,
   createChart,
   HistogramSeries,
   IChartApi,
@@ -36,6 +37,7 @@ export class LightweightChart extends HTMLElement {
   private _type: ChartType = "line";
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- data shape varies by series type
   private _data: any[] = [];
+  private _theme: "light" | "dark" = "light";
 
   connectedCallback(): void {
     if (!this.style.display) this.style.display = "block";
@@ -45,6 +47,7 @@ export class LightweightChart extends HTMLElement {
       autoSize: true,
       layout: { attributionLogo: false },
     });
+    this.applyTheme();
     this.addSeries();
     this.draw();
   }
@@ -73,6 +76,32 @@ export class LightweightChart extends HTMLElement {
   set data(value: unknown[]) {
     this._data = (value as unknown[]) ?? [];
     this.draw();
+  }
+
+  // lightweight-charts is a canvas — it doesn't read CSS, so it can't follow the page's light/dark
+  // theme on its own. Set `theme` to recolor its text + grid; the background stays transparent so the
+  // surface behind it (e.g. a wa-card) shows through and matches whichever mode is active.
+  get theme(): "light" | "dark" {
+    return this._theme;
+  }
+  set theme(value: "light" | "dark") {
+    this._theme = value === "dark" ? "dark" : "light";
+    this.applyTheme();
+  }
+
+  private applyTheme(): void {
+    if (!this.chart) return;
+    const dark = this._theme === "dark";
+    this.chart.applyOptions({
+      layout: {
+        background: { type: ColorType.Solid, color: "rgba(0,0,0,0)" },
+        textColor: dark ? "#c9c9d2" : "#222222",
+      },
+      grid: {
+        vertLines: { color: dark ? "#2c2c34" : "#ededed" },
+        horzLines: { color: dark ? "#2c2c34" : "#ededed" },
+      },
+    });
   }
 
   private addSeries(): void {

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -186,3 +186,58 @@ test("SendPatch fires a routable spaday:patch intent carrying the event value", 
   // the app routes this intent to its wire (e.g. a transports edit on model "global")
   expect(detail).toEqual({ model: "global", field: "live", value: true });
 });
+
+test("If runs then/else based on a prop condition read from another element", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const root = window.__spaday.mount(document.body, {
+      tag: "div",
+      slots: {
+        default: [
+          {
+            tag: "input",
+            props: { id: { Str: "sw" }, type: { Str: "checkbox" } },
+          },
+          { tag: "div", props: { id: { Str: "panel" } } },
+          {
+            tag: "button",
+            events: {
+              click: {
+                kind: "if",
+                cond: {
+                  expr: "prop",
+                  target: { ref: "id", id: "sw" },
+                  name: "checked",
+                },
+                then: {
+                  kind: "set",
+                  target: { ref: "id", id: "panel" },
+                  prop: "hidden",
+                  value: { expr: "lit", value: true },
+                },
+                else: {
+                  kind: "set",
+                  target: { ref: "id", id: "panel" },
+                  prop: "hidden",
+                  value: { expr: "lit", value: false },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const sw = root.querySelector("#sw");
+    const btn = root.querySelector("button");
+    const panel = document.getElementById("panel");
+    btn.click(); // sw unchecked -> else -> hidden=false
+    const whenUnchecked = panel.hidden;
+    sw.checked = true;
+    btn.click(); // sw checked (prop cond true) -> then -> hidden=true
+    const whenChecked = panel.hidden;
+    return { whenUnchecked, whenChecked };
+  });
+  expect(result.whenUnchecked).toBe(false);
+  expect(result.whenChecked).toBe(true);
+});

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -1,9 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 // The action DSL end-to-end: a node carries an action in its `events` map (the exact wire shape
-// `spaday/actions.py` emits), the runtime binds a listener in `build()`, and a real DOM event runs the
-// interpreter against live DOM. There is no server and no `diff`/`apply` here — that is the point:
-// behavior runs client-side with no round-trip to Python.
+// `spaday/actions.py` emits and the Rust core defines), the runtime binds a listener in `build()`, and
+// a real DOM event runs the interpreter against live DOM. Actions ride the wire as plain JSON (the
+// core's own DSL form), not a tagged Value. No server, no `diff`/`apply` — behavior runs client-side.
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/tests/runtime.html");
@@ -14,11 +14,10 @@ test("Toggle flips a boolean prop on the event's own element (this)", async ({
   page,
 }) => {
   const states = await page.evaluate(() => {
-    const { mount, tag } = window.__spaday;
-    const btn = mount(document.body, {
+    const btn = window.__spaday.mount(document.body, {
       tag: "button",
       events: {
-        click: tag({ kind: "toggle", target: { ref: "this" }, prop: "hidden" }),
+        click: { kind: "toggle", target: { ref: "this" }, prop: "hidden" },
       },
     });
     const seen = [];
@@ -35,8 +34,7 @@ test("SetProp by_id sets a literal on another element in the tree", async ({
   page,
 }) => {
   const hidden = await page.evaluate(() => {
-    const { mount, tag } = window.__spaday;
-    const root = mount(document.body, {
+    const root = window.__spaday.mount(document.body, {
       tag: "div",
       slots: {
         default: [
@@ -44,12 +42,12 @@ test("SetProp by_id sets a literal on another element in the tree", async ({
           {
             tag: "button",
             events: {
-              click: tag({
+              click: {
                 kind: "set",
                 target: { ref: "id", id: "panel" },
                 prop: "hidden",
                 value: { expr: "lit", value: true },
-              }),
+              },
             },
           },
         ],
@@ -67,8 +65,7 @@ test("SetProp binds an element prop to the event value through not_", async ({
   // The canonical `WaSwitch.on("change", SetProp(by_id("panel"), "hidden", not_(event_value())))`:
   // checking the box (event value true) shows the panel; unchecking hides it.
   const result = await page.evaluate(() => {
-    const { mount, tag } = window.__spaday;
-    const root = mount(document.body, {
+    const root = window.__spaday.mount(document.body, {
       tag: "div",
       slots: {
         default: [
@@ -77,12 +74,12 @@ test("SetProp binds an element prop to the event value through not_", async ({
             tag: "input",
             props: { type: { Str: "checkbox" } },
             events: {
-              change: tag({
+              change: {
                 kind: "set",
                 target: { ref: "id", id: "panel" },
                 prop: "hidden",
                 value: { expr: "not", of: { expr: "event" } },
-              }),
+              },
             },
           },
         ],
@@ -104,11 +101,10 @@ test("SetProp binds an element prop to the event value through not_", async ({
 
 test("Sequence runs its actions in order", async ({ page }) => {
   const state = await page.evaluate(() => {
-    const { mount, tag } = window.__spaday;
-    const btn = mount(document.body, {
+    const btn = window.__spaday.mount(document.body, {
       tag: "button",
       events: {
-        click: tag({
+        click: {
           kind: "seq",
           actions: [
             { kind: "toggle", target: { ref: "this" }, prop: "hidden" },
@@ -119,7 +115,7 @@ test("Sequence runs its actions in order", async ({ page }) => {
               value: { expr: "lit", value: "true" },
             },
           ],
-        }),
+        },
       },
     });
     btn.click();
@@ -130,19 +126,18 @@ test("Sequence runs its actions in order", async ({ page }) => {
 
 test("Emit dispatches a bubbling custom event", async ({ page }) => {
   const detail = await page.evaluate(() => {
-    const { mount, tag } = window.__spaday;
-    const root = mount(document.body, {
+    const root = window.__spaday.mount(document.body, {
       tag: "div",
       slots: {
         default: [
           {
             tag: "button",
             events: {
-              click: tag({
+              click: {
                 kind: "emit",
                 event: "ping",
                 detail: { expr: "lit", value: "hi" },
-              }),
+              },
             },
           },
         ],

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -150,3 +150,39 @@ test("Emit dispatches a bubbling custom event", async ({ page }) => {
   });
   expect(detail).toBe("hi");
 });
+
+test("SendPatch fires a routable spaday:patch intent carrying the event value", async ({
+  page,
+}) => {
+  const detail = await page.evaluate(() => {
+    const root = window.__spaday.mount(document.body, {
+      tag: "div",
+      slots: {
+        default: [
+          {
+            tag: "input",
+            props: { type: { Str: "checkbox" } },
+            events: {
+              change: {
+                kind: "patch",
+                model: "global",
+                field: "live",
+                value: { expr: "event" },
+              },
+            },
+          },
+        ],
+      },
+    });
+    return new Promise((resolve) => {
+      document.addEventListener("spaday:patch", (e) => resolve(e.detail), {
+        once: true,
+      });
+      const box = root.querySelector("input");
+      box.checked = true;
+      box.dispatchEvent(new Event("change"));
+    });
+  });
+  // the app routes this intent to its wire (e.g. a transports edit on model "global")
+  expect(detail).toEqual({ model: "global", field: "live", value: true });
+});

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -241,3 +241,47 @@ test("If runs then/else based on a prop condition read from another element", as
   expect(result.whenUnchecked).toBe(false);
   expect(result.whenChecked).toBe(true);
 });
+
+test("CallEndpoint makes the REST call with the templated JSON body", async ({
+  page,
+}) => {
+  const seen = [];
+  await page.route("**/api/save", (route) => {
+    const req = route.request();
+    seen.push({ method: req.method(), body: req.postData() });
+    return route.fulfill({ status: 200, body: "ok" });
+  });
+  await page.evaluate(() => {
+    const btn = window.__spaday.mount(document.body, {
+      tag: "button",
+      events: {
+        click: {
+          kind: "call",
+          method: "POST",
+          url: "/api/save",
+          body: { expr: "lit", value: { x: 1 } },
+        },
+      },
+    });
+    btn.click();
+  });
+  await page.waitForTimeout(150); // let the fetch reach the route handler
+  expect(seen).toEqual([{ method: "POST", body: '{"x":1}' }]);
+});
+
+test("NamedJs invokes a pre-registered handler (the no-eval escape hatch)", async ({
+  page,
+}) => {
+  const ran = await page.evaluate(() => {
+    let calls = 0;
+    window.__spaday.registerHandler("count", () => (calls += 1));
+    const btn = window.__spaday.mount(document.body, {
+      tag: "button",
+      events: { click: { kind: "js", handler: "count" } },
+    });
+    btn.click();
+    btn.click();
+    return calls;
+  });
+  expect(ran).toBe(2);
+});

--- a/js/tests/layout.html
+++ b/js/tests/layout.html
@@ -16,7 +16,8 @@
     />
     <script type="module" src="/dist/cdn/examples/webawesome.js"></script>
     <script type="module">
-      import { mount } from "/dist/esm/index.js"; // runtime + spa-* shell elements
+      import { mount, init } from "/dist/esm/index.js"; // runtime + spa-* shell elements
+      await init("/dist/pkg/spaday_bg.wasm");
       window.__spaday = { mount };
     </script>
   </head>

--- a/js/tests/layout.html
+++ b/js/tests/layout.html
@@ -17,7 +17,7 @@
     <script type="module" src="/dist/cdn/examples/webawesome.js"></script>
     <script type="module">
       import { mount, init } from "/dist/esm/index.js"; // runtime + spa-* shell elements
-      await init("/dist/pkg/spaday_bg.wasm");
+      await init({ module_or_path: "/dist/pkg/spaday_bg.wasm" });
       window.__spaday = { mount };
     </script>
   </head>

--- a/js/tests/layout.spec.js
+++ b/js/tests/layout.spec.js
@@ -212,3 +212,25 @@ test("the app shell lays out in order (nav → body → footer; gutter left of m
   expect(box.body.bottom).toBeLessThanOrEqual(box.footer.top + 1); // body above footer
   expect(box.gutter.right).toBeLessThanOrEqual(box.main.left + 1); // gutter left of main
 });
+
+test("layout props (gap / width) drive the shell's CSS custom properties", async ({
+  page,
+}) => {
+  const r = await page.evaluate(() => {
+    const { mount } = window.__spaday;
+    const stack = mount(document.body, {
+      tag: "spa-stack",
+      props: { gap: { Str: "24px" } },
+    });
+    const gutter = mount(document.body, {
+      tag: "spa-gutter",
+      props: { width: { Str: "320px" } },
+    });
+    return {
+      stackGap: getComputedStyle(stack).rowGap, // column gap = row-gap
+      gutterWidth: getComputedStyle(gutter).width,
+    };
+  });
+  expect(r.stackGap).toBe("24px");
+  expect(r.gutterWidth).toBe("320px");
+});

--- a/js/tests/runtime.html
+++ b/js/tests/runtime.html
@@ -4,7 +4,14 @@
     <meta charset="utf-8" />
     <title>spaday runtime test harness</title>
     <script type="module">
-      import { mount, applyPatch, interpret, tag } from "/dist/esm/index.js";
+      import {
+        mount,
+        applyPatch,
+        interpret,
+        tag,
+        init,
+      } from "/dist/esm/index.js";
+      await init("/dist/pkg/spaday_bg.wasm"); // the action interpreter runs in wasm
       window.__spaday = { mount, applyPatch, interpret, tag };
     </script>
   </head>

--- a/js/tests/runtime.html
+++ b/js/tests/runtime.html
@@ -10,9 +10,10 @@
         interpret,
         tag,
         init,
+        registerHandler,
       } from "/dist/esm/index.js";
       await init({ module_or_path: "/dist/pkg/spaday_bg.wasm" }); // the action interpreter runs in wasm
-      window.__spaday = { mount, applyPatch, interpret, tag };
+      window.__spaday = { mount, applyPatch, interpret, tag, registerHandler };
     </script>
   </head>
   <body></body>

--- a/js/tests/runtime.html
+++ b/js/tests/runtime.html
@@ -11,7 +11,7 @@
         tag,
         init,
       } from "/dist/esm/index.js";
-      await init("/dist/pkg/spaday_bg.wasm"); // the action interpreter runs in wasm
+      await init({ module_or_path: "/dist/pkg/spaday_bg.wasm" }); // the action interpreter runs in wasm
       window.__spaday = { mount, applyPatch, interpret, tag };
     </script>
   </head>

--- a/js/tests/runtime.spec.js
+++ b/js/tests/runtime.spec.js
@@ -158,3 +158,54 @@ test("a keyed reorder patch moves live elements (incremental == full render)", a
   expect(result.after).toBe(result.full); // incremental apply == a full re-render
   expect(result.origOrder).toEqual([2, 0, 1]); // c, a, b — the *same* elements, reordered
 });
+
+const TOGGLE = { kind: "toggle", target: { ref: "this" }, prop: "hidden" };
+
+test("an incremental SetEvent patch binds the new action on a live element", async ({
+  page,
+}) => {
+  const oldTree = { tag: "button" };
+  const newTree = { tag: "button", events: { click: TOGGLE } };
+  const patch = JSON.parse(
+    diff(JSON.stringify(oldTree), JSON.stringify(newTree)),
+  );
+  expect(JSON.stringify(patch)).toContain("SetEvent"); // the core emits it
+
+  const hidden = await page.evaluate(
+    ({ oldTree, patch }) => {
+      const { mount, applyPatch } = window.__spaday;
+      const btn = mount(document.body, oldTree); // no listener yet
+      applyPatch(btn, patch); // SetEvent binds it
+      btn.click();
+      return btn.hidden;
+    },
+    { oldTree, patch },
+  );
+  expect(hidden).toBe(true); // the action added by the patch actually ran
+});
+
+test("an incremental RemoveEvent patch detaches the action from a live element", async ({
+  page,
+}) => {
+  const oldTree = { tag: "button", events: { click: TOGGLE } };
+  const newTree = { tag: "button" };
+  const patch = JSON.parse(
+    diff(JSON.stringify(oldTree), JSON.stringify(newTree)),
+  );
+  expect(JSON.stringify(patch)).toContain("RemoveEvent");
+
+  const states = await page.evaluate(
+    ({ oldTree, patch }) => {
+      const { mount, applyPatch } = window.__spaday;
+      const btn = mount(document.body, oldTree); // listener bound on build
+      btn.click(); // toggles hidden -> true (proves it was active)
+      const afterFirst = btn.hidden;
+      applyPatch(btn, patch); // RemoveEvent detaches it
+      btn.click(); // would toggle back to false if still attached
+      return { afterFirst, afterRemoved: btn.hidden };
+    },
+    { oldTree, patch },
+  );
+  expect(states.afterFirst).toBe(true); // listener worked before removal
+  expect(states.afterRemoved).toBe(true); // unchanged ⇒ the listener was detached
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ skip = "*win32 *arm_64"
 branch = true
 omit = [
     "spaday/tests/integration/",
+    "spaday/examples/",
 ]
 
 [tool.coverage.report]

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -1,0 +1,178 @@
+//! The declarative action DSL — behavior as serializable data (Phase 2).
+//!
+//! An [`Action`] is the typed event-handler model the component tree carries (replacing the Phase 0
+//! `Action(Value)` placeholder). It is *data, not code*: authored in Python, serialized as the
+//! canonical wire form defined here, and evaluated in the browser by the wasm interpreter (the `js`
+//! crate) against DOM primitives the browser supplies — there is no `eval`. The core owns the model
+//! and the wire format so both bindings agree on the shape.
+//!
+//! The wire form (matched by `spaday.actions` in Python and the runtime in JS):
+//! - `Ref`:  `{"ref":"this"}` · `{"ref":"id","id":"panel"}`
+//! - `Expr`: `{"expr":"lit","value":<json>}` · `{"expr":"event"}` · `{"expr":"not","of":<Expr>}`
+//! - `Action`: `{"kind":"set",target,prop,value}` · `{"kind":"toggle",target,prop}` ·
+//!   `{"kind":"seq","actions":[..]}` · `{"kind":"emit","event","detail":<Expr>|null}`
+
+use serde::{Deserialize, Serialize};
+
+/// Parse a serialized action (the canonical wire form) into an [`Action`]. Used by the wasm
+/// interpreter so parsing/validation live in the core, not the binding.
+pub fn parse_action(json: &str) -> Result<Action, String> {
+    serde_json::from_str(json).map_err(|e| e.to_string())
+}
+
+/// A reference to a DOM element an action targets.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "ref", rename_all = "lowercase")]
+pub enum Ref {
+    /// The element the event fired on (the listener's element).
+    This,
+    /// The element with this `id` within the mounted tree.
+    Id { id: String },
+}
+
+/// A value computed in the browser at event time.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "expr", rename_all = "lowercase")]
+pub enum Expr {
+    /// A literal (plain JSON) value.
+    Lit { value: serde_json::Value },
+    /// The triggering event's value — a control's `checked` (bool), else `value`, else `detail`.
+    Event,
+    /// Boolean negation of an expression.
+    Not { of: Box<Expr> },
+}
+
+/// A declarative event handler, interpreted in the browser.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum Action {
+    /// Set `prop` on `target` to `value`.
+    #[serde(rename = "set")]
+    SetProp {
+        target: Ref,
+        prop: String,
+        value: Expr,
+    },
+    /// Flip a boolean `prop` on `target` (e.g. `hidden`, `checked`, `open`).
+    #[serde(rename = "toggle")]
+    Toggle { target: Ref, prop: String },
+    /// Run several actions in order.
+    #[serde(rename = "seq")]
+    Sequence { actions: Vec<Action> },
+    /// Dispatch a (bubbling) custom event named `event` with an optional `detail`.
+    #[serde(rename = "emit")]
+    Emit {
+        event: String,
+        #[serde(default)]
+        detail: Option<Expr>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Assert the action serializes to exactly `wire` and parses back — locking the cross-binding form.
+    fn round(action: &Action, wire: serde_json::Value) {
+        assert_eq!(serde_json::to_value(action).unwrap(), wire, "serialize");
+        assert_eq!(
+            &serde_json::from_value::<Action>(wire).unwrap(),
+            action,
+            "deserialize"
+        );
+    }
+
+    #[test]
+    fn toggle_on_this() {
+        round(
+            &Action::Toggle {
+                target: Ref::This,
+                prop: "hidden".into(),
+            },
+            json!({"kind": "toggle", "target": {"ref": "this"}, "prop": "hidden"}),
+        );
+    }
+
+    #[test]
+    fn setprop_by_id_with_not_event() {
+        round(
+            &Action::SetProp {
+                target: Ref::Id { id: "panel".into() },
+                prop: "hidden".into(),
+                value: Expr::Not {
+                    of: Box::new(Expr::Event),
+                },
+            },
+            json!({
+                "kind": "set",
+                "target": {"ref": "id", "id": "panel"},
+                "prop": "hidden",
+                "value": {"expr": "not", "of": {"expr": "event"}},
+            }),
+        );
+    }
+
+    #[test]
+    fn setprop_with_literal() {
+        round(
+            &Action::SetProp {
+                target: Ref::This,
+                prop: "type".into(),
+                value: Expr::Lit {
+                    value: json!("area"),
+                },
+            },
+            json!({"kind": "set", "target": {"ref": "this"}, "prop": "type", "value": {"expr": "lit", "value": "area"}}),
+        );
+    }
+
+    #[test]
+    fn sequence_and_emit_with_detail() {
+        round(
+            &Action::Sequence {
+                actions: vec![
+                    Action::Toggle {
+                        target: Ref::This,
+                        prop: "hidden".into(),
+                    },
+                    Action::Emit {
+                        event: "opened".into(),
+                        detail: Some(Expr::Lit { value: json!(true) }),
+                    },
+                ],
+            },
+            json!({
+                "kind": "seq",
+                "actions": [
+                    {"kind": "toggle", "target": {"ref": "this"}, "prop": "hidden"},
+                    {"kind": "emit", "event": "opened", "detail": {"expr": "lit", "value": true}},
+                ],
+            }),
+        );
+    }
+
+    #[test]
+    fn emit_without_detail_serializes_null() {
+        // matches the Python authoring (detail key present, null) and the JS `detail != null` check
+        round(
+            &Action::Emit {
+                event: "ping".into(),
+                detail: None,
+            },
+            json!({"kind": "emit", "event": "ping", "detail": null}),
+        );
+    }
+
+    #[test]
+    fn missing_detail_also_parses() {
+        let a: Action = serde_json::from_value(json!({"kind": "emit", "event": "ping"})).unwrap();
+        assert_eq!(
+            a,
+            Action::Emit {
+                event: "ping".into(),
+                detail: None
+            }
+        );
+    }
+}

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -66,6 +66,14 @@ pub enum Action {
         #[serde(default)]
         detail: Option<Expr>,
     },
+    /// Set `field` to `value` on a host-routed model (e.g. a transports model named `model`). The
+    /// interpreter surfaces this as a patch intent; the app routes it to the actual wire.
+    #[serde(rename = "patch")]
+    SendPatch {
+        model: String,
+        field: String,
+        value: Expr,
+    },
 }
 
 #[cfg(test)]
@@ -149,6 +157,18 @@ mod tests {
                     {"kind": "emit", "event": "opened", "detail": {"expr": "lit", "value": true}},
                 ],
             }),
+        );
+    }
+
+    #[test]
+    fn send_patch_wire() {
+        round(
+            &Action::SendPatch {
+                model: "global".into(),
+                field: "type".into(),
+                value: Expr::Event,
+            },
+            json!({"kind": "patch", "model": "global", "field": "type", "value": {"expr": "event"}}),
         );
     }
 

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -13,7 +13,8 @@
 //! - `Action`: `{"kind":"set",target,prop,value}` · `{"kind":"toggle",target,prop}` ·
 //!   `{"kind":"seq","actions":[..]}` · `{"kind":"emit","event","detail":<Expr>|null}` ·
 //!   `{"kind":"patch","model","field","value":<Expr>}` ·
-//!   `{"kind":"if","cond":<Expr>,"then":<Action>,"else":<Action>|null}`
+//!   `{"kind":"if","cond":<Expr>,"then":<Action>,"else":<Action>|null}` ·
+//!   `{"kind":"call","method","url","body":<Expr>|null}` · `{"kind":"js","handler"}`
 
 use serde::{Deserialize, Serialize};
 
@@ -87,6 +88,19 @@ pub enum Action {
         #[serde(rename = "else", default)]
         els: Option<Box<Action>>,
     },
+    /// A REST round-trip: `method` `url` with an optional JSON `body`. The one intentional server call
+    /// (the interpreter performs it via the host's `fetch`).
+    #[serde(rename = "call")]
+    CallEndpoint {
+        method: String,
+        url: String,
+        #[serde(default)]
+        body: Option<Expr>,
+    },
+    /// The escape hatch: invoke a pre-registered named JS handler (no arbitrary `eval`). For the rare
+    /// irreducible case the declarative actions can't express.
+    #[serde(rename = "js")]
+    NamedJs { handler: String },
 }
 
 #[cfg(test)]
@@ -223,6 +237,36 @@ mod tests {
                 els: None,
             },
             json!({"kind": "if", "cond": {"expr": "event"}, "then": {"kind": "toggle", "target": {"ref": "this"}, "prop": "hidden"}, "else": null}),
+        );
+    }
+
+    #[test]
+    fn call_endpoint_wire() {
+        round(
+            &Action::CallEndpoint {
+                method: "POST".into(),
+                url: "/api/order".into(),
+                body: Some(Expr::Event),
+            },
+            json!({"kind": "call", "method": "POST", "url": "/api/order", "body": {"expr": "event"}}),
+        );
+        round(
+            &Action::CallEndpoint {
+                method: "GET".into(),
+                url: "/ping".into(),
+                body: None,
+            },
+            json!({"kind": "call", "method": "GET", "url": "/ping", "body": null}),
+        );
+    }
+
+    #[test]
+    fn named_js_wire() {
+        round(
+            &Action::NamedJs {
+                handler: "confetti".into(),
+            },
+            json!({"kind": "js", "handler": "confetti"}),
         );
     }
 

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -8,9 +8,12 @@
 //!
 //! The wire form (matched by `spaday.actions` in Python and the runtime in JS):
 //! - `Ref`:  `{"ref":"this"}` · `{"ref":"id","id":"panel"}`
-//! - `Expr`: `{"expr":"lit","value":<json>}` · `{"expr":"event"}` · `{"expr":"not","of":<Expr>}`
+//! - `Expr`: `{"expr":"lit","value":<json>}` · `{"expr":"event"}` · `{"expr":"not","of":<Expr>}` ·
+//!   `{"expr":"prop","target":<Ref>,"name":"checked"}`
 //! - `Action`: `{"kind":"set",target,prop,value}` · `{"kind":"toggle",target,prop}` ·
-//!   `{"kind":"seq","actions":[..]}` · `{"kind":"emit","event","detail":<Expr>|null}`
+//!   `{"kind":"seq","actions":[..]}` · `{"kind":"emit","event","detail":<Expr>|null}` ·
+//!   `{"kind":"patch","model","field","value":<Expr>}` ·
+//!   `{"kind":"if","cond":<Expr>,"then":<Action>,"else":<Action>|null}`
 
 use serde::{Deserialize, Serialize};
 
@@ -40,6 +43,8 @@ pub enum Expr {
     Event,
     /// Boolean negation of an expression.
     Not { of: Box<Expr> },
+    /// The current value of a `name` prop on `target` (reads live element state).
+    Prop { target: Ref, name: String },
 }
 
 /// A declarative event handler, interpreted in the browser.
@@ -73,6 +78,14 @@ pub enum Action {
         model: String,
         field: String,
         value: Expr,
+    },
+    /// Run `then` if `cond` is truthy, else `els` (if present).
+    #[serde(rename = "if")]
+    If {
+        cond: Expr,
+        then: Box<Action>,
+        #[serde(rename = "else", default)]
+        els: Option<Box<Action>>,
     },
 }
 
@@ -169,6 +182,47 @@ mod tests {
                 value: Expr::Event,
             },
             json!({"kind": "patch", "model": "global", "field": "type", "value": {"expr": "event"}}),
+        );
+    }
+
+    #[test]
+    fn if_with_prop_cond_and_else_wire() {
+        round(
+            &Action::If {
+                cond: Expr::Prop {
+                    target: Ref::Id { id: "sw".into() },
+                    name: "checked".into(),
+                },
+                then: Box::new(Action::Toggle {
+                    target: Ref::This,
+                    prop: "hidden".into(),
+                }),
+                els: Some(Box::new(Action::Emit {
+                    event: "off".into(),
+                    detail: None,
+                })),
+            },
+            json!({
+                "kind": "if",
+                "cond": {"expr": "prop", "target": {"ref": "id", "id": "sw"}, "name": "checked"},
+                "then": {"kind": "toggle", "target": {"ref": "this"}, "prop": "hidden"},
+                "else": {"kind": "emit", "event": "off", "detail": null},
+            }),
+        );
+    }
+
+    #[test]
+    fn if_without_else_serializes_null() {
+        round(
+            &Action::If {
+                cond: Expr::Event,
+                then: Box::new(Action::Toggle {
+                    target: Ref::This,
+                    prop: "hidden".into(),
+                }),
+                els: None,
+            },
+            json!({"kind": "if", "cond": {"expr": "event"}, "then": {"kind": "toggle", "target": {"ref": "this"}, "prop": "hidden"}, "else": null}),
         );
     }
 

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -371,7 +371,6 @@ fn apply_op(root: &mut Node, op: &Op) {
 #[cfg(test)]
 mod diff_tests {
     use super::*;
-    use crate::value::Value;
 
     fn assert_round_trip(old: &Node, new: &Node) -> Patch {
         let patch = diff(old, new);

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -22,7 +22,8 @@ use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::node::{Action, Attr, EventName, Key, Node, SlotName};
+use crate::action::Action;
+use crate::node::{Attr, EventName, Key, Node, SlotName};
 
 /// One step down into a tree: the `index`-th child of slot `slot`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -406,10 +407,29 @@ mod diff_tests {
 
     #[test]
     fn test_event_changes() {
-        let old = Node::new("wa-button").event("click", Action(Value::str("a")));
+        use crate::action::Ref;
+        let old = Node::new("wa-button").event(
+            "click",
+            Action::Toggle {
+                target: Ref::This,
+                prop: "a".into(),
+            },
+        );
         let new = Node::new("wa-button")
-            .event("click", Action(Value::str("b")))
-            .event("dblclick", Action(Value::Null));
+            .event(
+                "click",
+                Action::Toggle {
+                    target: Ref::This,
+                    prop: "b".into(),
+                },
+            )
+            .event(
+                "dblclick",
+                Action::Emit {
+                    event: "x".into(),
+                    detail: None,
+                },
+            );
         assert_round_trip(&old, &new);
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,11 +6,13 @@
 //!
 //! Layers (built bottom-up):
 //! - [`value`] — the prop/state value type.
+//! - [`action`] — the declarative action DSL (event-handler model + wire format).
 //! - [`node`] — the serializable component tree ([`Node`], slots, events).
 //! - [`diff`] — structural diff/patch with keyed child reconciliation.
 //! - [`json`] — the JSON wire bridge the bindings call (`diff_json`/`apply_json`).
 //! - [`cem`] — the Custom Elements Manifest parser (Phase 1 binding generator).
 
+mod action;
 mod cem;
 mod diff;
 mod example;
@@ -18,9 +20,10 @@ mod json;
 mod node;
 mod value;
 
+pub use action::{parse_action, Action, Expr, Ref};
 pub use cem::{parse_cem, parse_manifest, ComponentSchema, PropSchema, PropType};
 pub use diff::{apply, diff, Op, Patch, Path, PathSeg};
 pub use example::Example;
 pub use json::{apply_json, diff_json};
-pub use node::{Action, Attr, EventName, Key, Node, SlotName, TagName, DEFAULT_SLOT};
+pub use node::{Attr, EventName, Key, Node, SlotName, TagName, DEFAULT_SLOT};
 pub use value::Value;

--- a/rust/src/node.rs
+++ b/rust/src/node.rs
@@ -3,15 +3,14 @@
 //! A [`Node`] is a single high-level web component: a tag, an optional reconciliation key,
 //! a bag of props (attributes/properties), named slots holding child nodes, and event handlers.
 //!
-//! Phase 0 models event handlers as an opaque [`Action`] (wrapping a [`Value`]) so the tree is
-//! structurally complete and diffable now. The real declarative action DSL replaces [`Action`]'s
-//! body in Phase 2 — the tree/diff machinery here is written against the `Action` type so that
-//! change is contained.
+//! Event handlers are the declarative [`Action`] DSL (see [`crate::action`]); the tree/diff machinery
+//! here is generic over the `Action` type.
 
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::action::Action;
 use crate::value::Value;
 
 pub type TagName = String;
@@ -22,13 +21,6 @@ pub type EventName = String;
 
 /// The conventional name for a component's unnamed (default) slot.
 pub const DEFAULT_SLOT: &str = "default";
-
-/// Phase 0 placeholder for a declarative event handler.
-///
-/// In Phase 2 this becomes the action DSL (`SetProp`/`Toggle`/`Bind`/`CallEndpoint`/...). It is a
-/// distinct newtype today so call sites and the diff engine don't have to change when that lands.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
-pub struct Action(pub Value);
 
 /// A node in the component tree.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -109,21 +101,23 @@ impl Node {
 #[cfg(test)]
 mod node_tests {
     use super::*;
+    use crate::action::Ref;
 
     #[test]
     fn test_builder() {
+        let toggle = Action::Toggle {
+            target: Ref::This,
+            prop: "checked".into(),
+        };
         let n = Node::new("wa-switch")
             .with_key("lamp")
             .prop("checked", true)
             .prop("size", "m")
-            .event("wa-change", Action(Value::str("toggle")));
+            .event("wa-change", toggle.clone());
         assert_eq!(n.tag, "wa-switch");
         assert_eq!(n.key.as_deref(), Some("lamp"));
         assert_eq!(n.props.get("checked"), Some(&Value::Bool(true)));
-        assert_eq!(
-            n.events.get("wa-change"),
-            Some(&Action(Value::str("toggle")))
-        );
+        assert_eq!(n.events.get("wa-change"), Some(&toggle));
     }
 
     #[test]

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -1,5 +1,5 @@
 from . import actions
-from .actions import Emit, Sequence, SetProp, Toggle, by_id, event_value, lit, not_, this
+from .actions import Emit, SendPatch, Sequence, SetProp, Toggle, by_id, event_value, lit, not_, this
 from .cem import classes, generate
 from .component import Component, element
 from .spaday import apply, diff, parse_cem  # compiled Rust extension (rust/python)
@@ -23,6 +23,7 @@ __all__ = [
     "Toggle",
     "Sequence",
     "Emit",
+    "SendPatch",
     "lit",
     "event_value",
     "not_",

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -1,5 +1,21 @@
 from . import actions
-from .actions import Emit, If, SendPatch, Sequence, SetProp, Toggle, bind, by_id, event_value, lit, not_, prop, this
+from .actions import (
+    CallEndpoint,
+    Emit,
+    If,
+    NamedJs,
+    SendPatch,
+    Sequence,
+    SetProp,
+    Toggle,
+    bind,
+    by_id,
+    event_value,
+    lit,
+    not_,
+    prop,
+    this,
+)
 from .cem import classes, generate
 from .component import Component, element
 from .spaday import apply, diff, parse_cem  # compiled Rust extension (rust/python)
@@ -25,6 +41,8 @@ __all__ = [
     "Emit",
     "SendPatch",
     "If",
+    "CallEndpoint",
+    "NamedJs",
     "lit",
     "event_value",
     "not_",

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -1,5 +1,5 @@
 from . import actions
-from .actions import Emit, SendPatch, Sequence, SetProp, Toggle, by_id, event_value, lit, not_, this
+from .actions import Emit, If, SendPatch, Sequence, SetProp, Toggle, bind, by_id, event_value, lit, not_, prop, this
 from .cem import classes, generate
 from .component import Component, element
 from .spaday import apply, diff, parse_cem  # compiled Rust extension (rust/python)
@@ -24,9 +24,12 @@ __all__ = [
     "Sequence",
     "Emit",
     "SendPatch",
+    "If",
     "lit",
     "event_value",
     "not_",
+    "prop",
     "this",
     "by_id",
+    "bind",
 ]

--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -146,3 +146,18 @@ class Emit(Action):
     def to_dict(self) -> Dict[str, Any]:
         detail = _expr(self.detail).to_dict() if self.detail is not None else None
         return {"kind": "emit", "event": self.event, "detail": detail}
+
+
+class SendPatch(Action):
+    """Set ``field`` to ``value`` on a host-routed ``model`` (e.g. a transports model).
+
+    The runtime surfaces this as a patch *intent* (a bubbling ``spaday:patch`` DOM event carrying
+    ``{model, field, value}``); the app routes it to the actual wire. This is how a control edit is
+    authored declaratively instead of with a hand-written transports listener.
+    """
+
+    def __init__(self, model: str, field: str, value: Any) -> None:
+        self.model, self.field, self.value = model, field, value
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": "patch", "model": self.model, "field": self.field, "value": _expr(self.value).to_dict()}

--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -19,7 +19,7 @@ expressions and ``this`` / ``by_id`` targets) is the first slice; reactive ``Bin
 ``SendPatch``, and conditionals follow.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class Expr:
@@ -68,6 +68,20 @@ def not_(of: Any) -> Expr:
 def _expr(value: Any) -> Expr:
     """Coerce a plain Python value to a literal expression; pass an `Expr` through."""
     return value if isinstance(value, Expr) else _Lit(value)
+
+
+class _Prop(Expr):
+    def __init__(self, target: "Ref", name: str) -> None:
+        self.target, self.name = target, name
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"expr": "prop", "target": self.target.to_dict(), "name": self.name}
+
+
+def prop(target: "Ref", name: str) -> Expr:
+    """The current value of a ``name`` prop on ``target`` — reads live element state, e.g.
+    ``prop(by_id("sw"), "checked")`` for use as a condition."""
+    return _Prop(target, name)
 
 
 class Ref:
@@ -161,3 +175,34 @@ class SendPatch(Action):
 
     def to_dict(self) -> Dict[str, Any]:
         return {"kind": "patch", "model": self.model, "field": self.field, "value": _expr(self.value).to_dict()}
+
+
+class If(Action):
+    """Run ``then`` if ``cond`` is truthy, else ``els`` (if given) — branch on live state, e.g.
+    ``If(prop(by_id("sw"), "checked"), SetProp(...), SetProp(...))``."""
+
+    def __init__(self, cond: Any, then: Action, els: Optional[Action] = None) -> None:
+        self.cond, self.then, self.els = cond, then, els
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": "if",
+            "cond": _expr(self.cond).to_dict(),
+            "then": self.then.to_dict(),
+            "else": self.els.to_dict() if self.els is not None else None,
+        }
+
+
+def bind(source: Any, target: Ref, target_prop: str, *, transform: Any = None) -> Any:
+    """One-way reactive binding: when ``source`` (a control component) changes, set ``target_prop`` on
+    ``target`` (a :class:`Ref`, e.g. ``by_id("panel")``) to the source's value — optionally passed
+    through ``transform`` (e.g. :func:`not_`). Returns ``source`` so it composes in a tree::
+
+        bind(WaSwitch().text("Show"), by_id("panel"), "hidden", transform=not_)
+
+    Event-driven (sugar over ``SetProp`` on the source's ``change``); the signal-graph reactive engine
+    and two-way binding are future work.
+    """
+    value = transform(event_value()) if transform else event_value()
+    source.on("change", SetProp(target, target_prop, value))
+    return source

--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -14,9 +14,12 @@ This is the "configure in Python, run in JS" core: the server holds session stat
 toggle or a prop binding runs client-side. The interpreter dispatches on each action's ``kind`` — there
 is no ``eval`` — so actions are safe to ship to untrusted, multi-tenant clients.
 
-The set here (``SetProp`` / ``Toggle`` / ``Sequence`` / ``Emit`` with literal / event-value / ``not``
-expressions and ``this`` / ``by_id`` targets) is the first slice; reactive ``Bind``, ``CallEndpoint``,
-``SendPatch``, and conditionals follow.
+Actions: ``SetProp`` / ``Toggle`` / ``Sequence`` / ``Emit`` (client-side); ``SendPatch`` (a model-edit
+intent the app routes to its wire, e.g. transports); ``If`` (conditionals); ``CallEndpoint`` (a REST
+round-trip); and ``NamedJs`` (a no-``eval`` escape hatch to a pre-registered handler). Expressions:
+``lit`` / ``event_value`` / ``not_`` / ``prop`` (read live element state); targets ``this`` / ``by_id``.
+``bind`` is a one-way reactive-binding helper. The signal-graph reactive engine (derived state, two-way
+binding) is the remaining Phase 2 work.
 """
 
 from typing import Any, Dict, List, Optional
@@ -191,6 +194,29 @@ class If(Action):
             "then": self.then.to_dict(),
             "else": self.els.to_dict() if self.els is not None else None,
         }
+
+
+class CallEndpoint(Action):
+    """A REST round-trip: ``method`` ``url`` with an optional JSON ``body`` (an :class:`Expr` or a plain
+    value). The one intentional server call — the runtime performs it with ``fetch``."""
+
+    def __init__(self, method: str, url: str, body: Any = None) -> None:
+        self.method, self.url, self.body = method, url, body
+
+    def to_dict(self) -> Dict[str, Any]:
+        body = _expr(self.body).to_dict() if self.body is not None else None
+        return {"kind": "call", "method": self.method, "url": self.url, "body": body}
+
+
+class NamedJs(Action):
+    """The escape hatch: invoke a pre-registered named JS handler (no arbitrary ``eval``). Register it
+    on the JS side with ``registerHandler(name, fn)``; use only for the rare irreducible case."""
+
+    def __init__(self, handler: str) -> None:
+        self.handler = handler
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": "js", "handler": self.handler}
 
 
 def bind(source: Any, target: Ref, target_prop: str, *, transform: Any = None) -> Any:

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -107,7 +107,8 @@ class Component:
         if self._slots:
             node["slots"] = {slot: [_as_node(c) for c in children] for slot, children in self._slots.items()}
         if self._events:
-            node["events"] = {name: _tag(action) for name, action in self._events.items()}
+            # actions are the core's own DSL wire form (see spaday.actions) — plain, not a tagged Value
+            node["events"] = dict(self._events)
         return node
 
     def to_json(self) -> str:

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -15,6 +15,8 @@ First cut — pure structural containers (no typed props yet). :class:`Main` is 
 via ``.prop("style", ...)``.
 """
 
+from typing import Optional
+
 from ..component import Component
 
 __all__ = ["App", "Nav", "Body", "Gutter", "Main", "Footer", "Stack", "Row", "Toolbar"]
@@ -39,9 +41,15 @@ class Body(Component):
 
 
 class Gutter(Component):
-    """A sidebar; place it before or after Main in a Body to get a left or right gutter."""
+    """A sidebar; place it before or after Main in a Body to get a left or right gutter.
+
+    ``width`` sets the gutter width (any CSS length); ``gap`` spaces its children.
+    """
 
     tag = "spa-gutter"
+
+    def __init__(self, *, width: Optional[str] = None, gap: Optional[str] = None, key: Optional[str] = None) -> None:
+        super().__init__(key=key, props={"width": width, "gap": gap})
 
 
 class Main(Component):
@@ -57,18 +65,28 @@ class Footer(Component):
 
 
 class Stack(Component):
-    """A vertical group (gap via the ``--spa-gap`` custom property)."""
+    """A vertical group. ``gap`` sets the space between children; ``align`` the cross-axis alignment."""
 
     tag = "spa-stack"
 
+    def __init__(self, *, gap: Optional[str] = None, align: Optional[str] = None, key: Optional[str] = None) -> None:
+        super().__init__(key=key, props={"gap": gap, "align": align})
+
 
 class Row(Component):
-    """A horizontal group, vertically centered (gap via ``--spa-gap``)."""
+    """A horizontal group. ``gap`` spaces children; ``align`` is cross-axis (default center) and
+    ``justify`` is main-axis distribution."""
 
     tag = "spa-row"
 
+    def __init__(self, *, gap: Optional[str] = None, align: Optional[str] = None, justify: Optional[str] = None, key: Optional[str] = None) -> None:
+        super().__init__(key=key, props={"gap": gap, "align": align, "justify": justify})
+
 
 class Toolbar(Component):
-    """A contained strip of actions/controls."""
+    """A contained strip of actions/controls. ``gap`` spaces them; ``align``/``justify`` lay them out."""
 
     tag = "spa-toolbar"
+
+    def __init__(self, *, gap: Optional[str] = None, align: Optional[str] = None, justify: Optional[str] = None, key: Optional[str] = None) -> None:
+        super().__init__(key=key, props={"gap": gap, "align": align, "justify": justify})

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -29,9 +29,12 @@ is independent per tab.
 - `__main__.py` authors the page (shell + controls + actions) and hosts two `Chart` models on transports
   (`Session`/`Server`, plus a `Hub` for per-session). It serves the page, the authored tree
   (`/tree.json`), the websockets (`/ws`, `/ws/session`), and the `js/` bundles.
-- `index.html` mounts the tree — which wires the action DSL automatically — and adds the only
-  hand-written glue: the two transports charts' control→edit listeners. That glue is what a future
-  `SendPatch` action will make declarative; the action DSL already removed it for the client-side card.
+- `index.html` first `await init("…/spaday_bg.wasm")` (the action interpreter runs in spaday's wasm
+  core, so it must be initialized before interactions — otherwise an action fires a clear error), then
+  mounts the tree — which wires the action DSL automatically — and adds the only hand-written glue: the
+  two transports charts' control→edit listeners, plus the light/dark toggle (`wa-dark` on `<html>`).
+  That glue is what future `SendPatch` / class-toggle actions will make declarative; the action DSL
+  already removed it for the client-side card.
 
 ## Notes
 

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -31,10 +31,11 @@ is independent per tab.
   (`/tree.json`), the websockets (`/ws`, `/ws/session`), and the `js/` bundles.
 - `index.html` first `await init("…/spaday_bg.wasm")` (the action interpreter runs in spaday's wasm
   core, so it must be initialized before interactions — otherwise an action fires a clear error), then
-  mounts the tree — which wires the action DSL automatically — and adds the only hand-written glue: the
-  two transports charts' control→edit listeners, plus the light/dark toggle (`wa-dark` on `<html>`).
-  That glue is what future `SendPatch` / class-toggle actions will make declarative; the action DSL
-  already removed it for the client-side card.
+  mounts the tree — which wires the action DSL automatically. The transports controls are now declarative
+  `SendPatch` actions; each fires a `spaday:patch` intent that **one** generic sink routes to the right
+  transports model (the per-control listeners are gone — only that model→wire bridge remains). The light/
+  dark toggle (`wa-dark` on `<html>`) + chart theming stay hand-written, since class/root toggling isn't
+  in the DSL yet.
 
 ## Notes
 

--- a/spaday/examples/__main__.py
+++ b/spaday/examples/__main__.py
@@ -15,9 +15,10 @@ It shows, on one page authored entirely in Python:
   listeners and never calls the server for these.
 - **transports (server-authoritative, multi-tenant)** — two live charts mirror Python models over
   ``@1kbgz/transports``. A **global** model on a shared :class:`transports.Server` syncs to every browser;
-  a **per-session** model on a :class:`transports.Hub` is private to each tab. Control changes are edits
-  applied on the server and fanned to clients (the hand-written glue in ``index.html`` is what a future
-  ``SendPatch`` action will make declarative).
+  a **per-session** model on a :class:`transports.Hub` is private to each tab. Control changes are
+  declarative :class:`~spaday.actions.SendPatch` actions: each fires a ``spaday:patch`` intent that one
+  generic sink in ``index.html`` routes to the right transports model — applied on the server and fanned
+  to clients. The per-control listeners are gone; only the model→wire bridge remains.
 """
 
 import asyncio
@@ -36,7 +37,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from spaday import element
-from spaday.actions import Sequence, SetProp, Toggle, by_id, event_value, not_
+from spaday.actions import SendPatch, Sequence, SetProp, Toggle, by_id, event_value, lit, not_
 from spaday.components.lightweight_charts import LightweightChart
 from spaday.components.shell import App, Body, Footer, Gutter, Main, Nav, Row, Stack, Toolbar
 from spaday.components.webawesome import WaButton, WaCallout, WaCard, WaOption, WaSelect, WaSwitch
@@ -139,8 +140,9 @@ def dsl_card() -> object:
 
 
 def transports_panel(prefix: str, title: str, chart_type: str) -> object:
-    """One live chart + its server-authoritative controls (wired to transports in index.html)."""
-    select = WaSelect(label="Type", value=chart_type).prop("id", f"{prefix}-type")
+    """One live chart + its controls. Edits are declarative SendPatch actions (routed to transports in
+    index.html); the ids remain so the inbound update can reflect the model back onto the controls."""
+    select = WaSelect(label="Type", value=chart_type).prop("id", f"{prefix}-type").on("change", SendPatch(prefix, "type", event_value()))
     for t in TYPES:
         select = select.child(WaOption(value=t).text(t.capitalize()))
     status = element("span").prop("id", f"{prefix}-status").prop("style", "margin-left:auto;color:#2962ff;font-size:.8rem").text("connecting…")
@@ -150,8 +152,8 @@ def transports_panel(prefix: str, title: str, chart_type: str) -> object:
         .child(
             Toolbar()
             .child(select)
-            .child(WaSwitch(checked=True).prop("id", f"{prefix}-live").text("Live"))
-            .child(WaButton(variant="neutral").prop("id", f"{prefix}-clear").text("Clear"))
+            .child(WaSwitch(checked=True).prop("id", f"{prefix}-live").text("Live").on("change", SendPatch(prefix, "live", event_value())))
+            .child(WaButton(variant="neutral").prop("id", f"{prefix}-clear").text("Clear").on("click", SendPatch(prefix, "data", lit([]))))
         )
         .child(LightweightChart(type=chart_type).prop("id", f"{prefix}-chart"))
     )

--- a/spaday/examples/__main__.py
+++ b/spaday/examples/__main__.py
@@ -37,7 +37,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from spaday import element
-from spaday.actions import SendPatch, Sequence, SetProp, Toggle, by_id, event_value, lit, not_
+from spaday.actions import SendPatch, Sequence, SetProp, Toggle, bind, by_id, event_value, lit, not_
 from spaday.components.lightweight_charts import LightweightChart
 from spaday.components.shell import App, Body, Footer, Gutter, Main, Nav, Row, Stack, Toolbar
 from spaday.components.webawesome import WaButton, WaCallout, WaCard, WaOption, WaSelect, WaSwitch
@@ -119,8 +119,8 @@ def dsl_card() -> object:
         )
         .child(
             Row()
-            .child(WaSwitch().text("Reveal advanced").on("change", SetProp(by_id("advanced"), "hidden", not_(event_value()))))
-            .child(callout("advanced", "Hidden until the switch is on: SetProp(hidden = not(event value)).", hidden=True))
+            .child(bind(WaSwitch().text("Reveal advanced"), by_id("advanced"), "hidden", transform=not_))
+            .child(callout("advanced", "Hidden until the switch is on — a one-way bind(switch -> advanced.hidden, not_).", hidden=True))
         )
         .child(
             Row()

--- a/spaday/examples/__main__.py
+++ b/spaday/examples/__main__.py
@@ -178,7 +178,14 @@ def page() -> dict:
     """The whole page, authored from shell components (no layout divs; raw elements only for text)."""
     return (
         App()
-        .child(Nav().child(element("strong").text("spaday")).child(element("span").text("· shell + action DSL + transports")))
+        .child(
+            Nav()
+            .child(element("strong").text("spaday"))
+            .child(element("span").text("· shell + action DSL + transports"))
+            # right-aligned; wired to a `wa-dark` class toggle in index.html (class/root toggling
+            # is page chrome the action DSL doesn't model yet, like the transports edits below)
+            .child(WaSwitch().prop("id", "theme-toggle").prop("style", "margin-left:auto").text("Dark"))
+        )
         .child(
             Body()
             .child(

--- a/spaday/examples/index.html
+++ b/spaday/examples/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="wa-theme-default">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -29,6 +29,21 @@
       a {
         color: #2962ff;
       }
+      /* Dark mode: WebAwesome components follow the `wa-dark` class; the shell reads these `--spa-*`
+         custom properties, which inherit through the shadow boundary, so the chrome follows too. */
+      html.wa-dark {
+        --spa-surface: #1c1c20;
+        --spa-surface-2: #26262c;
+        --spa-border: #36363d;
+        --spa-muted: #9a9aa4;
+      }
+      html.wa-dark body {
+        background: #161619;
+        color: #e8e8ec;
+      }
+      html.wa-dark p {
+        color: #b9b9c2;
+      }
     </style>
   </head>
   <body>
@@ -54,6 +69,12 @@
       mount(document.body, node); // shell + both cards; the action DSL is wired automatically
 
       const byId = (id) => document.getElementById(id);
+
+      // Light/dark toggle: flip the `wa-dark` class on <html>. (Class/root toggling is page chrome
+      // the action DSL doesn't model yet, so it's wired here like the transports edits.)
+      byId("theme-toggle").addEventListener("change", (e) =>
+        document.documentElement.classList.toggle("wa-dark", e.target.checked),
+      );
 
       // Wire one live chart to its transports connection (server-authoritative edits).
       function panel(prefix, wsUrl) {

--- a/spaday/examples/index.html
+++ b/spaday/examples/index.html
@@ -36,7 +36,7 @@
       // The whole page (shell layout + each control's Action) is authored by spaday/examples/__main__.py.
       // Mounting renders it and binds the action DSL — note there is NO addEventListener for the DSL card.
       // The only hand-written glue is for the two transports charts (edits aren't a declarative action yet).
-      import { mount } from "/js/dist/esm/index.js";
+      import { mount, init } from "/js/dist/esm/index.js";
       import "/js/dist/cdn/wrappers/lightweight-chart.js"; // defines <lightweight-chart>
       import {
         Client,
@@ -45,6 +45,7 @@
         wasm,
       } from "/js/node_modules/@1kbgz/transports/dist/cdn/index.js";
 
+      await init("/js/dist/pkg/spaday_bg.wasm"); // spaday's wasm core (the action interpreter)
       await wasm.default({
         module_or_path: "/js/node_modules/@1kbgz/transports/dist/pkg/transports_bg.wasm",
       });

--- a/spaday/examples/index.html
+++ b/spaday/examples/index.html
@@ -14,35 +14,22 @@
     />
     <script type="module" src="/js/dist/cdn/examples/webawesome.js"></script>
     <style>
-      /* Typography only — all layout comes from the spa-* shell components (shadow-DOM encapsulated). */
+      /* Typography only — layout comes from the spa-* shell components. Colors reference WebAwesome
+         theme tokens, so the page + shell follow light/dark automatically (the shell does the same
+         internally); the `wa-dark` toggle alone re-themes everything except the canvas charts. */
       body {
         margin: 0;
         font-family: system-ui, sans-serif;
-        background: #fafafa;
-        color: #222;
+        background: var(--wa-color-surface-lowered, #fafafa);
+        color: var(--wa-color-text-normal, #222);
       }
       p {
         margin: 0 0 4px;
-        color: #555;
+        color: var(--wa-color-text-quiet, #555);
         line-height: 1.5;
       }
       a {
-        color: #2962ff;
-      }
-      /* Dark mode: WebAwesome components follow the `wa-dark` class; the shell reads these `--spa-*`
-         custom properties, which inherit through the shadow boundary, so the chrome follows too. */
-      html.wa-dark {
-        --spa-surface: #1c1c20;
-        --spa-surface-2: #26262c;
-        --spa-border: #36363d;
-        --spa-muted: #9a9aa4;
-      }
-      html.wa-dark body {
-        background: #161619;
-        color: #e8e8ec;
-      }
-      html.wa-dark p {
-        color: #b9b9c2;
+        color: var(--wa-color-text-link, #2962ff);
       }
     </style>
   </head>

--- a/spaday/examples/index.html
+++ b/spaday/examples/index.html
@@ -70,11 +70,16 @@
 
       const byId = (id) => document.getElementById(id);
 
-      // Light/dark toggle: flip the `wa-dark` class on <html>. (Class/root toggling is page chrome
-      // the action DSL doesn't model yet, so it's wired here like the transports edits.)
-      byId("theme-toggle").addEventListener("change", (e) =>
-        document.documentElement.classList.toggle("wa-dark", e.target.checked),
-      );
+      // Light/dark toggle: flip the `wa-dark` class on <html> (WebAwesome + the shell follow it), and
+      // recolor the charts, which are canvases that can't read CSS. (Class/root toggling and the chart
+      // theme are page chrome the action DSL doesn't model yet, so they're wired here.)
+      byId("theme-toggle").addEventListener("change", (e) => {
+        const dark = e.target.checked;
+        document.documentElement.classList.toggle("wa-dark", dark);
+        document
+          .querySelectorAll("lightweight-chart")
+          .forEach((c) => (c.theme = dark ? "dark" : "light"));
+      });
 
       // Wire one live chart to its transports connection (server-authoritative edits).
       function panel(prefix, wsUrl) {

--- a/spaday/examples/index.html
+++ b/spaday/examples/index.html
@@ -60,7 +60,7 @@
         wasm,
       } from "/js/node_modules/@1kbgz/transports/dist/cdn/index.js";
 
-      await init("/js/dist/pkg/spaday_bg.wasm"); // spaday's wasm core (the action interpreter)
+      await init({ module_or_path: "/js/dist/pkg/spaday_bg.wasm" }); // spaday's wasm core (the action interpreter)
       await wasm.default({
         module_or_path: "/js/node_modules/@1kbgz/transports/dist/pkg/transports_bg.wasm",
       });
@@ -81,12 +81,20 @@
           .forEach((c) => (c.theme = dark ? "dark" : "light"));
       });
 
-      // Wire one live chart to its transports connection (server-authoritative edits).
+      // The controls' edits are now declarative `SendPatch` actions; each fires a `spaday:patch`
+      // intent that this single sink routes to the right transports model. (Previously each control
+      // had its own hand-written listener; the only wiring left is this generic model→wire bridge.)
+      const patchSinks = {};
+      document.addEventListener("spaday:patch", (e) => {
+        const { model, field, value } = e.detail;
+        patchSinks[model]?.(field, value);
+      });
+
+      // Connect one live chart to its transports model (inbound updates + the outbound patch sink).
       function panel(prefix, wsUrl) {
         const chart = byId(`${prefix}-chart`);
         const typeSel = byId(`${prefix}-type`);
         const liveSw = byId(`${prefix}-live`);
-        const clearBtn = byId(`${prefix}-clear`);
         const status = byId(`${prefix}-status`);
         chart.style.height = "260px";
 
@@ -96,8 +104,9 @@
 
         const ws = new WebSocket(wsUrl);
         ws.binaryType = "arraybuffer";
-        const send = (changes) =>
-          ws.send(client.edit(id, toValue({ ...model(), ...changes })));
+        // outbound: a SendPatch intent for this model becomes a server-authoritative transports edit
+        patchSinks[prefix] = (field, value) =>
+          ws.send(client.edit(id, toValue({ ...model(), [field]: value })));
 
         ws.addEventListener("message", (event) => {
           client.recv(
@@ -111,7 +120,7 @@
           if (!m) return;
           chart.type = m.type;
           chart.data = m.data;
-          if (typeSel.value !== m.type) typeSel.value = m.type;
+          if (typeSel.value !== m.type) typeSel.value = m.type; // reflect model -> control
           if (liveSw.checked !== m.live) liveSw.checked = m.live;
           status.textContent = "live";
         });
@@ -119,10 +128,6 @@
           "close",
           () => (status.textContent = "disconnected"),
         );
-
-        typeSel.addEventListener("change", () => send({ type: typeSel.value }));
-        liveSw.addEventListener("change", () => send({ live: liveSw.checked }));
-        clearBtn.addEventListener("click", () => send({ data: [] }));
       }
 
       const session = crypto.randomUUID(); // a fresh tenant per page load

--- a/spaday/tests/test_actions.py
+++ b/spaday/tests/test_actions.py
@@ -2,8 +2,10 @@ import json
 
 from spaday import apply, diff, element
 from spaday.actions import (
+    CallEndpoint,
     Emit,
     If,
+    NamedJs,
     SendPatch,
     Sequence,
     SetProp,
@@ -41,6 +43,13 @@ def test_action_to_dict_wire_shapes():
         "field": "type",
         "value": {"expr": "event"},
     }
+    assert CallEndpoint("POST", "/api/order", event_value()).to_dict() == {
+        "kind": "call",
+        "method": "POST",
+        "url": "/api/order",
+        "body": {"expr": "event"},
+    }
+    assert NamedJs("confetti").to_dict() == {"kind": "js", "handler": "confetti"}
 
 
 def test_setprop_coerces_a_plain_value_to_a_literal():
@@ -90,4 +99,21 @@ def test_bind_authors_a_setprop_on_the_source_change():
 
 def test_node_with_events_round_trips_through_core_diff_apply():
     tree = element("button").on("click", Toggle(this(), "hidden")).to_json()
+    assert json.loads(apply(tree, diff(tree, tree))) == json.loads(tree)
+
+
+def test_every_action_kind_round_trips_through_core():
+    # one of each Action on a different event — proves the Rust core accepts/round-trips every variant
+    node = (
+        element("button")
+        .on("a", SetProp(this(), "x", lit(1)))
+        .on("b", Toggle(this(), "hidden"))
+        .on("c", Sequence(Toggle(this(), "hidden"), Emit("e", lit(1))))
+        .on("d", Emit("opened", lit(True)))
+        .on("e", SendPatch("m", "f", event_value()))
+        .on("f", If(prop(by_id("sw"), "checked"), Toggle(this(), "hidden"), SetProp(this(), "x", lit(0))))
+        .on("g", CallEndpoint("POST", "/u", lit({"k": 1})))
+        .on("h", NamedJs("fn"))
+    )
+    tree = node.to_json()
     assert json.loads(apply(tree, diff(tree, tree))) == json.loads(tree)

--- a/spaday/tests/test_actions.py
+++ b/spaday/tests/test_actions.py
@@ -3,6 +3,7 @@ import json
 from spaday import apply, diff, element
 from spaday.actions import (
     Emit,
+    SendPatch,
     Sequence,
     SetProp,
     Toggle,
@@ -30,6 +31,12 @@ def test_action_to_dict_wire_shapes():
         "kind": "emit",
         "event": "opened",
         "detail": {"expr": "lit", "value": True},
+    }
+    assert SendPatch("global", "type", event_value()).to_dict() == {
+        "kind": "patch",
+        "model": "global",
+        "field": "type",
+        "value": {"expr": "event"},
     }
 
 

--- a/spaday/tests/test_actions.py
+++ b/spaday/tests/test_actions.py
@@ -3,14 +3,17 @@ import json
 from spaday import apply, diff, element
 from spaday.actions import (
     Emit,
+    If,
     SendPatch,
     Sequence,
     SetProp,
     Toggle,
+    bind,
     by_id,
     event_value,
     lit,
     not_,
+    prop,
     this,
 )
 
@@ -59,6 +62,29 @@ def test_on_serializes_event_as_plain_action_on_the_node():
         "kind": "toggle",
         "target": {"ref": "this"},
         "prop": "hidden",
+    }
+
+
+def test_if_and_prop_wire_shapes():
+    action = If(prop(by_id("sw"), "checked"), Toggle(this(), "hidden"), SetProp(this(), "x", lit(1)))
+    assert action.to_dict() == {
+        "kind": "if",
+        "cond": {"expr": "prop", "target": {"ref": "id", "id": "sw"}, "name": "checked"},
+        "then": {"kind": "toggle", "target": {"ref": "this"}, "prop": "hidden"},
+        "else": {"kind": "set", "target": {"ref": "this"}, "prop": "x", "value": {"expr": "lit", "value": 1}},
+    }
+    assert If(prop(by_id("sw"), "checked"), Toggle(this(), "hidden")).to_dict()["else"] is None
+
+
+def test_bind_authors_a_setprop_on_the_source_change():
+    sw = element("wa-switch")
+    out = bind(sw, by_id("panel"), "hidden", transform=not_)
+    assert out is sw  # composes in a tree
+    assert sw.to_node()["events"]["change"] == {
+        "kind": "set",
+        "target": {"ref": "id", "id": "panel"},
+        "prop": "hidden",
+        "value": {"expr": "not", "of": {"expr": "event"}},
     }
 
 

--- a/spaday/tests/test_actions.py
+++ b/spaday/tests/test_actions.py
@@ -45,15 +45,13 @@ def test_sequence_nests_actions():
     assert seq["actions"][1]["detail"] is None  # Emit with no detail
 
 
-def test_on_serializes_event_as_tagged_value_on_the_node():
+def test_on_serializes_event_as_plain_action_on_the_node():
     node = element("button").on("click", Toggle(this(), "hidden")).to_node()
-    # events ride the same externally-tagged `Value` form as props, so they survive the core wire
+    # events carry the action DSL's own wire form (plain), owned by the Rust core — not a tagged Value
     assert node["events"]["click"] == {
-        "Map": {
-            "kind": {"Str": "toggle"},
-            "target": {"Map": {"ref": {"Str": "this"}}},
-            "prop": {"Str": "hidden"},
-        }
+        "kind": "toggle",
+        "target": {"ref": "this"},
+        "prop": "hidden",
     }
 
 

--- a/spaday/tests/test_shell.py
+++ b/spaday/tests/test_shell.py
@@ -33,3 +33,12 @@ def test_shell_re_exported_from_components_package():
 
     assert components.App is App
     assert components.Stack is Stack
+
+
+def test_shell_layout_props_become_attributes():
+    # typed layout kwargs land as props (the runtime sets them as attributes -> CSS custom properties)
+    assert Stack(gap="24px", align="end").to_node()["props"] == {"gap": {"Str": "24px"}, "align": {"Str": "end"}}
+    assert Gutter(width="320px").to_node()["props"] == {"width": {"Str": "320px"}}
+    assert Row(justify="space-between").to_node()["props"] == {"justify": {"Str": "space-between"}}
+    # unset kwargs are omitted, so an unstyled primitive stays prop-free
+    assert "props" not in Stack().to_node()


### PR DESCRIPTION
## Summary

Moves the **action DSL into the shared Rust core** (model + wasm interpreter) and builds out the rest of
**Phase 2** — `SendPatch`, conditionals (`If`), `CallEndpoint`, the `NamedJs` escape hatch, and a
one-way `bind()` helper — plus a **dark mode** and **Phase 4.1 shell polish**. 8 commits.

## Action DSL → the core ("one core, two bindings")

- Typed `Action`/`Expr`/`Ref` model in Rust (`rust/src/action.rs`) — serde **is** the canonical wire
  format + validation, replacing the `Action(Value)` placeholder. Both bindings share one model.
- The interpreter moved from TS into the `js` wasm crate: it dispatches actions and evaluates
  expressions, calling back into JS for the DOM primitives via a `Host` FFI — **no `web-sys`, no `eval`**.
  The browser initializes the wasm (`init` re-exported, awaited at entry points) with a clear-error guard.
- Actions ride the wire **plain** (the old `tag`/`untag` shim is gone).

## Phase 2 action set

- `SetProp` / `Toggle` / `Sequence` / `Emit` — client-side.
- `SendPatch` — a model-edit **intent** (`spaday:patch`) the app routes to its wire. The omnibus's
  transports edits are declarative now: **one** generic sink replaced three per-control listeners.
- `If` + `prop` expr — conditionals branching on live element state.
- `CallEndpoint` — a declarative REST round-trip (the interpreter performs it via a host `fetch`).
- `NamedJs` — the no-`eval` escape hatch (`registerHandler`) for the rare irreducible case.
- `bind()` — a one-way reactive-binding helper.

## Runtime / shell / theming

- Incremental `SetEvent`/`RemoveEvent` are now applied (per-element listener tracking) — server-driven
  action add/change/remove reaches live elements (was a silent no-op).
- The `spa-*` shell auto-themes via WebAwesome color tokens; typed layout props (`gap`/`align`/`justify`/
  `width`).
- Light/dark toggle in the omnibus — shell, WebAwesome components, and the canvas charts all follow.

## Examples

- Consolidated to **one self-serving omnibus** (`python -m spaday.examples`), authored entirely from the
  shell components (no layout divs); demonstrates the DSL + transports (global + per-session) + dark mode.

## Tests

Core **38** (action serde incl. every variant) · pytest **30** (to_dict shapes, every-kind round-trip,
`bind`, shell layout props) · Playwright **29** (each action incl. `CallEndpoint`/`NamedJs`/`If`/
`SendPatch`, incremental event patches, rendered-layout regression). cargo fmt + clippy + prettier clean.

## Deferred (their own efforts, noted for reviewers)

- The **signal-graph reactive engine** (derived/computed state, two-way `Bind`) — Phase 2.3 beyond the
  event-driven `bind()` shipped here.
- Full **spaday ↔ transports convergence** — Phase 2.4 / Phase 0.4. `SendPatch` covers the practical
  edit path today as an app-routed intent.
