### PR TITLE
Bind the reactive Store to transports — the spaday↔transports seam (Phase 2.4)

### DIFF
--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -37,6 +37,11 @@ export type { Binding, Node } from "./runtime";
 export { Store } from "./signals";
 export type { Field } from "./signals";
 
+// The transports seam: bidirectionally sync a Store with a transports-mirrored model. Imports nothing
+// from transports — it speaks to the Client through the ModelClient interface (spaday's view of the wire).
+export { connectStore } from "./store-sync";
+export type { ModelClient, ValueCodec, StoreLink } from "./store-sync";
+
 // Action DSL: declarative behavior, interpreted in the browser on DOM events (no Python round-trip).
 export { interpret } from "./actions";
 export type { ActionContext } from "./actions";

--- a/js/src/ts/store-sync.ts
+++ b/js/src/ts/store-sync.ts
@@ -1,0 +1,81 @@
+// The seam between spaday and transports — and the one place either layer meets the other.
+//
+// spaday owns the UI: a component tree, reactive `bindings`, and the signal `Store` they read/write
+// (see signals.ts). It knows nothing about the wire. transports owns the wire: it mirrors an
+// authoritative model and exposes a `Client` to read/edit it. It knows nothing about UI.
+//
+// `connectStore` marries them WITHOUT importing transports: it speaks to the client through the small
+// `ModelClient` interface below — spaday's entire view of "the wire" is these four methods — and
+// converts between the wire's tagged values and plain JS via an injected `ValueCodec` (transports'
+// `fromValue`/`toValue`). So the boundary is enforced in the types: bind a `Store` to a transports
+// model and inbound patches flow model → fields → bound props, while a two-way control's change becomes
+// a server-authoritative `edit`. Swap in any object satisfying `ModelClient` and spaday is none the wiser.
+
+import { Store } from "./signals";
+
+/** Spaday's whole view of a transports `Client`: receive a frame, find the model, read it, edit it. */
+export interface ModelClient {
+  recv(data: string | Uint8Array): void;
+  ids(): number[];
+  value(id: number): unknown; // the model as a tagged core Value
+  edit(id: number, value: unknown): string; // an encoded edit frame to send back
+}
+
+/** Convert between tagged core Values and plain JS fields (transports' `fromValue` / `toValue`). */
+export interface ValueCodec {
+  fromValue(value: unknown): Record<string, unknown> | null;
+  toValue(plain: unknown): unknown;
+}
+
+export interface StoreLink {
+  /** Feed an inbound wire frame; the mirrored model's fields flow into the store (and bound props). */
+  receive(data: string | Uint8Array): void;
+  /** Stop pushing store changes to the wire. */
+  dispose(): void;
+}
+
+/**
+ * Bidirectionally sync a `Store` with a transports-mirrored model. Top-level model fields map by name
+ * to store fields: inbound frames pull them into the store; a store field change (e.g. from a two-way
+ * control) is pushed back as a `client.edit`, sent via `send`. Edits are server-authoritative — the
+ * change takes effect when the server echoes it back through `receive`.
+ */
+export function connectStore(
+  store: Store,
+  client: ModelClient,
+  send: (frame: string) => void,
+  codec: ValueCodec,
+): StoreLink {
+  let id: number | undefined;
+  let inbound = false; // true while applying a received frame, so we don't echo it straight back out
+  const wired = new Set<string>();
+  const unsubs: Array<() => void> = [];
+
+  return {
+    receive(data) {
+      client.recv(data);
+      if (id === undefined) id = client.ids()[0];
+      if (id === undefined) return; // no model yet (snapshot not received)
+      const model = codec.fromValue(client.value(id));
+      if (!model) return;
+      inbound = true;
+      for (const [field, value] of Object.entries(model)) {
+        store.set(field, value); // model → store (→ any bound props)
+        if (!wired.has(field)) {
+          wired.add(field);
+          unsubs.push(
+            store.subscribe(field, (v) => {
+              if (inbound || id === undefined) return; // ignore echoes of an inbound update
+              const current = codec.fromValue(client.value(id)) ?? {};
+              send(client.edit(id, codec.toValue({ ...current, [field]: v })));
+            }),
+          );
+        }
+      }
+      inbound = false;
+    },
+    dispose() {
+      for (const unsub of unsubs) unsub();
+    },
+  };
+}

--- a/js/tests/runtime.html
+++ b/js/tests/runtime.html
@@ -12,6 +12,7 @@
         init,
         registerHandler,
         Store,
+        connectStore,
       } from "/dist/esm/index.js";
       await init({ module_or_path: "/dist/pkg/spaday_bg.wasm" }); // the action interpreter runs in wasm
       window.__spaday = {
@@ -21,6 +22,7 @@
         tag,
         registerHandler,
         Store,
+        connectStore,
       };
     </script>
   </head>

--- a/js/tests/store-sync.spec.js
+++ b/js/tests/store-sync.spec.js
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test";
+
+// The spaday ↔ transports seam (connectStore): bind a Store to a transports model through a fake Client
+// (recv/ids/value/edit) with an identity codec. This exercises spaday's adapter — the mapping of model
+// fields ↔ store fields ↔ bound props, and the echo guard — without transports itself, which is exactly
+// the point: the adapter's whole view of the wire is the ModelClient interface.
+
+// In-page: a transports-Client-shaped fake holding a plain model (recv merges an inbound frame, value
+// returns it, edit records the outbound frame), plus an identity codec since the fake stores plain JS.
+const FAKE = () => {
+  const client = {
+    model: {},
+    sent: [],
+    recv(d) {
+      Object.assign(this.model, JSON.parse(d));
+    },
+    ids() {
+      return Object.keys(this.model).length ? [1] : [];
+    },
+    value() {
+      return this.model;
+    },
+    edit(_id, v) {
+      const frame = JSON.stringify(v);
+      this.sent.push(frame);
+      return frame;
+    },
+  };
+  return { client, codec: { fromValue: (v) => v, toValue: (v) => v } };
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/tests/runtime.html");
+  await page.waitForFunction(() => window.__spaday);
+});
+
+test("inbound: a received model field flows to a bound prop", async ({
+  page,
+}) => {
+  const text = await page.evaluate((makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { mount, Store, connectStore } = window.__spaday;
+    const store = new Store();
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "span",
+        bindings: { textContent: { field: "label", mode: "one-way" } },
+      },
+      store,
+    );
+    const link = connectStore(store, client, () => {}, codec);
+    link.receive(JSON.stringify({ label: "hello" })); // server pushes the model
+    return root.textContent;
+  }, FAKE.toString());
+  expect(text).toBe("hello");
+});
+
+test("outbound: a two-way control change is sent as a server-authoritative edit", async ({
+  page,
+}) => {
+  const result = await page.evaluate((makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { mount, Store, connectStore } = window.__spaday;
+    const store = new Store();
+    const input = mount(
+      document.createElement("div"),
+      {
+        tag: "input",
+        props: { type: { Str: "checkbox" } },
+        bindings: { checked: { field: "on", mode: "two-way" } },
+      },
+      store,
+    );
+    const link = connectStore(store, client, (f) => client.sent.push(f), codec);
+    link.receive(JSON.stringify({ on: false })); // seed + wire
+    input.checked = true;
+    input.dispatchEvent(new Event("change")); // two-way: control → field → edit
+    return {
+      sent: client.sent.map((f) => JSON.parse(f)),
+      modelStillFalse: client.model.on,
+    };
+  }, FAKE.toString());
+  expect(result.sent).toContainEqual({ on: true }); // the control's change went out as an edit
+  expect(result.modelStillFalse).toBe(false); // edits are server-authoritative: model unchanged until echo
+});
+
+test("inbound updates a two-way control, and applying an inbound frame does not echo back out", async ({
+  page,
+}) => {
+  const result = await page.evaluate((makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { mount, Store, connectStore } = window.__spaday;
+    const store = new Store();
+    const input = mount(
+      document.createElement("div"),
+      {
+        tag: "input",
+        props: { type: { Str: "checkbox" } },
+        bindings: { checked: { field: "on", mode: "two-way" } },
+      },
+      store,
+    );
+    const out = [];
+    const link = connectStore(store, client, (f) => out.push(f), codec);
+    link.receive(JSON.stringify({ on: false }));
+    link.receive(JSON.stringify({ on: true })); // a server echo / push
+    return { checked: input.checked, echoes: out.length };
+  }, FAKE.toString());
+  expect(result.checked).toBe(true); // the inbound value reached the bound control
+  expect(result.echoes).toBe(0); // echo guard: inbound updates are not sent straight back out
+});

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -44,3 +44,19 @@ is independent per tab.
 - **Wholesale data patches**: a chart's series is one opaque prop, so each change resends `data`
   (correct, not minimal); per-point deltas need the series modeled as tree state — later.
 - **TradingView logo** is disabled in the chart wrapper; attribution is in the page footer.
+
+## `reactive.py` — declarative two-way binding over transports (Phase 2.4)
+
+A second, focused app showing the spaday ↔ transports boundary at its cleanest. A `Controls` model lives
+in a `transports.Session`; the page authors controls **bound** to its fields
+(`.bind("value", "label", mode="two-way")`) and wires the wire in one line:
+
+- **transports** owns the wire — a `Client` mirrors the model and sends edits; spaday never touches it.
+- **spaday** owns the UI — a signal `Store` backs the tree's bindings; it never touches the wire.
+- **`connectStore`** is the only seam — model fields ↔ store fields, edits server-authoritative.
+
+There are no control listeners and no `client.edit` calls in the page; the bindings do it. Open two tabs
+and they stay in sync. This is what the omnibus's hand-wired `SendPatch`→sink bridge becomes once the
+reactive engine carries it.
+
+Run: `python -m spaday.examples.reactive` → http://127.0.0.1:8001

--- a/spaday/examples/reactive.html
+++ b/spaday/examples/reactive.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>spaday × transports — reactive bindings</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 2rem;
+      }
+      label {
+        font-weight: 600;
+        margin-right: 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module">
+      // spaday owns the UI; transports owns the wire; connectStore is the only place they meet. Note
+      // there is NO control-change handler and NO client.edit() call below — the tree's two-way
+      // bindings + connectStore do it all.
+      import { mount, init, Store, connectStore } from "/js/dist/esm/index.js";
+      import {
+        Client,
+        fromValue,
+        toValue,
+        wasm,
+      } from "/js/node_modules/@1kbgz/transports/dist/cdn/index.js";
+
+      await init({ module_or_path: "/js/dist/pkg/spaday_bg.wasm" }); // spaday's wasm (action interpreter)
+      await wasm.default({
+        module_or_path:
+          "/js/node_modules/@1kbgz/transports/dist/pkg/transports_bg.wasm",
+      });
+
+      const node = await (await fetch("/tree.json")).json();
+
+      const store = new Store(); // spaday: reactive state backing the tree's bindings
+      const client = new Client(); // transports: mirror of the authoritative model
+      const ws = new WebSocket(`ws://${location.host}/ws`);
+      ws.binaryType = "arraybuffer";
+
+      // the seam: model fields ↔ store fields; a two-way control's change → a server-authoritative edit
+      const link = connectStore(store, client, (frame) => ws.send(frame), {
+        fromValue,
+        toValue,
+      });
+      ws.addEventListener("message", (event) =>
+        link.receive(
+          typeof event.data === "string"
+            ? event.data
+            : new Uint8Array(event.data),
+        ),
+      );
+
+      mount(document.body, node, store); // bindings read/write the store — no listeners authored here
+    </script>
+  </body>
+</html>

--- a/spaday/examples/reactive.py
+++ b/spaday/examples/reactive.py
@@ -1,0 +1,85 @@
+"""A reactive page over transports: spaday bindings ↔ a transports model, with no hand-wired glue.
+
+The functional split *is* the point of this example:
+
+- **transports owns the wire.** A `Controls` model lives in a `transports.Session`; the browser mirrors
+  it with a transports `Client` and sends edits. spaday never touches the wire.
+- **spaday owns the UI.** The tree's controls are *bound* to model fields (`.bind(..., mode="two-way")`)
+  and read/written through a signal `Store`. There are no `onChange` handlers and no `client.edit`
+  calls authored in the page.
+- **`connectStore` is the seam.** It marries the two without either knowing about the other: inbound
+  patches flow model → store → bound props, and a two-way control's change becomes a
+  server-authoritative edit. Open two tabs — they stay in sync through the server.
+
+Run: ``python -m spaday.examples.reactive`` then open http://127.0.0.1:8001/.
+"""
+
+import asyncio
+from pathlib import Path
+
+import transports
+import uvicorn
+from pydantic import BaseModel
+from starlette.applications import Starlette
+from starlette.responses import FileResponse, JSONResponse
+from starlette.routing import Mount, Route, WebSocketRoute
+from starlette.staticfiles import StaticFiles
+
+from spaday import element
+from spaday.components.shell import Main, Row, Stack
+
+HERE = Path(__file__).parent
+JS = HERE.parent.parent / "js"
+
+
+class Controls(BaseModel):
+    label: str = "hello"
+    on: bool = True
+
+
+session = transports.Session()
+controls = Controls()
+session.host(controls)
+server = transports.Server(session)
+
+
+def tree() -> dict:
+    """The UI: controls two-way-bound to model fields, plus a one-way echo — no event wiring."""
+    return (
+        Main()
+        .child(element("strong").text("Reactive controls over transports — bindings, no glue"))
+        .child(
+            Stack()
+            .child(Row().child(element("label").text("Label")).child(element("input").prop("type", "text").bind("value", "label", mode="two-way")))
+            .child(Row().child(element("label").text("On")).child(element("input").prop("type", "checkbox").bind("checked", "on", mode="two-way")))
+            .child(Row().child(element("span").text("Echo: ")).child(element("span").bind("textContent", "label")))
+        )
+        .to_node()
+    )
+
+
+async def homepage(_request):
+    return FileResponse(HERE / "reactive.html")
+
+
+async def tree_json(_request):
+    return JSONResponse(tree())
+
+
+async def startup():
+    asyncio.create_task(transports.autosync(server))
+
+
+app = Starlette(
+    routes=[
+        Route("/", homepage),
+        Route("/tree.json", tree_json),
+        WebSocketRoute("/ws", transports.ws_endpoint(server)),
+        Mount("/js", StaticFiles(directory=JS)),
+    ],
+    on_startup=[startup],
+)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8001)


### PR DESCRIPTION
Phase 2.4 (web). Backs the 2.3 signal `Store` (now on main, #57) with a transports model so model↔UI binding is fully declarative — retiring the dashboard's hand-wired glue.

## The boundary (the point of this PR)

`connectStore` is the **only** place spaday and transports meet, and it imports **nothing** from transports:

- **transports owns the wire** — a `Client` mirrors the authoritative model and sends edits.
- **spaday owns the UI** — a signal `Store` backs the tree's reactive `bindings`.
- the seam speaks to the client through a tiny `ModelClient` interface (`recv`/`ids`/`value`/`edit` — spaday's *whole* view of the wire) + an injected `ValueCodec`. The distinction is enforced in the **types**, not just by convention.

Inbound frames flow model → fields → bound props; a two-way control's change becomes a server-authoritative `edit`; an echo guard avoids bouncing inbound updates straight back out.

## Example — `spaday/examples/reactive.py`

A `Controls` model in a `transports.Session`; controls **two-way-bound** to its fields; `connectStore` as one line of glue. The page has **no control-change listeners and no `client.edit` calls** — the bindings do it. Open two tabs → they stay in sync.

## Verification

- Playwright `store-sync` spec against a fake `Client`: inbound→bound-prop, outbound two-way→edit, echo guard.
- The example **end-to-end against real transports** (real `Client` + WebSocket, two tabs): inbound seeds both controls (`label="hello"`, `on=true`); editing in tab 1 fans server-authoritatively to a fresh tab 2 (`label="world"`, `on=false`); no console errors.
- `prettier`/`ruff`/`ty` clean.

(Branch predates #56/#57 but touches disjoint files — the merge-base diff is exactly these 7 files.)

Next: the **notebook** half of 2.4 — a synced `_state` traitlet on `spaday.Widget` backing the same `Store` — then a tadaima demo.