### PR TITLE
Inline the wasm core into the widget bundle

### DIFF
--- a/js/build.mjs
+++ b/js/build.mjs
@@ -38,9 +38,12 @@ const BUNDLES = [
     outfile: "dist/cdn/examples/webawesome.js",
   },
   {
-    // spaday as an anywidget ESM (self-contained runtime); the Python Widget loads it as `_esm`.
+    // spaday as an anywidget ESM (self-contained runtime + inlined wasm); the Python Widget loads it
+    // as `_esm`. The `binary` loader inlines the wasm core into the bundle (see widget.ts), so the
+    // widget is one self-contained file with no separately-synced `_wasm`.
     entryPoints: ["src/ts/widget.ts"],
     outfile: "dist/cdn/widget.js",
+    loader: { ".wasm": "binary" },
   },
   {
     // The widget bundle with the full WebAwesome catalog statically registered — the default ESM for
@@ -48,6 +51,7 @@ const BUNDLES = [
     // is a generated virtual module (see WA_WIDGET_ENTRY) re-exporting the lean widget's default.
     stdin: { contents: WA_WIDGET_ENTRY, resolveDir: ".", loader: "js" },
     outfile: "dist/cdn/widget.webawesome.js",
+    loader: { ".wasm": "binary" },
   },
 ];
 

--- a/js/src/ts/wasm.d.ts
+++ b/js/src/ts/wasm.d.ts
@@ -1,0 +1,4 @@
+declare module "*.wasm" {
+  const bytes: Uint8Array;
+  export default bytes;
+}

--- a/js/src/ts/widget.ts
+++ b/js/src/ts/widget.ts
@@ -1,14 +1,19 @@
 // spaday as an anywidget: render a spaday component tree inside any anywidget host — Jupyter
 // (Lab/Notebook/Colab/VS Code), Marimo, Shiny-for-Python, Solara, Panel — over the widget's model.
 //
-// The model carries the serialized component tree (`_tree`) and the spaday wasm core (`_wasm`, the
-// action interpreter). The spaday runtime mounts the tree and keeps it live by diffing successive
-// trees with the same core `diff`/`applyPatch` it uses over a transports wire — so a Python-side
+// The model carries only the serialized component tree (`_tree`); the wasm core (the action
+// interpreter) is inlined into this bundle, so nothing else syncs over the comm. The spaday runtime
+// mounts the tree and keeps it live by diffing successive trees with the same core `diff`/`applyPatch`
+// it uses over a transports wire — so a Python-side
 // `widget.update(tree)` produces a minimal DOM patch, not a re-render. Behavior authored in Python
 // (the action DSL) runs client-side here with no kernel round-trip; the DSL's outbound intents
 // (a `SendPatch` action's `spaday:patch`) are forwarded to the kernel over the model.
 
 import { applyPatch, diff, init, mount, Node } from "./index";
+
+// the spaday wasm core, inlined into this bundle as bytes (esbuild `binary` loader; see build.mjs),
+// so the widget is one self-contained ESM with no separately-synced `_wasm`.
+import wasm from "../../dist/pkg/spaday_bg.wasm";
 
 interface AnyModel {
   get(key: string): unknown;
@@ -17,27 +22,16 @@ interface AnyModel {
   send(content: unknown): void;
 }
 
-// `_wasm` arrives as an ArrayBuffer or a view into one (anywidget hosts commonly traffic in DataViews);
-// honor the view's offset/length so we don't hand the initializer extra bytes from a shared buffer.
-function toBytes(raw: unknown): Uint8Array {
-  if (raw instanceof ArrayBuffer) return new Uint8Array(raw);
-  if (ArrayBuffer.isView(raw))
-    return new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength);
-  throw new Error("widget _wasm must be an ArrayBuffer or a typed-array view");
-}
-
-// The wasm core is process-wide, so initialize it once from the first model's bytes; later widgets
-// reuse the same ready promise. On failure, drop it so a later widget with valid bytes can retry
-// (a cached rejection would otherwise poison every subsequent render until reload).
+// The wasm core is inlined into this bundle and is process-wide, so initialize it once; later widgets
+// reuse the same promise. On failure, drop it so a retry can re-attempt (a cached rejection would
+// otherwise poison every later render until reload).
 let ready: Promise<void> | undefined;
-function ensureWasm(model: AnyModel): Promise<void> {
+function ensureWasm(): Promise<void> {
   if (!ready) {
-    ready = init({ module_or_path: toBytes(model.get("_wasm")) }).catch(
-      (err) => {
-        ready = undefined;
-        throw err;
-      },
-    );
+    ready = init({ module_or_path: wasm }).catch((err) => {
+      ready = undefined;
+      throw err;
+    });
   }
   return ready;
 }
@@ -47,8 +41,8 @@ function ensureWasm(model: AnyModel): Promise<void> {
 const INTENTS = ["spaday:patch"];
 
 export default {
-  async initialize({ model }: { model: AnyModel }): Promise<void> {
-    await ensureWasm(model);
+  async initialize(): Promise<void> {
+    await ensureWasm();
   },
   async render({
     model,
@@ -57,7 +51,7 @@ export default {
     model: AnyModel;
     el: HTMLElement;
   }): Promise<() => void> {
-    await ensureWasm(model);
+    await ensureWasm();
 
     let tree = model.get("_tree") as Node;
     let root = mount(el, tree);

--- a/js/tests/widget-webawesome.html
+++ b/js/tests/widget-webawesome.html
@@ -6,7 +6,7 @@
     <script type="module">
       // The WebAwesome-inclusive widget bundle, loaded as an anywidget host would. Importing it must
       // statically register the wa-* catalog (no runtime chunk loading). Same fake model as the lean
-      // harness so the render flow is testable without a kernel.
+      // harness; the wasm core is inlined in the bundle, so nothing is fetched.
       import widget from "/dist/cdn/widget.webawesome.js";
 
       function fakeModel(state) {
@@ -26,10 +26,7 @@
         };
       }
 
-      const wasm = await (
-        await fetch("/dist/pkg/spaday_bg.wasm")
-      ).arrayBuffer();
-      window.__widget = { widget, fakeModel, wasm };
+      window.__widget = { widget, fakeModel };
     </script>
   </head>
   <body></body>

--- a/js/tests/widget-webawesome.spec.js
+++ b/js/tests/widget-webawesome.spec.js
@@ -22,7 +22,7 @@ test("statically registers the WebAwesome catalog (no runtime chunk loading)", a
 
 test("mounts and upgrades a wa-* tree in the widget", async ({ page }) => {
   const result = await page.evaluate(async () => {
-    const { widget, fakeModel, wasm } = window.__widget;
+    const { widget, fakeModel } = window.__widget;
     const tree = {
       tag: "wa-button",
       props: { variant: { Str: "brand" }, textContent: { Str: "Go" } },
@@ -30,10 +30,10 @@ test("mounts and upgrades a wa-* tree in the widget", async ({ page }) => {
         click: { kind: "toggle", target: { ref: "this" }, prop: "hidden" },
       },
     };
-    const model = fakeModel({ _wasm: wasm, _tree: tree });
+    const model = fakeModel({ _tree: tree });
     const el = document.createElement("div");
     document.body.appendChild(el);
-    await widget.initialize({ model });
+    await widget.initialize();
     await widget.render({ model, el });
 
     const button = el.querySelector("wa-button");

--- a/js/tests/widget.html
+++ b/js/tests/widget.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <title>spaday anywidget test harness</title>
     <script type="module">
-      // Load the built anywidget ESM exactly as an anywidget host would, and stand up a minimal
-      // fake model (the bits widget.js uses: get / on / off / send) so the render flow is testable
-      // without a real kernel. The spaday wasm rides the model as bytes, like the Python Widget ships it.
+      // Load the built anywidget ESM exactly as an anywidget host would, and stand up a minimal fake
+      // model (the bits widget.js uses: get / set / on / off / send) so the render flow is testable
+      // without a real kernel. The wasm core is inlined in the bundle, so nothing is fetched.
       import widget from "/dist/cdn/widget.js";
 
       function fakeModel(state) {
@@ -26,8 +26,7 @@
         };
       }
 
-      const wasm = await (await fetch("/dist/pkg/spaday_bg.wasm")).arrayBuffer();
-      window.__widget = { widget, fakeModel, wasm };
+      window.__widget = { widget, fakeModel };
     </script>
   </head>
   <body></body>

--- a/js/tests/widget.spec.js
+++ b/js/tests/widget.spec.js
@@ -1,40 +1,20 @@
 import { test, expect } from "@playwright/test";
 
-// The spaday anywidget ESM (dist/cdn/widget.js) end-to-end against a fake anywidget model: it mounts
-// a tree, applies a minimal diff when `_tree` changes (live elements preserved), runs the action DSL
-// client-side, and forwards a SendPatch intent to the kernel over the model. The wasm core inits from
-// the model's bytes inside the page — no kernel, no server.
+// The spaday anywidget ESM (dist/cdn/widget.js) end-to-end against a fake anywidget model: it mounts a
+// tree, applies a minimal diff when `_tree` changes (live elements preserved), runs the action DSL
+// client-side, and forwards a SendPatch intent to the kernel over the model. The wasm core is inlined
+// in the bundle, so there is no kernel and nothing to fetch.
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/tests/widget.html");
   await page.waitForFunction(() => window.__widget);
 });
 
-test("accepts _wasm as a view into a larger buffer (offset honored)", async ({
-  page,
-}) => {
-  const ok = await page.evaluate(async () => {
-    const { widget, fakeModel, wasm } = window.__widget;
-    // pad the wasm into a bigger buffer and hand the widget a DataView slice of it
-    const pad = 8;
-    const buf = new ArrayBuffer(pad + wasm.byteLength);
-    new Uint8Array(buf, pad).set(new Uint8Array(wasm));
-    const view = new DataView(buf, pad, wasm.byteLength);
-
-    const model = fakeModel({ _wasm: view, _tree: { tag: "section" } });
-    const el = document.createElement("div");
-    await widget.initialize({ model });
-    await widget.render({ model, el });
-    return el.querySelector("section") !== null; // mounted ⇒ wasm initialized from the offset view
-  });
-  expect(ok).toBe(true);
-});
-
 test("renders the tree, then patches the live DOM on a _tree change", async ({
   page,
 }) => {
   const result = await page.evaluate(async () => {
-    const { widget, fakeModel, wasm } = window.__widget;
+    const { widget, fakeModel } = window.__widget;
     const span = (s) => ({ tag: "span", props: { textContent: { Str: s } } });
     const tree = (s) => ({
       tag: "div",
@@ -42,9 +22,9 @@ test("renders the tree, then patches the live DOM on a _tree change", async ({
       slots: { default: [span(s)] },
     });
 
-    const model = fakeModel({ _wasm: wasm, _tree: tree("a") });
+    const model = fakeModel({ _tree: tree("a") });
     const el = document.createElement("div");
-    await widget.initialize({ model });
+    await widget.initialize();
     const cleanup = await widget.render({ model, el });
 
     const before = el.innerHTML;
@@ -72,7 +52,7 @@ test("runs a client-side action and forwards a SendPatch intent to the model", a
   page,
 }) => {
   const result = await page.evaluate(async () => {
-    const { widget, fakeModel, wasm } = window.__widget;
+    const { widget, fakeModel } = window.__widget;
     // a button carrying two actions in sequence: a client-side Toggle (no round-trip) and a SendPatch
     // (the model-edit intent the host forwards to Python).
     const tree = {
@@ -101,10 +81,10 @@ test("runs a client-side action and forwards a SendPatch intent to the model", a
       },
     };
 
-    const model = fakeModel({ _wasm: wasm, _tree: tree });
+    const model = fakeModel({ _tree: tree });
     const el = document.createElement("div");
     document.body.appendChild(el);
-    await widget.initialize({ model });
+    await widget.initialize();
     await widget.render({ model, el });
 
     const button = el.querySelector("#b");

--- a/js/tools/bundle.mjs
+++ b/js/tools/bundle.mjs
@@ -38,6 +38,9 @@ export const bundle = async (config) => {
     const result = await esbuild.build({
         ...DEFAULT_BUILD,
         ...config,
+        // merge (don't replace) the loader map so a bundle can override one extension, e.g. inline the
+        // wasm as bytes for the self-contained widget instead of emitting it as a file.
+        loader: { ...COMMON_LOADER, ...(config.loader || {}) },
     });
 
     if (result.metafile) {

--- a/spaday/tests/test_widget.py
+++ b/spaday/tests/test_widget.py
@@ -7,11 +7,10 @@ from spaday import Toggle, by_id, element  # noqa: E402
 from spaday.widget import Widget  # noqa: E402
 
 
-def test_serializes_the_tree_and_ships_the_wasm_core():
+def test_serializes_the_tree():
     w = Widget(element("div").prop("id", "root").text("hi"))
     assert w._tree["tag"] == "div"
     assert "id" in w._tree["props"]
-    assert len(w._wasm) > 0  # the action-interpreter wasm rides the model to the frontend
 
 
 def test_accepts_a_prebuilt_node_dict():
@@ -41,11 +40,11 @@ def test_on_intent_receives_frontend_messages():
 def test_extension_assets_are_present():
     from spaday import widget as widget_mod
 
-    # installed wheels must ship spaday/extension/** (force-included in pyproject); otherwise the
-    # _esm / _css / wasm the widget loads go missing and `import spaday.widget` breaks.
+    # installed wheels must ship spaday/extension/** (artifacts in pyproject); otherwise the _esm /
+    # _css the widget loads go missing and it fails to render. (The wasm core is inlined into the _esm
+    # bundle at build time, so there is no separate wasm file to load at runtime.)
     assert widget_mod._ESM.exists()
     assert widget_mod._CSS.exists()
-    assert (widget_mod._EXT / "pkg" / "spaday_bg.wasm").exists()
 
 
 def test_widget_is_lazily_exported_from_the_package():

--- a/spaday/widget.py
+++ b/spaday/widget.py
@@ -2,10 +2,10 @@
 
 `Widget(tree)` hosts a spaday component tree in any anywidget host — Jupyter (Lab/Notebook/Colab/VS
 Code), Marimo, Shiny-for-Python, Solara, Panel — so a spaday UI drops into a notebook cell or a Panel
-app with no server. The component tree rides the widget's model (`_tree`); the spaday wasm core (the
-action interpreter) rides `_wasm`; the JS half (`extension/cdn/widget.webawesome.js`) mounts the tree
-with the spaday runtime and registers the full WebAwesome catalog, so `wa-*` controls render in the
-notebook with no extra script. Behavior authored in Python (the action DSL) runs client-side with no
+app with no server. The component tree rides the widget's model (`_tree`); the JS half
+(`extension/cdn/widget.webawesome.js`) inlines the spaday runtime *and* its wasm core and registers the
+full WebAwesome catalog, so it mounts the tree and renders `wa-*` controls in the notebook with no extra
+script and nothing else to load. Behavior authored in Python (the action DSL) runs client-side with no
 kernel round-trip; a `SendPatch` action's intent is delivered back to Python via `on_intent`.
 
 `update(tree)` re-syncs the tree, and the browser applies a minimal `diff`/`applyPatch` — the same
@@ -29,7 +29,6 @@ _EXT = Path(__file__).parent / "extension"
 # renders in a notebook with no extra script (the lean `widget.js` is for hosts that load WA themselves).
 _ESM = _EXT / "cdn" / "widget.webawesome.js"
 _CSS = _EXT / "css" / "webawesome.css"  # WebAwesome's base + theme tokens (import chain resolved)
-_WASM = (_EXT / "pkg" / "spaday_bg.wasm").read_bytes()
 
 Tree = Union[Component, dict]
 
@@ -43,8 +42,6 @@ class Widget(anywidget.AnyWidget):
 
     _esm = _ESM
     _css = _CSS  # WebAwesome base + theme tokens, injected into the host page
-    # the spaday wasm core (action interpreter), shipped to the frontend as a synced byte buffer
-    _wasm = traitlets.Bytes(_WASM).tag(sync=True)
     _tree = traitlets.Dict().tag(sync=True)
 
     def __init__(self, tree: Tree, **kwargs: Any) -> None:


### PR DESCRIPTION
Follow-up to #55. The widget's ESM now **embeds** the spaday wasm core, so the widget is one fully self-contained file.

## What

- The two widget bundles use esbuild's `binary` loader for `.wasm`, so `widget.ts` imports `spaday_bg.wasm` and inits from the inlined bytes. `bundle()` now **merges** the loader map (rather than replacing it) so a per-bundle override composes with the defaults.
- Drops the `_wasm` traitlet (and the import-time wasm read) from `spaday.Widget`. The model now syncs **only** the component tree (`_tree`).
- Removes the `DataView`/byte-offset handling and its test — there's no model-supplied buffer anymore. The wasm inits once, process-wide.

## Why

Previously the wasm (~506KB) rode the `_wasm` traitlet and anywidget synced it as model state **per widget instance**. Embedding moves it into the ESM, which loads once and is cached — no per-widget comm sync, and simpler code. `widget.webawesome.js` grows ~675KB (base64) as a result.

## Verification

- Build: no sibling `.wasm` emitted (inlined); `widget.webawesome.js` 1.1MB → 1.79MB.
- `pytest spaday/tests` 36 · `playwright test` 33 · `ty` · `prettier`/`clippy` all green.
- Widget specs init from the inlined wasm with nothing fetched; `Widget` no longer carries `_wasm`.

Net −23 lines (the byte-handling path is gone).