### PR TITLE
Back the widget Store with a synced _state model (Phase 2.4 — notebook)

### DIFF
--- a/js/src/ts/widget.ts
+++ b/js/src/ts/widget.ts
@@ -1,15 +1,16 @@
 // spaday as an anywidget: render a spaday component tree inside any anywidget host — Jupyter
 // (Lab/Notebook/Colab/VS Code), Marimo, Shiny-for-Python, Solara, Panel — over the widget's model.
 //
-// The model carries only the serialized component tree (`_tree`); the wasm core (the action
-// interpreter) is inlined into this bundle, so nothing else syncs over the comm. The spaday runtime
+// The model carries the serialized component tree (`_tree`) and a reactive data model (`_state`) the
+// tree's bindings read/write; the wasm core (the action interpreter) is inlined into this bundle, so
+// the only things that sync over the comm are those two. The spaday runtime
 // mounts the tree and keeps it live by diffing successive trees with the same core `diff`/`applyPatch`
 // it uses over a transports wire — so a Python-side
 // `widget.update(tree)` produces a minimal DOM patch, not a re-render. Behavior authored in Python
 // (the action DSL) runs client-side here with no kernel round-trip; the DSL's outbound intents
 // (a `SendPatch` action's `spaday:patch`) are forwarded to the kernel over the model.
 
-import { applyPatch, diff, init, mount, Node } from "./index";
+import { applyPatch, diff, init, mount, Node, Store } from "./index";
 
 // the spaday wasm core, inlined into this bundle as bytes (esbuild `binary` loader; see build.mjs),
 // so the widget is one self-contained ESM with no separately-synced `_wasm`.
@@ -17,6 +18,8 @@ import wasm from "../../dist/pkg/spaday_bg.wasm";
 
 interface AnyModel {
   get(key: string): unknown;
+  set(key: string, value: unknown): void;
+  save_changes(): void;
   on(event: string, cb: () => void): void;
   off(event: string, cb: () => void): void;
   send(content: unknown): void;
@@ -36,6 +39,43 @@ function ensureWasm(): Promise<void> {
   return ready;
 }
 
+// Back the runtime's signal Store with the widget's synced `_state` dict — the notebook counterpart to
+// `connectStore` (transports). Inbound: a Python-side `_state` change flows into the store (and bound
+// props). Outbound: a two-way control's change writes `_state` back to the kernel. An echo guard keeps
+// an inbound update from bouncing straight back out.
+function connectState(store: Store, model: AnyModel): () => void {
+  let inbound = false;
+  const wired = new Set<string>();
+  const unsubs: Array<() => void> = [];
+  const pull = () => {
+    const state = (model.get("_state") ?? {}) as Record<string, unknown>;
+    inbound = true;
+    for (const [field, value] of Object.entries(state)) {
+      store.set(field, value);
+      if (!wired.has(field)) {
+        wired.add(field);
+        unsubs.push(
+          store.subscribe(field, (v) => {
+            if (inbound) return;
+            model.set("_state", {
+              ...((model.get("_state") ?? {}) as Record<string, unknown>),
+              [field]: v,
+            });
+            model.save_changes();
+          }),
+        );
+      }
+    }
+    inbound = false;
+  };
+  model.on("change:_state", pull);
+  pull(); // seed from the initial state
+  return () => {
+    model.off("change:_state", pull);
+    for (const unsub of unsubs) unsub();
+  };
+}
+
 // Intents the action DSL bubbles to the host element; forward each to the kernel over the model so a
 // Python handler (Widget.on_intent) can react.
 const INTENTS = ["spaday:patch"];
@@ -53,15 +93,20 @@ export default {
   }): Promise<() => void> {
     await ensureWasm();
 
+    // back the tree's reactive bindings with the widget's synced `_state`, seeded before mount so the
+    // bindings pick up their initial values.
+    const store = new Store();
+    const stateLink = connectState(store, model);
+
     let tree = model.get("_tree") as Node;
-    let root = mount(el, tree);
+    let root = mount(el, tree, store);
 
     const onTree = () => {
       const next = model.get("_tree") as Node;
       const patch = JSON.parse(
         diff(JSON.stringify(tree), JSON.stringify(next)),
       );
-      root = applyPatch(root, patch);
+      root = applyPatch(root, patch, store);
       tree = next;
     };
     model.on("change:_tree", onTree);
@@ -71,6 +116,7 @@ export default {
     for (const name of INTENTS) el.addEventListener(name, forward);
 
     return () => {
+      stateLink();
       model.off("change:_tree", onTree);
       for (const name of INTENTS) el.removeEventListener(name, forward);
       root.remove();

--- a/js/tests/widget-webawesome.html
+++ b/js/tests/widget-webawesome.html
@@ -19,6 +19,7 @@
             state[k] = v;
             (listeners["change:" + k] || []).forEach((f) => f());
           },
+          save_changes: () => {},
           on: (ev, cb) => (listeners[ev] = (listeners[ev] || []).concat(cb)),
           off: (ev, cb) =>
             (listeners[ev] = (listeners[ev] || []).filter((f) => f !== cb)),

--- a/js/tests/widget.html
+++ b/js/tests/widget.html
@@ -5,8 +5,8 @@
     <title>spaday anywidget test harness</title>
     <script type="module">
       // Load the built anywidget ESM exactly as an anywidget host would, and stand up a minimal fake
-      // model (the bits widget.js uses: get / set / on / off / send) so the render flow is testable
-      // without a real kernel. The wasm core is inlined in the bundle, so nothing is fetched.
+      // model (the bits widget.js uses: get / set / save_changes / on / off / send) so the render flow
+      // is testable without a real kernel. The wasm core is inlined in the bundle, so nothing is fetched.
       import widget from "/dist/cdn/widget.js";
 
       function fakeModel(state) {
@@ -19,6 +19,7 @@
             state[k] = v;
             (listeners["change:" + k] || []).forEach((f) => f());
           },
+          save_changes: () => {},
           on: (ev, cb) => (listeners[ev] = (listeners[ev] || []).concat(cb)),
           off: (ev, cb) =>
             (listeners[ev] = (listeners[ev] || []).filter((f) => f !== cb)),

--- a/js/tests/widget.spec.js
+++ b/js/tests/widget.spec.js
@@ -99,3 +99,34 @@ test("runs a client-side action and forwards a SendPatch intent to the model", a
     detail: { model: "demo", field: "ping", value: true },
   });
 });
+
+test("two-way binds a control to the widget _state (notebook reactive)", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async () => {
+    const { widget, fakeModel } = window.__widget;
+    const model = fakeModel({
+      _state: { on: false },
+      _tree: {
+        tag: "input",
+        props: { type: { Str: "checkbox" } },
+        bindings: { checked: { field: "on", mode: "two-way" } },
+      },
+    });
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    await widget.initialize();
+    await widget.render({ model, el });
+
+    const box = el.querySelector("input");
+    const seededUnchecked = box.checked; // inbound: _state.on=false → unchecked on mount
+    box.checked = true;
+    box.dispatchEvent(new Event("change")); // outbound: control → _state
+    const stateAfterToggle = model.get("_state");
+    model.set("_state", { on: false }); // inbound from "Python": _state → control
+    return { seededUnchecked, stateAfterToggle, recheckedFalse: box.checked };
+  });
+  expect(result.seededUnchecked).toBe(false); // initial _state flowed to the control
+  expect(result.stateAfterToggle).toEqual({ on: true }); // the control wrote _state back
+  expect(result.recheckedFalse).toBe(false); // a Python-side _state change updated the control
+});

--- a/spaday/examples/devices.py
+++ b/spaday/examples/devices.py
@@ -1,0 +1,48 @@
+"""Smart-home device panel in a notebook — switches two-way-bound to device state, no server.
+
+The reactive engine end-to-end inside the anywidget host: each device's switch is `.bind`-ed two-way to
+a field of the widget's `_state`, so flipping it in the browser updates Python — and a Python-side
+``widget.state = {...}`` updates the switches. The runtime's signal `Store` is backed by the synced
+`_state` model (the notebook counterpart to backing it from a transports session).
+
+In a Jupyter cell::
+
+    from spaday.examples.devices import demo
+    w = demo(); w                # a panel of device switches
+
+Flip a switch: the card updates *client-side* and `_state` syncs to Python, where `on_state` prints it.
+Drive it the other way from Python::
+
+    w.state = {**w.state, "Kitchen": True}   # the Kitchen switch turns on in the browser
+
+This is the tadaima scenario (device cards, client-side toggles, state synced to a backend) — here the
+backend is just the kernel.
+"""
+
+from spaday import Component, element
+from spaday.components.shell import Row, Stack
+from spaday.components.webawesome import WaCard, WaSwitch
+from spaday.widget import Widget
+
+DEVICES = {"Living room": True, "Kitchen": False, "Bedroom": False, "Garage": False}
+
+
+def panel(devices: dict) -> Component:
+    """A card per device; each switch is two-way-bound to its `_state` field by name."""
+    cards = Stack()
+    for name in devices:
+        cards = cards.child(
+            WaCard(appearance="outlined").child(
+                Row()
+                .child(element("strong").text(name))
+                .child(WaSwitch().prop("style", "margin-left:auto").bind("checked", name, mode="two-way"))
+            )
+        )
+    return cards
+
+
+def demo() -> Widget:
+    """A ready-to-display device panel; UI-driven state changes are printed via `on_state`."""
+    widget = Widget(panel(DEVICES), state=dict(DEVICES))
+    widget.on_state(lambda state: print("devices:", state))
+    return widget

--- a/spaday/examples/devices.py
+++ b/spaday/examples/devices.py
@@ -33,9 +33,7 @@ def panel(devices: dict) -> Component:
     for name in devices:
         cards = cards.child(
             WaCard(appearance="outlined").child(
-                Row()
-                .child(element("strong").text(name))
-                .child(WaSwitch().prop("style", "margin-left:auto").bind("checked", name, mode="two-way"))
+                Row().child(element("strong").text(name)).child(WaSwitch().prop("style", "margin-left:auto").bind("checked", name, mode="two-way"))
             )
         )
     return cards

--- a/spaday/tests/test_widget.py
+++ b/spaday/tests/test_widget.py
@@ -26,6 +26,22 @@ def test_update_reassigns_the_synced_tree():
     assert w._tree["tag"] == "section"
 
 
+def test_state_seeds_and_is_settable():
+    w = Widget(element("div"), state={"on": True})
+    assert w._state == {"on": True}
+    assert w.state == {"on": True}
+    w.state = {"on": False, "level": 3}
+    assert w._state == {"on": False, "level": 3}
+
+
+def test_on_state_fires_on_change():
+    w = Widget(element("div"), state={"on": True})
+    seen = []
+    w.on_state(seen.append)
+    w.state = {"on": False}
+    assert seen == [{"on": False}]
+
+
 def test_on_intent_receives_frontend_messages():
     w = Widget(element("button").on("click", Toggle(by_id("x"), "hidden")))
     seen = []

--- a/spaday/widget.py
+++ b/spaday/widget.py
@@ -17,7 +17,7 @@ transports-hosted domain model: use this `Widget` to render a spaday tree direct
 """
 
 from pathlib import Path
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List, Optional, Union
 
 import anywidget
 import traitlets
@@ -43,16 +43,34 @@ class Widget(anywidget.AnyWidget):
     _esm = _ESM
     _css = _CSS  # WebAwesome base + theme tokens, injected into the host page
     _tree = traitlets.Dict().tag(sync=True)
+    # the reactive data model the tree's bindings read/write; synced both ways over the comm, so a
+    # two-way-bound control updates Python here, and a Python-side change updates the bound props.
+    _state = traitlets.Dict().tag(sync=True)
 
-    def __init__(self, tree: Tree, **kwargs: Any) -> None:
+    def __init__(self, tree: Tree, state: Optional[dict] = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._tree = _to_node(tree)
+        self._state = dict(state or {})
         self._intent_handlers: List[Callable[[dict], None]] = []
         self.on_msg(self._on_msg)
 
     def update(self, tree: Tree) -> None:
         """Replace the rendered tree; the browser applies a minimal diff to the live DOM."""
         self._tree = _to_node(tree)
+
+    @property
+    def state(self) -> dict:
+        """The reactive data model backing the tree's bindings. Assign it to drive bound props from
+        Python; a two-way-bound control updates it from the browser. Use ``on_state`` to react."""
+        return self._state
+
+    @state.setter
+    def state(self, value: dict) -> None:
+        self._state = dict(value)
+
+    def on_state(self, handler: Callable[[dict], None]) -> None:
+        """Register a handler called with the new state dict whenever it changes (incl. from a control)."""
+        self.observe(lambda change: handler(change["new"]), names="_state")
 
     def on_intent(self, handler: Callable[[dict], None]) -> None:
         """Register a handler for frontend intents — a `SendPatch` action's ``{type, detail}``."""


### PR DESCRIPTION
The **notebook** half of Phase 2.4 — the symmetric counterpart to #58 (web/transports). The runtime's signal `Store` (2.3) is now backed by the Widget's synced `_state` dict, so a spaday tree's reactive `bindings` mirror Python state **both ways** inside Jupyter (and the rest of the anywidget ecosystem) with no server.

## What

- **`widget.ts`** — `connectState(store, model)` wires the `Store` ↔ `_state`: inbound (a Python-side `_state` change → store fields → bound props), outbound (a two-way control's change → `model.set("_state", …)` → the kernel), echo-guarded. `render` seeds the store before `mount`.
- **`widget.py`** — `_state` synced `Dict`; `Widget(tree, state=…)`; a `state` property (assign to drive bound props from Python); `on_state(cb)` to react to changes (incl. UI-driven).
- **example `spaday/examples/devices.py`** — device cards with switches **two-way-bound** to device state. Flip one in the browser → Python's `on_state` sees it; `w.state = {…}` in Python → the switches update. The tadaima scenario, in a notebook.

## The distinction (same as #58, different transport)

The Store is wire-agnostic; the *backing* is swappable. #58 backs it with a transports `Client` over a WebSocket; this PR backs it with the anywidget model's `_state` over the comm. Same bindings, same `Store`, different seam.

## Verification

- Playwright: a control two-way-bound to `_state` — inbound seeds it, a toggle writes `_state`, and a `model.set("_state", …)` updates the control. (42 pytest · 40 Playwright total.)
- Python: `state` seed/get/set and `on_state` firing on change.
- `ruff`/`ty`/`prettier` clean.

Independent of #58 (disjoint files). With both, the reactive engine (2.3) is backed in **both** contexts — the foundation tadaima needs is in place.