### PR TITLE
Package spaday as an anywidget (spaday.Widget)

### DIFF
--- a/js/build.mjs
+++ b/js/build.mjs
@@ -5,6 +5,18 @@ import { node_modules_external } from "./tools/externals.mjs";
 import fs from "fs";
 import cpy from "cpy";
 
+// Statically register the whole WebAwesome catalog by importing each installed component module, so the
+// widget bundle is self-contained (no runtime chunk loading — WebAwesome's own `webawesome.js` entry is
+// a lazy bootstrap that can't resolve under anywidget's single-file ESM). Generated from node_modules,
+// so it tracks the installed version with no committed list.
+const WA_COMPONENTS = "node_modules/@awesome.me/webawesome/dist/components";
+const WA_WIDGET_ENTRY =
+  fs
+    .readdirSync(WA_COMPONENTS)
+    .filter((n) => fs.existsSync(`${WA_COMPONENTS}/${n}/${n}.js`))
+    .map((n) => `import "@awesome.me/webawesome/dist/components/${n}/${n}.js";`)
+    .join("\n") + '\nexport { default } from "./src/ts/widget";\n';
+
 const BUNDLES = [
   {
     entryPoints: ["src/ts/index.ts"],
@@ -30,11 +42,22 @@ const BUNDLES = [
     entryPoints: ["src/ts/widget.ts"],
     outfile: "dist/cdn/widget.js",
   },
+  {
+    // The widget bundle with the full WebAwesome catalog statically registered — the default ESM for
+    // the Python `Widget`, so every wa-* element renders in a notebook with no extra script. The entry
+    // is a generated virtual module (see WA_WIDGET_ENTRY) re-exporting the lean widget's default.
+    stdin: { contents: WA_WIDGET_ENTRY, resolveDir: ".", loader: "js" },
+    outfile: "dist/cdn/widget.webawesome.js",
+  },
 ];
 
 async function build() {
   // Bundle css
   await bundle_css();
+  // WebAwesome's base + theme CSS (resolve its @import chain into one file) for the widget's `_css`.
+  await bundle_css(
+    "node_modules/@awesome.me/webawesome/dist/styles/webawesome.css",
+  );
 
   // Copy HTML
   cpy("src/html/*", "dist/");

--- a/js/build.mjs
+++ b/js/build.mjs
@@ -25,6 +25,11 @@ const BUNDLES = [
     entryPoints: ["src/ts/examples/webawesome.ts"],
     outfile: "dist/cdn/examples/webawesome.js",
   },
+  {
+    // spaday as an anywidget ESM (self-contained runtime); the Python Widget loads it as `_esm`.
+    entryPoints: ["src/ts/widget.ts"],
+    outfile: "dist/cdn/widget.js",
+  },
 ];
 
 async function build() {

--- a/js/src/ts/widget.ts
+++ b/js/src/ts/widget.ts
@@ -17,17 +17,27 @@ interface AnyModel {
   send(content: unknown): void;
 }
 
+// `_wasm` arrives as an ArrayBuffer or a view into one (anywidget hosts commonly traffic in DataViews);
+// honor the view's offset/length so we don't hand the initializer extra bytes from a shared buffer.
+function toBytes(raw: unknown): Uint8Array {
+  if (raw instanceof ArrayBuffer) return new Uint8Array(raw);
+  if (ArrayBuffer.isView(raw))
+    return new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength);
+  throw new Error("widget _wasm must be an ArrayBuffer or a typed-array view");
+}
+
 // The wasm core is process-wide, so initialize it once from the first model's bytes; later widgets
-// reuse the same ready promise.
+// reuse the same ready promise. On failure, drop it so a later widget with valid bytes can retry
+// (a cached rejection would otherwise poison every subsequent render until reload).
 let ready: Promise<void> | undefined;
 function ensureWasm(model: AnyModel): Promise<void> {
   if (!ready) {
-    const raw = model.get("_wasm");
-    const bytes =
-      raw instanceof ArrayBuffer
-        ? new Uint8Array(raw)
-        : new Uint8Array((raw as DataView).buffer);
-    ready = init({ module_or_path: bytes });
+    ready = init({ module_or_path: toBytes(model.get("_wasm")) }).catch(
+      (err) => {
+        ready = undefined;
+        throw err;
+      },
+    );
   }
   return ready;
 }

--- a/js/src/ts/widget.ts
+++ b/js/src/ts/widget.ts
@@ -1,0 +1,75 @@
+// spaday as an anywidget: render a spaday component tree inside any anywidget host — Jupyter
+// (Lab/Notebook/Colab/VS Code), Marimo, Shiny-for-Python, Solara, Panel — over the widget's model.
+//
+// The model carries the serialized component tree (`_tree`) and the spaday wasm core (`_wasm`, the
+// action interpreter). The spaday runtime mounts the tree and keeps it live by diffing successive
+// trees with the same core `diff`/`applyPatch` it uses over a transports wire — so a Python-side
+// `widget.update(tree)` produces a minimal DOM patch, not a re-render. Behavior authored in Python
+// (the action DSL) runs client-side here with no kernel round-trip; the DSL's outbound intents
+// (a `SendPatch` action's `spaday:patch`) are forwarded to the kernel over the model.
+
+import { applyPatch, diff, init, mount, Node } from "./index";
+
+interface AnyModel {
+  get(key: string): unknown;
+  on(event: string, cb: () => void): void;
+  off(event: string, cb: () => void): void;
+  send(content: unknown): void;
+}
+
+// The wasm core is process-wide, so initialize it once from the first model's bytes; later widgets
+// reuse the same ready promise.
+let ready: Promise<void> | undefined;
+function ensureWasm(model: AnyModel): Promise<void> {
+  if (!ready) {
+    const raw = model.get("_wasm");
+    const bytes =
+      raw instanceof ArrayBuffer
+        ? new Uint8Array(raw)
+        : new Uint8Array((raw as DataView).buffer);
+    ready = init({ module_or_path: bytes });
+  }
+  return ready;
+}
+
+// Intents the action DSL bubbles to the host element; forward each to the kernel over the model so a
+// Python handler (Widget.on_intent) can react.
+const INTENTS = ["spaday:patch"];
+
+export default {
+  async initialize({ model }: { model: AnyModel }): Promise<void> {
+    await ensureWasm(model);
+  },
+  async render({
+    model,
+    el,
+  }: {
+    model: AnyModel;
+    el: HTMLElement;
+  }): Promise<() => void> {
+    await ensureWasm(model);
+
+    let tree = model.get("_tree") as Node;
+    let root = mount(el, tree);
+
+    const onTree = () => {
+      const next = model.get("_tree") as Node;
+      const patch = JSON.parse(
+        diff(JSON.stringify(tree), JSON.stringify(next)),
+      );
+      root = applyPatch(root, patch);
+      tree = next;
+    };
+    model.on("change:_tree", onTree);
+
+    const forward = (event: Event) =>
+      model.send({ type: event.type, detail: (event as CustomEvent).detail });
+    for (const name of INTENTS) el.addEventListener(name, forward);
+
+    return () => {
+      model.off("change:_tree", onTree);
+      for (const name of INTENTS) el.removeEventListener(name, forward);
+      root.remove();
+    };
+  },
+};

--- a/js/tests/widget-webawesome.html
+++ b/js/tests/widget-webawesome.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>spaday anywidget (WebAwesome) test harness</title>
+    <script type="module">
+      // The WebAwesome-inclusive widget bundle, loaded as an anywidget host would. Importing it must
+      // statically register the wa-* catalog (no runtime chunk loading). Same fake model as the lean
+      // harness so the render flow is testable without a kernel.
+      import widget from "/dist/cdn/widget.webawesome.js";
+
+      function fakeModel(state) {
+        const listeners = {};
+        const sent = [];
+        return {
+          _sent: sent,
+          get: (k) => state[k],
+          set: (k, v) => {
+            state[k] = v;
+            (listeners["change:" + k] || []).forEach((f) => f());
+          },
+          on: (ev, cb) => (listeners[ev] = (listeners[ev] || []).concat(cb)),
+          off: (ev, cb) =>
+            (listeners[ev] = (listeners[ev] || []).filter((f) => f !== cb)),
+          send: (content) => sent.push(content),
+        };
+      }
+
+      const wasm = await (
+        await fetch("/dist/pkg/spaday_bg.wasm")
+      ).arrayBuffer();
+      window.__widget = { widget, fakeModel, wasm };
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/js/tests/widget-webawesome.spec.js
+++ b/js/tests/widget-webawesome.spec.js
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+// The WebAwesome-inclusive widget bundle (dist/cdn/widget.webawesome.js): loading it must statically
+// register the wa-* catalog, and the widget must render and upgrade those elements in a notebook with
+// no extra script or network — the whole point of bundling WebAwesome into the widget.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/tests/widget-webawesome.html");
+  await page.waitForFunction(() => window.__widget);
+});
+
+test("statically registers the WebAwesome catalog (no runtime chunk loading)", async ({
+  page,
+}) => {
+  const defined = await page.evaluate(() => ({
+    button: !!customElements.get("wa-button"),
+    card: !!customElements.get("wa-card"),
+    switch_: !!customElements.get("wa-switch"),
+  }));
+  expect(defined).toEqual({ button: true, card: true, switch_: true });
+});
+
+test("mounts and upgrades a wa-* tree in the widget", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const { widget, fakeModel, wasm } = window.__widget;
+    const tree = {
+      tag: "wa-button",
+      props: { variant: { Str: "brand" }, textContent: { Str: "Go" } },
+      events: {
+        click: { kind: "toggle", target: { ref: "this" }, prop: "hidden" },
+      },
+    };
+    const model = fakeModel({ _wasm: wasm, _tree: tree });
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    await widget.initialize({ model });
+    await widget.render({ model, el });
+
+    const button = el.querySelector("wa-button");
+    await customElements.whenDefined("wa-button");
+    const upgraded = !!button.shadowRoot; // WebAwesome controls render into a shadow root
+    button.click(); // the action DSL still runs on the upgraded element
+    return { upgraded, hidden: button.hidden, label: button.textContent };
+  });
+
+  expect(result.upgraded).toBe(true);
+  expect(result.label).toBe("Go");
+  expect(result.hidden).toBe(true); // the client-side Toggle ran
+});

--- a/js/tests/widget.html
+++ b/js/tests/widget.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>spaday anywidget test harness</title>
+    <script type="module">
+      // Load the built anywidget ESM exactly as an anywidget host would, and stand up a minimal
+      // fake model (the bits widget.js uses: get / on / off / send) so the render flow is testable
+      // without a real kernel. The spaday wasm rides the model as bytes, like the Python Widget ships it.
+      import widget from "/dist/cdn/widget.js";
+
+      function fakeModel(state) {
+        const listeners = {};
+        const sent = [];
+        return {
+          _sent: sent,
+          get: (k) => state[k],
+          set: (k, v) => {
+            state[k] = v;
+            (listeners["change:" + k] || []).forEach((f) => f());
+          },
+          on: (ev, cb) => (listeners[ev] = (listeners[ev] || []).concat(cb)),
+          off: (ev, cb) =>
+            (listeners[ev] = (listeners[ev] || []).filter((f) => f !== cb)),
+          send: (content) => sent.push(content),
+        };
+      }
+
+      const wasm = await (await fetch("/dist/pkg/spaday_bg.wasm")).arrayBuffer();
+      window.__widget = { widget, fakeModel, wasm };
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/js/tests/widget.spec.js
+++ b/js/tests/widget.spec.js
@@ -10,6 +10,26 @@ test.beforeEach(async ({ page }) => {
   await page.waitForFunction(() => window.__widget);
 });
 
+test("accepts _wasm as a view into a larger buffer (offset honored)", async ({
+  page,
+}) => {
+  const ok = await page.evaluate(async () => {
+    const { widget, fakeModel, wasm } = window.__widget;
+    // pad the wasm into a bigger buffer and hand the widget a DataView slice of it
+    const pad = 8;
+    const buf = new ArrayBuffer(pad + wasm.byteLength);
+    new Uint8Array(buf, pad).set(new Uint8Array(wasm));
+    const view = new DataView(buf, pad, wasm.byteLength);
+
+    const model = fakeModel({ _wasm: view, _tree: { tag: "section" } });
+    const el = document.createElement("div");
+    await widget.initialize({ model });
+    await widget.render({ model, el });
+    return el.querySelector("section") !== null; // mounted ⇒ wasm initialized from the offset view
+  });
+  expect(ok).toBe(true);
+});
+
 test("renders the tree, then patches the live DOM on a _tree change", async ({
   page,
 }) => {

--- a/js/tests/widget.spec.js
+++ b/js/tests/widget.spec.js
@@ -1,0 +1,101 @@
+import { test, expect } from "@playwright/test";
+
+// The spaday anywidget ESM (dist/cdn/widget.js) end-to-end against a fake anywidget model: it mounts
+// a tree, applies a minimal diff when `_tree` changes (live elements preserved), runs the action DSL
+// client-side, and forwards a SendPatch intent to the kernel over the model. The wasm core inits from
+// the model's bytes inside the page — no kernel, no server.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/tests/widget.html");
+  await page.waitForFunction(() => window.__widget);
+});
+
+test("renders the tree, then patches the live DOM on a _tree change", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async () => {
+    const { widget, fakeModel, wasm } = window.__widget;
+    const span = (s) => ({ tag: "span", props: { textContent: { Str: s } } });
+    const tree = (s) => ({
+      tag: "div",
+      props: { id: { Str: "root" } },
+      slots: { default: [span(s)] },
+    });
+
+    const model = fakeModel({ _wasm: wasm, _tree: tree("a") });
+    const el = document.createElement("div");
+    await widget.initialize({ model });
+    const cleanup = await widget.render({ model, el });
+
+    const before = el.innerHTML;
+    el.querySelector("span").__orig = true; // prove the next update reuses this node
+    model.set("_tree", tree("b")); // a Python-side widget.update(...) lands as this change
+    const after = el.innerHTML;
+    const sameNode = el.querySelector("span").__orig === true;
+
+    cleanup();
+    return {
+      before,
+      after,
+      sameNode,
+      childrenAfterCleanup: el.children.length,
+    };
+  });
+
+  expect(result.before).toBe('<div id="root"><span>a</span></div>');
+  expect(result.after).toBe('<div id="root"><span>b</span></div>');
+  expect(result.sameNode).toBe(true); // incremental diff/applyPatch, not a re-render
+  expect(result.childrenAfterCleanup).toBe(0); // cleanup detaches the mounted root
+});
+
+test("runs a client-side action and forwards a SendPatch intent to the model", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async () => {
+    const { widget, fakeModel, wasm } = window.__widget;
+    // a button carrying two actions in sequence: a client-side Toggle (no round-trip) and a SendPatch
+    // (the model-edit intent the host forwards to Python).
+    const tree = {
+      tag: "div",
+      slots: {
+        default: [
+          {
+            tag: "button",
+            props: { id: { Str: "b" } },
+            events: {
+              click: {
+                kind: "seq",
+                actions: [
+                  { kind: "toggle", target: { ref: "this" }, prop: "hidden" },
+                  {
+                    kind: "patch",
+                    model: "demo",
+                    field: "ping",
+                    value: { expr: "lit", value: true },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const model = fakeModel({ _wasm: wasm, _tree: tree });
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    await widget.initialize({ model });
+    await widget.render({ model, el });
+
+    const button = el.querySelector("#b");
+    button.click();
+    return { hidden: button.hidden, sent: model._sent };
+  });
+
+  expect(result.hidden).toBe(true); // the Toggle ran in the browser
+  expect(result.sent).toHaveLength(1); // exactly the SendPatch intent
+  expect(result.sent[0]).toEqual({
+    type: "spaday:patch",
+    detail: { model: "demo", field: "ping", value: true },
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,12 @@ exclude = [
     "rust",
     "spaday/tests",
 ]
+# The JS build (hatch-js hook) emits the runtime/widget assets under spaday/extension, which is
+# git-ignored; include them as build artifacts so installed wheels ship the widget's _esm / _css /
+# wasm (without this, `from spaday.widget import Widget` fails on a pip-installed package).
+artifacts = [
+    "spaday/extension/**",
+]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
+widget = ["anywidget"]
 develop = [
+    "anywidget",
     "build",
     "bump-my-version",
     "check-dist",

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -50,4 +50,15 @@ __all__ = [
     "this",
     "by_id",
     "bind",
+    # anywidget host (optional; requires the `widget` extra)
+    "Widget",
 ]
+
+
+def __getattr__(name: str):
+    # `Widget` pulls in anywidget (an optional dep), so load it lazily — `import spaday` stays light.
+    if name == "Widget":
+        from .widget import Widget
+
+        return Widget
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/spaday/examples/widget.py
+++ b/spaday/examples/widget.py
@@ -1,41 +1,46 @@
-"""Render a spaday UI in a notebook (or Panel) with no server — see :class:`spaday.widget.Widget`.
+"""Render a WebAwesome UI in a notebook (or Panel) with no server — see :class:`spaday.widget.Widget`.
 
 In a Jupyter cell::
 
     from spaday.examples.widget import demo
-    w = demo(); w          # the cell renders the spaday tree
+    w = demo(); w          # the cell renders the spaday tree, WebAwesome and all
 
-Click **Toggle panel**: the panel shows/hides *client-side* — the action DSL runs in the browser, no
-kernel round-trip. Click **Ping Python**: a ``SendPatch`` intent rides the widget model back to the
-kernel, where ``on_intent`` prints it (the browser → Python edge). ``w.update(build(...))`` re-syncs
-the tree and the browser applies a minimal DOM patch.
+Click **Toggle panel**: the callout shows/hides *client-side* — the action DSL runs in the browser, no
+kernel round-trip. Flip **Reveal advanced**: a one-way `bind` drives a second callout. Click **Ping
+Python**: a ``SendPatch`` intent rides the widget model back to the kernel, where ``on_intent`` prints
+it (the browser → Python edge). ``w.update(build(...))`` re-syncs the tree and the browser applies a
+minimal DOM patch.
 
 The same widget renders in Panel (it bridges anywidgets)::
 
     import panel as pn; pn.extension()
     pn.panel(demo())
-
-This demo uses raw elements + the ``spa-*`` shell, which the widget bundle defines on its own. To use
-WebAwesome (``wa-*``) controls in a notebook, load WebAwesome in the page too (a follow-up is to
-bundle it into the widget).
 """
 
-from spaday import Component, SendPatch, Toggle, by_id, element, lit
+from spaday import Component, SendPatch, Toggle, bind, by_id, element, lit, not_
 from spaday.components.shell import Row, Stack
+from spaday.components.webawesome import WaButton, WaCallout, WaCard, WaSwitch
 from spaday.widget import Widget
 
 
-def build(message: str = "I'm a panel — the button flips my `hidden` property in the browser.") -> Component:
-    """The demo tree: a client-side Toggle and a Python-bound SendPatch over a small shell layout."""
-    return (
+def build(message: str = "I'm a panel — the button flips my `hidden` property, in the browser.") -> Component:
+    """The demo tree: WebAwesome controls carrying client-side actions + a Python-bound SendPatch."""
+    return WaCard(appearance="outlined").child(
         Stack()
-        .child(element("strong").text("spaday in a notebook — behavior runs in the browser"))
+        .child(element("strong").text("spaday in a notebook — WebAwesome, behavior in the browser"))
         .child(
             Row()
-            .child(element("button").text("Toggle panel").on("click", Toggle(by_id("panel"), "hidden")))
-            .child(element("button").text("Ping Python").on("click", SendPatch("demo", "ping", lit(True))))
+            .child(WaButton(variant="brand").text("Toggle panel").on("click", Toggle(by_id("panel"), "hidden")))
+            .child(WaButton(variant="neutral").text("Ping Python").on("click", SendPatch("demo", "ping", lit(True))))
         )
-        .child(element("p").prop("id", "panel").text(message))
+        .child(bind(WaSwitch().text("Reveal advanced"), by_id("advanced"), "hidden", transform=not_))
+        .child(WaCallout(variant="neutral").prop("id", "panel").text(message))
+        .child(
+            WaCallout(variant="brand")
+            .prop("id", "advanced")
+            .prop("hidden", True)
+            .text("Advanced — revealed by the switch (a one-way bind, client-side).")
+        )
     )
 
 

--- a/spaday/examples/widget.py
+++ b/spaday/examples/widget.py
@@ -1,0 +1,46 @@
+"""Render a spaday UI in a notebook (or Panel) with no server — see :class:`spaday.widget.Widget`.
+
+In a Jupyter cell::
+
+    from spaday.examples.widget import demo
+    w = demo(); w          # the cell renders the spaday tree
+
+Click **Toggle panel**: the panel shows/hides *client-side* — the action DSL runs in the browser, no
+kernel round-trip. Click **Ping Python**: a ``SendPatch`` intent rides the widget model back to the
+kernel, where ``on_intent`` prints it (the browser → Python edge). ``w.update(build(...))`` re-syncs
+the tree and the browser applies a minimal DOM patch.
+
+The same widget renders in Panel (it bridges anywidgets)::
+
+    import panel as pn; pn.extension()
+    pn.panel(demo())
+
+This demo uses raw elements + the ``spa-*`` shell, which the widget bundle defines on its own. To use
+WebAwesome (``wa-*``) controls in a notebook, load WebAwesome in the page too (a follow-up is to
+bundle it into the widget).
+"""
+
+from spaday import Component, SendPatch, Toggle, by_id, element, lit
+from spaday.components.shell import Row, Stack
+from spaday.widget import Widget
+
+
+def build(message: str = "I'm a panel — the button flips my `hidden` property in the browser.") -> Component:
+    """The demo tree: a client-side Toggle and a Python-bound SendPatch over a small shell layout."""
+    return (
+        Stack()
+        .child(element("strong").text("spaday in a notebook — behavior runs in the browser"))
+        .child(
+            Row()
+            .child(element("button").text("Toggle panel").on("click", Toggle(by_id("panel"), "hidden")))
+            .child(element("button").text("Ping Python").on("click", SendPatch("demo", "ping", lit(True))))
+        )
+        .child(element("p").prop("id", "panel").text(message))
+    )
+
+
+def demo() -> Widget:
+    """A ready-to-display `Widget`; intents from the browser are printed via `on_intent`."""
+    widget = Widget(build())
+    widget.on_intent(lambda content: print("intent from browser:", content))
+    return widget

--- a/spaday/tests/test_widget.py
+++ b/spaday/tests/test_widget.py
@@ -33,7 +33,19 @@ def test_on_intent_receives_frontend_messages():
     w.on_intent(seen.append)
     msg = {"type": "spaday:patch", "detail": {"model": "m", "field": "f", "value": True}}
     w._on_msg(w, msg, [])
+    w._on_msg(w, {"type": "other", "x": 1}, [])  # non-intent messages are ignored
+    w._on_msg(w, "not a dict", [])
     assert seen == [msg]
+
+
+def test_extension_assets_are_present():
+    from spaday import widget as widget_mod
+
+    # installed wheels must ship spaday/extension/** (force-included in pyproject); otherwise the
+    # _esm / _css / wasm the widget loads go missing and `import spaday.widget` breaks.
+    assert widget_mod._ESM.exists()
+    assert widget_mod._CSS.exists()
+    assert (widget_mod._EXT / "pkg" / "spaday_bg.wasm").exists()
 
 
 def test_widget_is_lazily_exported_from_the_package():

--- a/spaday/tests/test_widget.py
+++ b/spaday/tests/test_widget.py
@@ -1,0 +1,40 @@
+import pytest
+
+pytest.importorskip("anywidget")  # the optional `widget` extra
+
+import spaday  # noqa: E402
+from spaday import Toggle, by_id, element  # noqa: E402
+from spaday.widget import Widget  # noqa: E402
+
+
+def test_serializes_the_tree_and_ships_the_wasm_core():
+    w = Widget(element("div").prop("id", "root").text("hi"))
+    assert w._tree["tag"] == "div"
+    assert "id" in w._tree["props"]
+    assert len(w._wasm) > 0  # the action-interpreter wasm rides the model to the frontend
+
+
+def test_accepts_a_prebuilt_node_dict():
+    node = {"tag": "section", "props": {"id": {"Str": "x"}}}
+    assert Widget(node)._tree == node
+
+
+def test_update_reassigns_the_synced_tree():
+    w = Widget(element("div").text("a"))
+    before = w._tree
+    w.update(element("section").text("b"))
+    assert w._tree != before
+    assert w._tree["tag"] == "section"
+
+
+def test_on_intent_receives_frontend_messages():
+    w = Widget(element("button").on("click", Toggle(by_id("x"), "hidden")))
+    seen = []
+    w.on_intent(seen.append)
+    msg = {"type": "spaday:patch", "detail": {"model": "m", "field": "f", "value": True}}
+    w._on_msg(w, msg, [])
+    assert seen == [msg]
+
+
+def test_widget_is_lazily_exported_from_the_package():
+    assert spaday.Widget is Widget  # resolves via spaday.__getattr__, no eager anywidget import

--- a/spaday/widget.py
+++ b/spaday/widget.py
@@ -3,9 +3,10 @@
 `Widget(tree)` hosts a spaday component tree in any anywidget host — Jupyter (Lab/Notebook/Colab/VS
 Code), Marimo, Shiny-for-Python, Solara, Panel — so a spaday UI drops into a notebook cell or a Panel
 app with no server. The component tree rides the widget's model (`_tree`); the spaday wasm core (the
-action interpreter) rides `_wasm`; the JS half (`extension/cdn/widget.js`) mounts the tree with the
-spaday runtime. Behavior authored in Python (the action DSL) runs client-side with no kernel
-round-trip; a `SendPatch` action's intent is delivered back to Python via `on_intent`.
+action interpreter) rides `_wasm`; the JS half (`extension/cdn/widget.webawesome.js`) mounts the tree
+with the spaday runtime and registers the full WebAwesome catalog, so `wa-*` controls render in the
+notebook with no extra script. Behavior authored in Python (the action DSL) runs client-side with no
+kernel round-trip; a `SendPatch` action's intent is delivered back to Python via `on_intent`.
 
 `update(tree)` re-syncs the tree, and the browser applies a minimal `diff`/`applyPatch` — the same
 core used over a transports wire — so a changed tree patches the live DOM rather than re-rendering.
@@ -24,7 +25,10 @@ import traitlets
 from .component import Component
 
 _EXT = Path(__file__).parent / "extension"
-_ESM = _EXT / "cdn" / "widget.js"
+# the WebAwesome-inclusive bundle: every wa-* element is statically registered, so the default catalog
+# renders in a notebook with no extra script (the lean `widget.js` is for hosts that load WA themselves).
+_ESM = _EXT / "cdn" / "widget.webawesome.js"
+_CSS = _EXT / "css" / "webawesome.css"  # WebAwesome's base + theme tokens (import chain resolved)
 _WASM = (_EXT / "pkg" / "spaday_bg.wasm").read_bytes()
 
 Tree = Union[Component, dict]
@@ -38,6 +42,7 @@ class Widget(anywidget.AnyWidget):
     """An anywidget that renders a spaday component tree; `update()` re-syncs it incrementally."""
 
     _esm = _ESM
+    _css = _CSS  # WebAwesome base + theme tokens, injected into the host page
     # the spaday wasm core (action interpreter), shipped to the frontend as a synced byte buffer
     _wasm = traitlets.Bytes(_WASM).tag(sync=True)
     _tree = traitlets.Dict().tag(sync=True)

--- a/spaday/widget.py
+++ b/spaday/widget.py
@@ -62,6 +62,8 @@ class Widget(anywidget.AnyWidget):
         self._intent_handlers.append(handler)
 
     def _on_msg(self, _widget: Any, content: Any, _buffers: Any) -> None:
-        if isinstance(content, dict):
+        # Only the action DSL's intents (a `SendPatch`'s `spaday:patch`) reach handlers — not arbitrary
+        # frontend/host custom messages that may share this channel.
+        if isinstance(content, dict) and content.get("type") == "spaday:patch":
             for handler in self._intent_handlers:
                 handler(content)

--- a/spaday/widget.py
+++ b/spaday/widget.py
@@ -1,0 +1,62 @@
+"""spaday as an anywidget: render a component tree in Jupyter (and the wider anywidget ecosystem).
+
+`Widget(tree)` hosts a spaday component tree in any anywidget host — Jupyter (Lab/Notebook/Colab/VS
+Code), Marimo, Shiny-for-Python, Solara, Panel — so a spaday UI drops into a notebook cell or a Panel
+app with no server. The component tree rides the widget's model (`_tree`); the spaday wasm core (the
+action interpreter) rides `_wasm`; the JS half (`extension/cdn/widget.js`) mounts the tree with the
+spaday runtime. Behavior authored in Python (the action DSL) runs client-side with no kernel
+round-trip; a `SendPatch` action's intent is delivered back to Python via `on_intent`.
+
+`update(tree)` re-syncs the tree, and the browser applies a minimal `diff`/`applyPatch` — the same
+core used over a transports wire — so a changed tree patches the live DOM rather than re-rendering.
+
+The anywidget model is the sync channel here, in the role transports' comm adapter plays for a
+transports-hosted domain model: use this `Widget` to render a spaday tree directly; use a transports
+`Session` over the comm (`transports.serve_comm`) when the data is a transports model the tree reads.
+"""
+
+from pathlib import Path
+from typing import Any, Callable, List, Union
+
+import anywidget
+import traitlets
+
+from .component import Component
+
+_EXT = Path(__file__).parent / "extension"
+_ESM = _EXT / "cdn" / "widget.js"
+_WASM = (_EXT / "pkg" / "spaday_bg.wasm").read_bytes()
+
+Tree = Union[Component, dict]
+
+
+def _to_node(tree: Tree) -> dict:
+    return tree.to_node() if isinstance(tree, Component) else tree
+
+
+class Widget(anywidget.AnyWidget):
+    """An anywidget that renders a spaday component tree; `update()` re-syncs it incrementally."""
+
+    _esm = _ESM
+    # the spaday wasm core (action interpreter), shipped to the frontend as a synced byte buffer
+    _wasm = traitlets.Bytes(_WASM).tag(sync=True)
+    _tree = traitlets.Dict().tag(sync=True)
+
+    def __init__(self, tree: Tree, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._tree = _to_node(tree)
+        self._intent_handlers: List[Callable[[dict], None]] = []
+        self.on_msg(self._on_msg)
+
+    def update(self, tree: Tree) -> None:
+        """Replace the rendered tree; the browser applies a minimal diff to the live DOM."""
+        self._tree = _to_node(tree)
+
+    def on_intent(self, handler: Callable[[dict], None]) -> None:
+        """Register a handler for frontend intents — a `SendPatch` action's ``{type, detail}``."""
+        self._intent_handlers.append(handler)
+
+    def _on_msg(self, _widget: Any, content: Any, _buffers: Any) -> None:
+        if isinstance(content, dict):
+            for handler in self._intent_handlers:
+                handler(content)


### PR DESCRIPTION
The Integrations keystone: a spaday UI drops into a notebook (and the wider anywidget ecosystem — Marimo, Shiny, Solara, Panel) with no server.

## What

`spaday.Widget(tree)` hosts any spaday component tree in an anywidget:

- the tree rides the widget model (`_tree`); the spaday wasm core (the action interpreter) rides `_wasm`
- the ESM (`js/src/ts/widget.ts` → self-contained `extension/cdn/widget.js`) mounts the tree and, on each `update(tree)`, applies a minimal **spaday `diff`/`applyPatch`** — live elements preserved, not a re-render
- the **action DSL runs client-side** (Toggle/SetProp/… with no kernel round-trip)
- a `SendPatch` action's intent is forwarded back to Python via `on_intent` (the browser→Python edge)

Adds the `widget` extra (`anywidget`), a demo (`spaday/examples/widget.py`), Python tests, and a Playwright ESM spec.

## How it relates to the transports comm

Complementary channels over the same comm. This `Widget` syncs the **component tree** directly over the anywidget model; a transports `Session` over the comm (`transports.serve_comm`) is the path when the data is a **transports-hosted domain model** the tree reads (daggre's widget pattern). Phase 0.4 (tree-on-transports) would later unify them; not needed here.

## Verification

- `pytest spaday/tests` — 35 passed (5 new: tree serialize, prebuilt-node, `update`, `on_intent`, lazy export)
- `playwright test` — 31 passed (2 new ESM specs: tree mount + incremental patch reusing live nodes; client-side action + SendPatch intent forwarded)
- `ruff`, `ty`, `prettier`, `clippy` clean; `import spaday` stays light (no eager `anywidget`)

Note: the demo uses raw elements + the `spa-*` shell (the widget bundle defines those itself). Using WebAwesome `wa-*` in a notebook needs WebAwesome loaded in the page — a follow-up is to bundle it into the widget.