### PR TITLE
Reactive engine: signal store + prop↔field bindings (Phase 2.3)

### DIFF
--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -31,7 +31,11 @@ export type { ComponentSchema, PropSchema, PropType } from "./cem";
 
 // Browser runtime: render a component tree to the DOM and apply tree patches incrementally.
 export { mount, applyPatch } from "./runtime";
-export type { Node } from "./runtime";
+export type { Binding, Node } from "./runtime";
+
+// Reactive engine: a signal store whose fields back the tree's reactive `bindings` (prop ↔ field).
+export { Store } from "./signals";
+export type { Field } from "./signals";
 
 // Action DSL: declarative behavior, interpreted in the browser on DOM events (no Python round-trip).
 export { interpret } from "./actions";

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -7,7 +7,13 @@
 // handlers, rebinding/detaching them as incremental `SetEvent`/`RemoveEvent` patches arrive.
 
 import { interpret } from "./actions";
+import { Store } from "./signals";
 import { untag, Value } from "./value";
+
+export interface Binding {
+  field: string;
+  mode: string;
+}
 
 export interface Node {
   tag: string;
@@ -15,6 +21,7 @@ export interface Node {
   props?: Record<string, Value>;
   slots?: Record<string, Node[]>;
   events?: Record<string, unknown>;
+  bindings?: Record<string, Binding>;
 }
 
 interface PathSeg {
@@ -25,9 +32,12 @@ type Path = PathSeg[];
 
 const DEFAULT_SLOT = "default";
 
-/** Build the DOM for a tree and append it to `container`; returns the root element. */
-export function mount(container: Element, tree: Node): Element {
-  const el = build(tree);
+/**
+ * Build the DOM for a tree and append it to `container`; returns the root element. Pass a `store` to
+ * activate the tree's reactive `bindings` (prop ↔ state field); without one, bindings are inert.
+ */
+export function mount(container: Element, tree: Node, store?: Store): Element {
+  const el = build(tree, store);
   container.appendChild(el);
   return el;
 }
@@ -37,9 +47,13 @@ export function mount(container: Element, tree: Node): Element {
  * current root — a root-level `Replace` swaps the element, so callers must keep the returned value
  * (the original `root` reference would be left detached).
  */
-export function applyPatch(root: Element, patch: { ops: Op[] }): Element {
+export function applyPatch(
+  root: Element,
+  patch: { ops: Op[] },
+  store?: Store,
+): Element {
   let current = root;
-  for (const op of patch.ops) current = applyOp(current, op);
+  for (const op of patch.ops) current = applyOp(current, op, store);
   return current;
 }
 
@@ -67,16 +81,62 @@ function unbindEvent(el: Element, name: string): void {
   }
 }
 
-function build(node: Node): Element {
+// Live binding teardowns per element/prop, so an incremental patch can rewire or detach them. A binding
+// subscribes the prop to its state field; a two-way binding also writes the field when the control changes.
+const bindings = new WeakMap<Element, Map<string, () => void>>();
+const VALUE_EVENTS = ["change", "input"]; // a control writes its bound field on these
+
+function readProp(el: Element, name: string): unknown {
+  if (name in el) return (el as unknown as Record<string, unknown>)[name];
+  return el.hasAttribute(name) ? el.getAttribute(name) : null;
+}
+
+function wireBinding(
+  el: Element,
+  prop: string,
+  spec: Binding,
+  store: Store,
+): void {
+  unwireBinding(el, prop); // replace any prior wiring for this prop
+  const teardowns: Array<() => void> = [];
+  if (store.has(spec.field)) setProp(el, prop, store.get(spec.field)); // initial field → prop
+  teardowns.push(store.subscribe(spec.field, (v) => setProp(el, prop, v)));
+  if (spec.mode === "two-way") {
+    const onChange = () => store.set(spec.field, readProp(el, prop));
+    for (const ev of VALUE_EVENTS) el.addEventListener(ev, onChange);
+    teardowns.push(() => {
+      for (const ev of VALUE_EVENTS) el.removeEventListener(ev, onChange);
+    });
+  }
+  let map = bindings.get(el);
+  if (!map) bindings.set(el, (map = new Map()));
+  map.set(prop, () => teardowns.forEach((t) => t()));
+}
+
+function unwireBinding(el: Element, prop: string): void {
+  const map = bindings.get(el);
+  const teardown = map?.get(prop);
+  if (teardown) {
+    teardown();
+    map!.delete(prop);
+  }
+}
+
+function build(node: Node, store?: Store): Element {
   const el = document.createElement(node.tag);
   for (const [name, value] of Object.entries(node.props ?? {})) {
     setProp(el, name, untag(value));
   }
   for (const [slot, children] of Object.entries(node.slots ?? {})) {
-    for (const child of children) appendInSlot(el, slot, build(child));
+    for (const child of children) appendInSlot(el, slot, build(child, store));
   }
   for (const [name, action] of Object.entries(node.events ?? {})) {
     bindEvent(el, name, action); // actions ride the wire as the core's DSL form (plain JSON)
+  }
+  if (store) {
+    for (const [prop, spec] of Object.entries(node.bindings ?? {})) {
+      wireBinding(el, prop, spec, store);
+    }
   }
   return el;
 }
@@ -137,6 +197,8 @@ type Op =
   | { RemoveProp: { path: Path; name: string } }
   | { SetEvent: { path: Path; name: string; action: unknown } }
   | { RemoveEvent: { path: Path; name: string } }
+  | { SetBinding: { path: Path; name: string; binding: Binding } }
+  | { RemoveBinding: { path: Path; name: string } }
   | { SetKey: { path: Path; key: string | null } }
   | { InsertChild: { path: Path; slot: string; index: number; node: Node } }
   | { RemoveChild: { path: Path; slot: string; index: number } }
@@ -149,7 +211,7 @@ function resolve(root: Element, path: Path): Element {
   return el;
 }
 
-function applyOp(root: Element, op: Op): Element {
+function applyOp(root: Element, op: Op, store?: Store): Element {
   if ("SetProp" in op) {
     setProp(
       resolve(root, op.SetProp.path),
@@ -164,9 +226,15 @@ function applyOp(root: Element, op: Op): Element {
   } else if ("RemoveEvent" in op) {
     const { path, name } = op.RemoveEvent;
     unbindEvent(resolve(root, path), name);
+  } else if ("SetBinding" in op) {
+    const { path, name, binding } = op.SetBinding;
+    if (store) wireBinding(resolve(root, path), name, binding, store);
+  } else if ("RemoveBinding" in op) {
+    const { path, name } = op.RemoveBinding;
+    unwireBinding(resolve(root, path), name);
   } else if ("InsertChild" in op) {
     const { path, slot, index, node } = op.InsertChild;
-    insertInSlot(resolve(root, path), slot, index, build(node));
+    insertInSlot(resolve(root, path), slot, index, build(node, store));
   } else if ("RemoveChild" in op) {
     const { path, slot, index } = op.RemoveChild;
     childrenInSlot(resolve(root, path), slot)[index].remove();
@@ -178,7 +246,7 @@ function applyOp(root: Element, op: Op): Element {
     insertInSlot(parent, slot, to, moving);
   } else if ("Replace" in op) {
     const target = resolve(root, op.Replace.path);
-    const replacement = build(op.Replace.node);
+    const replacement = build(op.Replace.node, store);
     target.replaceWith(replacement);
     if (op.Replace.path.length === 0) return replacement; // the root element itself was swapped
   }

--- a/js/src/ts/signals.ts
+++ b/js/src/ts/signals.ts
@@ -1,0 +1,43 @@
+// A tiny reactive store: named state fields with subscribers — the client-side half of the reactive
+// engine. The runtime binds component props to fields (a node's `bindings`, authored via `Component.bind`
+// in Python); setting a field notifies every bound prop, and a two-way-bound control writes its field
+// back on change. The same store can later be backed by a transports model or the anywidget model so UI
+// state and app/server state mirror (Phase 2.4).
+
+export type Field = string;
+type Subscriber = (value: unknown) => void;
+
+export class Store {
+  private values: Map<Field, unknown>;
+  private subscribers: Map<Field, Set<Subscriber>> = new Map();
+
+  constructor(initial: Record<Field, unknown> = {}) {
+    this.values = new Map(Object.entries(initial));
+  }
+
+  get(field: Field): unknown {
+    return this.values.get(field);
+  }
+
+  has(field: Field): boolean {
+    return this.values.has(field);
+  }
+
+  /** Set a field and notify its subscribers; a no-op if the value is unchanged. */
+  set(field: Field, value: unknown): void {
+    if (Object.is(this.values.get(field), value)) return;
+    this.values.set(field, value);
+    const subs = this.subscribers.get(field);
+    if (subs) for (const cb of [...subs]) cb(value);
+  }
+
+  /** Subscribe to a field; returns an unsubscribe function. */
+  subscribe(field: Field, cb: Subscriber): () => void {
+    let subs = this.subscribers.get(field);
+    if (!subs) this.subscribers.set(field, (subs = new Set()));
+    subs.add(cb);
+    return () => {
+      subs!.delete(cb);
+    };
+  }
+}

--- a/js/tests/runtime.html
+++ b/js/tests/runtime.html
@@ -11,9 +11,17 @@
         tag,
         init,
         registerHandler,
+        Store,
       } from "/dist/esm/index.js";
       await init({ module_or_path: "/dist/pkg/spaday_bg.wasm" }); // the action interpreter runs in wasm
-      window.__spaday = { mount, applyPatch, interpret, tag, registerHandler };
+      window.__spaday = {
+        mount,
+        applyPatch,
+        interpret,
+        tag,
+        registerHandler,
+        Store,
+      };
     </script>
   </head>
   <body></body>

--- a/js/tests/signals.spec.js
+++ b/js/tests/signals.spec.js
@@ -1,0 +1,96 @@
+import fs from "fs";
+import { test, expect } from "@playwright/test";
+import { diff } from "../src/ts/index";
+import { initSync } from "../dist/pkg/spaday";
+
+// The reactive engine: a `Store` of named fields backs the tree's `bindings` (prop ↔ field). One-way
+// bindings flow field → prop; two-way bindings also write the field when the control changes. `diff`
+// runs here in node to produce SetBinding ops; `mount`/`applyPatch` run in the browser page.
+
+test.beforeAll(() => {
+  initSync({ module: fs.readFileSync("./dist/pkg/spaday_bg.wasm") });
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/tests/runtime.html");
+  await page.waitForFunction(() => window.__spaday);
+});
+
+test("one-way binding flows a field to the bound prop, reactively", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ msg: "hi" });
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "span",
+        bindings: { textContent: { field: "msg", mode: "one-way" } },
+      },
+      store,
+    );
+    const initial = root.textContent; // field's initial value applied on mount
+    store.set("msg", "bye"); // a field change updates the bound prop
+    return { initial, after: root.textContent };
+  });
+  expect(result.initial).toBe("hi");
+  expect(result.after).toBe("bye");
+});
+
+test("two-way binding: a control writes its field, updating other props bound to it", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ on: false });
+    const checkbox = (key) => ({
+      tag: "input",
+      key,
+      props: { type: { Str: "checkbox" } },
+      bindings: { checked: { field: "on", mode: "two-way" } },
+    });
+    const root = mount(
+      document.createElement("div"),
+      { tag: "div", slots: { default: [checkbox("a"), checkbox("b")] } },
+      store,
+    );
+    const [a, b] = root.querySelectorAll("input");
+    const before = [a.checked, b.checked];
+    a.checked = true;
+    a.dispatchEvent(new Event("change")); // control → field
+    return { before, storeOn: store.get("on"), bChecked: b.checked };
+  });
+  expect(result.before).toEqual([false, false]);
+  expect(result.storeOn).toBe(true); // the control's change wrote the field
+  expect(result.bChecked).toBe(true); // ...which flowed to the other bound control
+});
+
+test("an incremental SetBinding patch wires a binding on a live element", async ({
+  page,
+}) => {
+  const oldTree = { tag: "span" };
+  const newTree = {
+    tag: "span",
+    bindings: { textContent: { field: "x", mode: "one-way" } },
+  };
+  const patch = JSON.parse(
+    diff(JSON.stringify(oldTree), JSON.stringify(newTree)),
+  );
+  expect(JSON.stringify(patch)).toContain("SetBinding"); // the core emits it
+
+  const result = await page.evaluate(
+    ({ oldTree, patch }) => {
+      const { mount, applyPatch, Store } = window.__spaday;
+      const store = new Store({ x: "a" });
+      const root = mount(document.createElement("div"), oldTree, store); // unbound
+      applyPatch(root, patch, store); // SetBinding wires it
+      const initial = root.textContent;
+      store.set("x", "b");
+      return { initial, after: root.textContent };
+    },
+    { oldTree, patch },
+  );
+  expect(result.initial).toBe("a"); // bound on apply, initial value applied
+  expect(result.after).toBe("b"); // and reactive thereafter
+});

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -23,7 +23,7 @@ use std::collections::BTreeSet;
 use serde::{Deserialize, Serialize};
 
 use crate::action::Action;
-use crate::node::{Attr, EventName, Key, Node, SlotName};
+use crate::node::{Attr, Binding, EventName, Key, Node, SlotName};
 
 /// One step down into a tree: the `index`-th child of slot `slot`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,6 +56,15 @@ pub enum Op {
     RemoveEvent {
         path: Path,
         name: EventName,
+    },
+    SetBinding {
+        path: Path,
+        name: Attr,
+        binding: Binding,
+    },
+    RemoveBinding {
+        path: Path,
+        name: Attr,
     },
     SetKey {
         path: Path,
@@ -92,6 +101,8 @@ impl Op {
             | Op::RemoveProp { path, .. }
             | Op::SetEvent { path, .. }
             | Op::RemoveEvent { path, .. }
+            | Op::SetBinding { path, .. }
+            | Op::RemoveBinding { path, .. }
             | Op::SetKey { path, .. }
             | Op::InsertChild { path, .. }
             | Op::RemoveChild { path, .. }
@@ -188,6 +199,25 @@ fn diff_node(path: &Path, old: &Node, new: &Node, ops: &mut Vec<Op>) {
     for name in old.events.keys() {
         if !new.events.contains_key(name) {
             ops.push(Op::RemoveEvent {
+                path: path.to_vec(),
+                name: name.clone(),
+            });
+        }
+    }
+
+    // Bindings.
+    for (name, nb) in &new.bindings {
+        if old.bindings.get(name) != Some(nb) {
+            ops.push(Op::SetBinding {
+                path: path.to_vec(),
+                name: name.clone(),
+                binding: nb.clone(),
+            });
+        }
+    }
+    for name in old.bindings.keys() {
+        if !new.bindings.contains_key(name) {
+            ops.push(Op::RemoveBinding {
                 path: path.to_vec(),
                 name: name.clone(),
             });
@@ -336,6 +366,12 @@ fn apply_op(root: &mut Node, op: &Op) {
         Op::RemoveEvent { name, .. } => {
             target.events.remove(name);
         }
+        Op::SetBinding { name, binding, .. } => {
+            target.bindings.insert(name.clone(), binding.clone());
+        }
+        Op::RemoveBinding { name, .. } => {
+            target.bindings.remove(name);
+        }
         Op::SetKey { key, .. } => {
             target.key = key.clone();
         }
@@ -430,6 +466,35 @@ mod diff_tests {
                 },
             );
         assert_round_trip(&old, &new);
+    }
+
+    #[test]
+    fn test_binding_changes() {
+        use crate::node::{BindMode, Binding};
+        let old = Node::new("wa-switch").bind(
+            "checked",
+            Binding {
+                field: "on".into(),
+                mode: BindMode::TwoWay,
+            },
+        );
+        let new = Node::new("wa-switch")
+            .bind(
+                "checked",
+                Binding {
+                    field: "lit".into(), // field changed
+                    mode: BindMode::TwoWay,
+                },
+            )
+            .bind(
+                "disabled",
+                Binding {
+                    field: "locked".into(), // added
+                    mode: BindMode::OneWay,
+                },
+            );
+        let patch = assert_round_trip(&old, &new);
+        assert_eq!(patch.len(), 2); // checked's binding changed + disabled added
     }
 
     #[test]

--- a/rust/src/node.rs
+++ b/rust/src/node.rs
@@ -18,9 +18,28 @@ pub type Key = String;
 pub type Attr = String;
 pub type SlotName = String;
 pub type EventName = String;
+pub type Field = String;
 
 /// The conventional name for a component's unnamed (default) slot.
 pub const DEFAULT_SLOT: &str = "default";
+
+/// How a reactive [`Binding`] flows: one-way (state field → prop) or two-way (also prop → field, for
+/// value-like controls whose change should write the field back).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum BindMode {
+    #[serde(rename = "one-way")]
+    OneWay,
+    #[serde(rename = "two-way")]
+    TwoWay,
+}
+
+/// A reactive binding of a prop to a state field. The runtime's signal store keeps the prop in sync
+/// with the field; two-way bindings also write the field when the bound control changes.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Binding {
+    pub field: Field,
+    pub mode: BindMode,
+}
 
 /// A node in the component tree.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -39,6 +58,9 @@ pub struct Node {
     /// Event handlers keyed by event name (`"click"`, `"wa-change"`, ...).
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub events: BTreeMap<EventName, Action>,
+    /// Reactive prop bindings: a prop name → the state field it tracks (see the runtime signal store).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub bindings: BTreeMap<Attr, Binding>,
 }
 
 impl Node {
@@ -50,6 +72,7 @@ impl Node {
             props: BTreeMap::new(),
             slots: BTreeMap::new(),
             events: BTreeMap::new(),
+            bindings: BTreeMap::new(),
         }
     }
 
@@ -68,6 +91,12 @@ impl Node {
     /// Builder: set an event handler.
     pub fn event(mut self, name: impl Into<EventName>, action: Action) -> Node {
         self.events.insert(name.into(), action);
+        self
+    }
+
+    /// Builder: bind a prop to a reactive state field.
+    pub fn bind(mut self, prop: impl Into<Attr>, binding: Binding) -> Node {
+        self.bindings.insert(prop.into(), binding);
         self
     }
 

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -58,6 +58,7 @@ class Component:
         self._props: Dict[str, Any] = {k: v for k, v in (props or {}).items() if v is not None}
         self._slots: Dict[str, List[Child]] = {}
         self._events: Dict[str, dict] = {}
+        self._bindings: Dict[str, dict] = {}
 
     def key(self, key: str) -> "Component":
         """Set the reconciliation key (for keyed child diffing)."""
@@ -97,6 +98,18 @@ class Component:
         self._events[event] = action.to_dict()
         return self
 
+    def bind(self, prop: str, field: str, *, mode: str = "one-way") -> "Component":
+        """Reactively bind a ``prop`` to a state ``field`` in the runtime's signal store.
+
+        ``mode="one-way"`` keeps the prop in sync with the field; ``"two-way"`` also writes the field
+        back when the control changes (for value-like controls). The binding is data interpreted in the
+        browser — the field's value flows to the prop with no round-trip to Python.
+        """
+        if mode not in ("one-way", "two-way"):
+            raise ValueError(f"bind mode must be 'one-way' or 'two-way', not {mode!r}")
+        self._bindings[prop] = {"field": field, "mode": mode}
+        return self
+
     def to_node(self) -> dict:
         """The node as the core's JSON-ready dict (empty fields omitted, like the Rust core)."""
         node: dict = {"tag": self.tag}
@@ -109,6 +122,8 @@ class Component:
         if self._events:
             # actions are the core's own DSL wire form (see spaday.actions) — plain, not a tagged Value
             node["events"] = dict(self._events)
+        if self._bindings:
+            node["bindings"] = dict(self._bindings)
         return node
 
     def to_json(self) -> str:

--- a/spaday/tests/test_bindings.py
+++ b/spaday/tests/test_bindings.py
@@ -1,0 +1,29 @@
+import json
+
+import pytest
+
+import spaday
+from spaday import element
+
+
+def test_bind_emits_one_way_by_default():
+    node = element("span").bind("textContent", "msg").to_node()
+    assert node["bindings"] == {"textContent": {"field": "msg", "mode": "one-way"}}
+
+
+def test_bind_two_way():
+    node = element("input").bind("checked", "on", mode="two-way").to_node()
+    assert node["bindings"]["checked"] == {"field": "on", "mode": "two-way"}
+
+
+def test_bind_rejects_unknown_mode():
+    with pytest.raises(ValueError):
+        element("span").bind("x", "y", mode="sideways")
+
+
+def test_bindings_diff_and_apply_round_trip_through_the_core():
+    old = element("span").to_json()
+    new = element("span").bind("textContent", "msg").to_json()
+    patch = spaday.diff(old, new)
+    assert "SetBinding" in patch  # the Rust core diffs bindings to a SetBinding op
+    assert json.loads(spaday.apply(old, patch)) == json.loads(new)


### PR DESCRIPTION
First half of the Phase 2 reactive engine. The component tree gains **reactive bindings** — a prop bound to a named state field — interpreted client-side by a small signal `Store`. This is what makes model↔UI binding *declarative* (today the dashboard hand-wires it), and the foundation the tadaima MVP needs.

## What

- **Rust core**: `Node.bindings` (prop → `{field, mode}`, one-/two-way). The diff engine emits `SetBinding`/`RemoveBinding`, so adding/changing/removing a binding patches a **live** element — mirrors the event handling. Rides PyO3 + wasm through the JSON bridge with no signature changes.
- **Runtime** (`signals.ts` + `runtime.ts`): a `Store` (fields + subscribers); `mount`/`applyPatch` take an optional store and wire each binding — field → prop reactively, and for **two-way**, the control's `change`/`input` writes the field back. Per-element/prop teardowns so incremental patches rewire/detach cleanly.
- **Python**: `Component.bind(prop, field, mode="one-way"|"two-way")`.

## Scope

This is the **client-side** engine. Backing the store with a transports session model and the anywidget `_state` — so UI state and app/server state mirror, and a tadaima demo — is **Phase 2.4** (next PR). Derived/computed signals are a later refinement; the one-way `bind` *helper* in `spaday.actions` (element→element event sugar) is unchanged and orthogonal.

## Verification

- `cargo test` 39 (incl. binding round-trip) · `pytest` 40 · `playwright` 37 — one-way, two-way (a control's change flows to other props bound to the same field), and incremental `SetBinding` on a live element.
- `ruff`/`ty`/`prettier`/`clippy` clean.

Independent of #56 (touches `node.rs`/`diff.rs`/`runtime.ts`, disjoint from #56's `widget.ts`/`bundle.mjs`).