### PR TITLE
Build-time validation: resolve by_id action references (Phase 2.1)

### DIFF
--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -19,6 +19,7 @@ from .actions import (
 from .cem import classes, generate
 from .component import Component, element
 from .spaday import apply, diff, parse_cem  # compiled Rust extension (rust/python)
+from .validate import ValidationError, validate
 
 __version__ = "0.1.0"
 
@@ -33,6 +34,9 @@ __all__ = [
     "classes",
     "Component",
     "element",
+    # build-time validation
+    "validate",
+    "ValidationError",
     # action DSL (declarative behavior, run in the browser)
     "actions",
     "SetProp",

--- a/spaday/tests/test_validate.py
+++ b/spaday/tests/test_validate.py
@@ -17,11 +17,7 @@ from spaday import (
 
 
 def test_resolved_by_id_passes():
-    tree = (
-        element("div")
-        .child(element("button").on("click", Toggle(by_id("panel"), "hidden")))
-        .child(element("p").prop("id", "panel").text("hi"))
-    )
+    tree = element("div").child(element("button").on("click", Toggle(by_id("panel"), "hidden"))).child(element("p").prop("id", "panel").text("hi"))
     validate(tree)  # no raise
 
 

--- a/spaday/tests/test_validate.py
+++ b/spaday/tests/test_validate.py
@@ -1,0 +1,73 @@
+import pytest
+
+import spaday
+from spaday import (
+    Emit,
+    If,
+    Sequence,
+    SetProp,
+    Toggle,
+    ValidationError,
+    by_id,
+    element,
+    prop,
+    this,
+    validate,
+)
+
+
+def test_resolved_by_id_passes():
+    tree = (
+        element("div")
+        .child(element("button").on("click", Toggle(by_id("panel"), "hidden")))
+        .child(element("p").prop("id", "panel").text("hi"))
+    )
+    validate(tree)  # no raise
+
+
+def test_unresolved_by_id_raises_with_details():
+    tree = element("button").on("click", Toggle(by_id("missing"), "hidden"))
+    with pytest.raises(ValidationError) as exc:
+        validate(tree)
+    assert "'missing'" in str(exc.value)
+
+
+def test_this_target_needs_no_resolution():
+    validate(element("button").on("click", Toggle(this(), "hidden")))
+
+
+def test_refs_inside_sequence_if_and_expr_are_all_checked():
+    tree = element("button").on(
+        "click",
+        Sequence(
+            SetProp(by_id("a"), "hidden", False),
+            If(prop(by_id("b"), "checked"), Emit("x"), SetProp(by_id("c"), "hidden", True)),
+        ),
+    )
+    with pytest.raises(ValidationError) as exc:
+        validate(tree)
+    msg = str(exc.value)
+    assert "'a'" in msg and "'b'" in msg and "'c'" in msg  # nested action + expr refs all caught
+
+
+def test_only_unresolved_refs_are_reported():
+    tree = (
+        element("div")
+        .child(element("button").on("click", Sequence(Toggle(by_id("ok"), "hidden"), Toggle(by_id("bad"), "hidden"))))
+        .child(element("span").prop("id", "ok"))
+    )
+    with pytest.raises(ValidationError) as exc:
+        validate(tree)
+    unresolved = str(exc.value).split("known ids")[0]
+    assert "'bad'" in unresolved and "'ok'" not in unresolved
+
+
+def test_validate_accepts_a_serialized_node_dict():
+    node = element("button").on("click", Toggle(by_id("x"), "hidden")).to_node()
+    with pytest.raises(ValidationError):
+        validate(node)
+
+
+def test_exported_from_package():
+    assert spaday.validate is validate
+    assert issubclass(spaday.ValidationError, ValueError)

--- a/spaday/validate.py
+++ b/spaday/validate.py
@@ -1,0 +1,79 @@
+"""Build-time validation of a component tree: catch dangling action references before they ship.
+
+An action that targets ``by_id("panel")`` does nothing at runtime if no element in the tree has that
+id — a silent, easy-to-miss bug. :func:`validate` walks the tree and raises :class:`ValidationError`
+listing every ``by_id`` reference (in an action or a ``prop(...)`` expression, however deeply nested)
+that doesn't resolve to a node's id in the same tree.
+
+Reactive ``bind`` targets a state *field*, not a node, so it has nothing to resolve here; and prop
+*names* aren't checked (the typed component constructors already validate those, and the string escape
+hatches legitimately allow custom attributes).
+"""
+
+from typing import Any, Iterator, List, Set, Union
+
+from .component import Component
+
+
+class ValidationError(ValueError):
+    """Raised by :func:`validate` when a component tree has unresolved references."""
+
+
+def _collect_ids(node: dict, ids: Set[str]) -> None:
+    id_value = (node.get("props") or {}).get("id")
+    if isinstance(id_value, dict) and isinstance(id_value.get("Str"), str):
+        ids.add(id_value["Str"])
+    for children in (node.get("slots") or {}).values():
+        for child in children:
+            _collect_ids(child, ids)
+
+
+def _expr_refs(expr: Any) -> Iterator[str]:
+    if not isinstance(expr, dict):
+        return
+    target = expr.get("target")
+    if expr.get("expr") == "prop" and isinstance(target, dict) and target.get("ref") == "id":
+        yield target["id"]
+    if expr.get("expr") == "not":
+        yield from _expr_refs(expr.get("of"))
+
+
+def _action_refs(action: Any) -> Iterator[str]:
+    if not isinstance(action, dict):
+        return
+    target = action.get("target")
+    if isinstance(target, dict) and target.get("ref") == "id":
+        yield target["id"]
+    for key in ("value", "detail", "body", "cond"):
+        yield from _expr_refs(action.get(key))
+    for sub in action.get("actions") or []:
+        yield from _action_refs(sub)
+    for key in ("then", "else"):
+        if action.get(key) is not None:
+            yield from _action_refs(action[key])
+
+
+def _collect_refs(node: dict, refs: List[str]) -> None:
+    for action in (node.get("events") or {}).values():
+        refs.extend(_action_refs(action))
+    for children in (node.get("slots") or {}).values():
+        for child in children:
+            _collect_refs(child, refs)
+
+
+def validate(tree: Union[Component, dict]) -> None:
+    """Raise :class:`ValidationError` if any ``by_id(...)`` reference in the tree's actions is unresolved.
+
+    Pass a :class:`~spaday.component.Component` (or its serialized node dict). Returns ``None`` on success.
+    """
+    node = tree.to_node() if isinstance(tree, Component) else tree
+    ids: Set[str] = set()
+    _collect_ids(node, ids)
+    refs: List[str] = []
+    _collect_refs(node, refs)
+    missing = sorted({ref for ref in refs if ref not in ids})
+    if missing:
+        known = sorted(ids)
+        raise ValidationError(
+            "unresolved by_id reference(s): " + ", ".join(repr(m) for m in missing) + f" (known ids: {known})"
+        )

--- a/spaday/validate.py
+++ b/spaday/validate.py
@@ -74,6 +74,4 @@ def validate(tree: Union[Component, dict]) -> None:
     missing = sorted({ref for ref in refs if ref not in ids})
     if missing:
         known = sorted(ids)
-        raise ValidationError(
-            "unresolved by_id reference(s): " + ", ".join(repr(m) for m in missing) + f" (known ids: {known})"
-        )
+        raise ValidationError("unresolved by_id reference(s): " + ", ".join(repr(m) for m in missing) + f" (known ids: {known})")


### PR DESCRIPTION
First half of Phase 2.1. `spaday.validate(tree)` walks a component tree and raises `ValidationError` listing every `by_id(...)` reference — in an action or a `prop(...)` expression, however deeply nested (Sequence / If / etc.) — that doesn't resolve to a node's id in the same tree. This catches the most common, hardest-to-debug authoring bug: *an action targets a typo'd id and silently does nothing at runtime.*

## Scope decision

The roadmap's 2.1 is "a SetProp must target a real prop of a real component." I split that:

- **Target resolution — done here.** `by_id` refs must resolve to a real node. Unambiguous, zero false positives, no schema needed.
- **Prop-*name* validation — deliberately deferred.** It's fuzzy and low-value: the typed component constructors already validate props set the normal way (`WaButton(variant=…)` errors on a bogus kwarg), and the string escape hatches (`.prop()` / `.bind()` / `SetProp(target, "name", …)`) legitimately allow custom attributes (`style`, `data-*`, `hidden`, …), so strict CEM-attr checking would mostly produce false positives. Reconciling Python kwarg names ↔ wire prop names ↔ CEM attrs is a rabbit hole for little gain.

Reactive `bind` targets a state *field*, not a node, so it has nothing to resolve.

## Why it's an explicit call

A `by_id` ref resolves against the **whole tree** (a sibling, not the subtree), and `to_node` serializes subtrees recursively — so auto-validating in `to_node` would wrongly fail valid trees. Validation runs once on the root: `spaday.validate(tree)`.

## Verification

7 tests (resolved/unresolved, `this` ignored, refs nested in Sequence/If/prop-expr, only-unresolved-reported, dict input, export). Full suite **47 pytest**; `ruff`/`ty` clean.

Part of *finish Phase 2*; the other remaining item, derived/computed signals (2.3), is next.