### PR TITLE
Regenerate the docs following Diátaxis

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,50 @@
 [![License](https://img.shields.io/github/license/1kbgz/spaday)](https://github.com/1kbgz/spaday)
 [![PyPI](https://img.shields.io/pypi/v/spaday.svg)](https://pypi.python.org/pypi/spaday)
 
+Build reactive web-component UIs **configured in Python, executed in the browser**.
+
 ## Overview
 
-> [!NOTE]
-> This library was generated using [copier](https://copier.readthedocs.io/en/stable/) from the [Base Python Project Template repository](https://github.com/python-project-templates/base).
+You author a UI as a tree of typed Python components — [WebAwesome](https://webawesome.com) by default,
+or any library that ships a [Custom Elements Manifest](https://github.com/webcomponents/custom-elements-manifest).
+You attach behavior as **declarative data**: an action DSL (toggle a prop, send a model edit, call an
+endpoint) and reactive **bindings** (a control two-way-bound to a state field, or a prop computed from
+others). spaday's JavaScript runtime renders the tree to real web components and interprets that
+behavior **client-side** — so a toggle or a derived value updates with no round-trip to Python.
+
+That UI state is a [transports](https://github.com/1kbgz/transports) model, so it syncs over any
+connection (WebSocket, SSE, Jupyter comm) and any codec; the same tree drops into a web app or a Jupyter
+notebook unchanged.
+
+Like transports, spaday is a **Rust core with thin bindings**: the component tree, the diff engine, the
+CEM parser, the action interpreter, and the reactive engine live in Rust and compile to **PyO3** (Python
+authors the tree) and **wasm** (the browser runs it). One core, two bindings.
+
+```python
+from spaday import Widget
+from spaday.components.webawesome import WaCard, WaSwitch
+
+# a switch two-way-bound to a state field, rendered in a Jupyter cell
+ui = WaCard().child(WaSwitch().text("Lamp").bind("checked", "on", mode="two-way"))
+w = Widget(ui, state={"on": True})
+w  # flip the switch → w.state["on"] flips in Python; set w.state → the switch follows
+```
+
+## Install
+
+```bash
+pip install spaday            # core: author + serialize component trees
+pip install "spaday[widget]"  # + the Jupyter / anywidget host
+```
+
+## Documentation
+
+- **[Tutorial](docs/src/tutorial.md)** — build your first interactive UI, step by step (in a notebook).
+- **How-to guides** — [author a component tree](docs/src/components.md),
+  [add behavior and reactivity](docs/src/behavior.md),
+  [use it in a notebook](docs/src/notebook.md),
+  [sync to a server over transports](docs/src/transports.md),
+  [wrap an imperative JS library](docs/src/wrappers.md),
+  [generate typed classes from a manifest](docs/src/cem.md).
+- **[API reference](docs/src/api.md)** — the Python surface.
+- **[How spaday works](docs/src/concepts.md)** — the architecture and the reasoning behind it.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,27 +1,87 @@
-# API Reference
+# API reference
 
-## Component authoring
+The Python surface of spaday. The component classes themselves (`WaButton`, `Stack`, `LightweightChart`,
+…) are generated and not listed here — see [Author a component tree](components.md) and
+[Generate typed classes](cem.md).
+
+## Authoring
 
 ```{eval-rst}
 .. autoclass:: spaday.Component
    :members:
    :member-order: bysource
+
+.. autofunction:: spaday.element
+```
+
+## Action DSL
+
+Behavior attached to a component with `Component.on`; see [Add behavior and reactivity](behavior.md).
+
+### Actions
+
+```{eval-rst}
+.. autoclass:: spaday.SetProp
+.. autoclass:: spaday.Toggle
+.. autoclass:: spaday.Sequence
+.. autoclass:: spaday.Emit
+.. autoclass:: spaday.SendPatch
+.. autoclass:: spaday.If
+.. autoclass:: spaday.CallEndpoint
+.. autoclass:: spaday.NamedJs
+```
+
+### Expressions and references
+
+```{eval-rst}
+.. autofunction:: spaday.lit
+.. autofunction:: spaday.event_value
+.. autofunction:: spaday.not_
+.. autofunction:: spaday.prop
+.. autofunction:: spaday.field
+.. autofunction:: spaday.eq
+.. autofunction:: spaday.all_
+.. autofunction:: spaday.any_
+.. autofunction:: spaday.this
+.. autofunction:: spaday.by_id
+```
+
+### Binding helper
+
+`spaday.bind` is a one-way event-driven convenience (control change → set a target prop). For reactive
+state bindings prefer `Component.bind` / `Component.compute` (above).
+
+```{eval-rst}
+.. autofunction:: spaday.bind
+```
+
+## Validation
+
+```{eval-rst}
+.. autofunction:: spaday.validate
+.. autoexception:: spaday.ValidationError
 ```
 
 ## CEM binding generator
 
 ```{eval-rst}
 .. autofunction:: spaday.parse_cem
-
 .. autofunction:: spaday.generate
+.. autofunction:: spaday.classes
+```
+
+## Notebook host
+
+```{eval-rst}
+.. autoclass:: spaday.Widget
+   :members: update, state, on_state, on_intent
 ```
 
 ## Core diff / apply
 
-The low-level component-tree engine (JSON wire form), shared byte-for-byte with the browser.
+The low-level component-tree engine (JSON wire form), shared byte-for-byte with the browser runtime.
 
 ```{eval-rst}
 .. autofunction:: spaday.diff
-
 .. autofunction:: spaday.apply
 ```

--- a/docs/src/behavior.md
+++ b/docs/src/behavior.md
@@ -1,0 +1,118 @@
+# Add behavior and reactivity
+
+This guide shows you how to make a tree interactive: running actions on events, binding controls to
+state, and computing props from state. All of it is authored in Python as **data** and runs in the
+browser — no per-interaction round-trip. For the underlying idea, see [How spaday works](concepts.md).
+
+## Run an action when an event fires
+
+Attach a declarative action to a DOM event with `.on(event, action)`:
+
+```python
+from spaday import by_id, Toggle
+from spaday.components.webawesome import WaButton
+
+WaButton().text("Details").on("click", Toggle(by_id("info"), "hidden"))
+```
+
+`Toggle(target, prop)` flips a boolean prop. Target an element with `by_id("info")` (an element whose
+`id` is `info`) or `this()` (the element the event fired on). The other actions:
+
+- `SetProp(target, prop, value)` — set a prop to a value or expression.
+- `Sequence(a, b, …)` — run several actions in order.
+- `If(cond, then, els=None)` — branch on a live condition.
+- `Emit(event, detail=None)` — dispatch a custom DOM event.
+- `SendPatch`, `CallEndpoint`, `NamedJs` — see below.
+
+## Reference live values in an action
+
+Action values are **expressions** evaluated when the event fires:
+
+```python
+from spaday import by_id, event_value, not_, SetProp
+from spaday.components.webawesome import WaSwitch
+
+# set the panel's `hidden` to the *negation* of the switch's new value
+WaSwitch().on("change", SetProp(by_id("panel"), "hidden", not_(event_value())))
+```
+
+- `event_value()` — the triggering control's value (its `checked`, else `value`, else the event detail).
+- `prop(target, name)` — read a prop off a live element (handy as an `If` condition).
+- `lit(value)` — a literal; a plain Python value is coerced to one automatically.
+
+## Bind a control to state
+
+For state that outlives a single event, use the reactive **signal store**. Bind a prop to a named state
+field with `.bind(prop, field, mode=...)`:
+
+```python
+from spaday.components.webawesome import WaSwitch
+
+WaSwitch().bind("checked", "lamp", mode="two-way")
+```
+
+- `mode="one-way"` (default) keeps the prop in sync with the field.
+- `mode="two-way"` also writes the field back when the control changes.
+
+Two controls bound to the same field stay in sync; a field changed anywhere updates every prop bound to
+it. **Where the field lives** depends on the host: in a notebook it is the widget's state
+([notebook guide](notebook.md)); on a server it is a transports model
+([transports guide](transports.md)).
+
+## Compute a prop from state
+
+To *derive* a prop rather than mirror a single field, use `.compute(prop, expr)` with a field
+expression. It recomputes whenever any field it reads changes (one-way by nature):
+
+```python
+from spaday import all_, eq, field, not_
+from spaday.components.webawesome import WaButton, WaCallout
+
+# disabled = not(enabled)
+WaButton().compute("disabled", not_(field("enabled")))
+
+# hidden unless mode == "advanced"
+WaCallout().compute("hidden", not_(eq(field("mode"), "advanced")))
+
+# ready = a and b
+WaButton().compute("disabled", not_(all_(field("a"), field("b"))))
+```
+
+The field-expression helpers: `field(name)`, `lit(value)`, `not_(e)`, `eq(a, b)`, `all_(*es)` (AND),
+`any_(*es)` (OR). They compose.
+
+## Send a model edit or call an endpoint
+
+Two actions intentionally reach beyond the browser:
+
+```python
+from spaday import CallEndpoint, SendPatch, event_value
+from spaday.components.webawesome import WaButton, WaSelect
+
+# mutate a transports model field — the app routes the edit to the wire (server-authoritative)
+WaSelect().on("change", SendPatch("chart", "type", event_value()))
+
+# the one explicit server round-trip: a REST call
+WaButton().text("Save").on("click", CallEndpoint("POST", "/save", body=event_value()))
+```
+
+`SendPatch` is usually unnecessary once you use a two-way binding (above) — the binding carries the
+control→model edit declaratively. Reach for `SendPatch` for an imperative edit that
+isn't a simple control value.
+
+## The escape hatch
+
+For the rare irreducible case, `NamedJs("handler")` invokes a JavaScript handler you pre-registered in
+the browser with `registerHandler("handler", fn)`. It calls by name — never `eval` — so the safety
+property holds.
+
+## Validate references before shipping
+
+A `by_id("typo")` that points at no element does nothing at runtime, silently. Catch it at authoring
+time:
+
+```python
+import spaday
+
+spaday.validate(tree)   # raises ValidationError listing any unresolved by_id reference
+```

--- a/docs/src/cem.md
+++ b/docs/src/cem.md
@@ -1,0 +1,44 @@
+# Generate typed classes from a manifest
+
+spaday's typed component classes are generated from a [Custom Elements Manifest](https://github.com/webcomponents/custom-elements-manifest)
+(`custom-elements.json`) — the standard description web-component libraries publish. This guide shows
+you how to generate classes for any such library. (For a library that is *not* a web component, see
+[Wrap an imperative library](wrappers.md).)
+
+## Generate a committed module
+
+For typed classes you check into your project, use the `spaday-cem` CLI or `spaday.generate`:
+
+```bash
+spaday-cem path/to/custom-elements.json -o my_components.py
+```
+
+```python
+import spaday
+
+code = spaday.generate("custom-elements.json")   # returns the module source (typed classes)
+```
+
+This is how the built-in WebAwesome catalog is produced. A test checks the committed
+`spaday/components/webawesome.py` against its source manifest so it can't silently drift; regenerate it
+with `spaday-cem <manifest> -o spaday/components/webawesome.py` followed by `ruff format`.
+
+## Build classes at runtime
+
+For a one-off or experimental manifest, `spaday.classes` builds the classes in memory instead — no file,
+no static types, but it still validates keyword names:
+
+```python
+import spaday
+
+ns = spaday.classes("custom-elements.json")                    # {"WaSwitch": <class>, ...}
+WaSwitch = spaday.classes("custom-elements.json", "WaSwitch")  # or one class by name
+WaSwitch(checked=True).to_node()
+```
+
+## One manifest, both bindings
+
+The parse that produces the Python classes ({py:func}`spaday.parse_cem`, in the Rust core) also drives
+the JavaScript runtime's registry — how each prop is set, which events to bind, the slot names. So a
+single manifest yields both the typed Python authoring API and the browser binding, with no chance of
+the two disagreeing.

--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -1,80 +1,99 @@
-# Components
+# Author a component tree
 
-spaday binds **web components** into a tree you author in typed Python. A UI is a tree of
-{py:class}`~spaday.component.Component` nodes — each a tag, props, and child slots — that serializes
-to the wire form the core's `diff`/`apply` engine understands.
+This guide shows you how to build a spaday UI from typed components: setting props, nesting children,
+laying out with shell components, and serializing the result. To attach behavior, see
+[Add behavior and reactivity](behavior.md).
 
-## Authoring a tree
+## Use a built-in component
 
-Component classes are generated from a web-component library's manifest (see below). WebAwesome ships
-built-in:
-
-```python
-from spaday.components.webawesome import WaCard, WaSwitch, WaButton
-
-card = (
-    WaCard(appearance="filled")
-    .child_in("header", WaButton(variant="brand"))
-    .child(WaSwitch(checked=True, size="large").key("lamp"))
-)
-
-card.to_json()   # the wire form for spaday.diff / spaday.apply
-```
-
-Each attribute is a typed keyword argument (`checked: Optional[bool]`, `size:
-Optional[Literal["small", "medium", "large"]]`, ...). A prop you don't set is omitted, so the element
-keeps its own default and patches stay minimal. Compose children with `child` / `child_in`, and set a
-reconciliation key with `key`.
-
-```{note}
-This is the binding layer — structure and props. Wiring *behavior* to events (the declarative action
-DSL) is a later phase; generated classes expose props and slots today.
-```
-
-## Binding any library — the CEM generator
-
-The typed classes are generated from a [Custom Elements Manifest] (`custom-elements.json`), the
-standard description web-component libraries publish. {py:func}`spaday.parse_cem` (in the Rust core)
-normalizes a manifest into component schemas; {py:func}`spaday.generate` renders them into a Python
-module. Point it at any library:
-
-```bash
-spaday-cem path/to/custom-elements.json -o my_components.py
-```
+WebAwesome components are generated as typed classes. Import one and set its attributes as keyword
+arguments:
 
 ```python
-import spaday
+from spaday.components.webawesome import WaButton
 
-code = spaday.generate("custom-elements.json")   # returns the module source (typed classes)
+WaButton(variant="brand", size="large")
 ```
 
-`generate` is the right choice when you want **typed, committed** classes (the WebAwesome catalog is
-produced this way). For a one-off or experimental manifest, {py:func}`spaday.classes` builds the
-component classes **at runtime** instead — no file, no static types, but it still validates keyword
-names:
+Every attribute is a typed keyword (`variant: Optional[Literal["brand", "neutral", ...]]`,
+`disabled: Optional[bool]`, …), so a typo or a wrong type is an error at authoring time. A prop you
+**don't** pass is omitted, so the element keeps its own default and update patches stay minimal.
+
+To use a component library other than WebAwesome, [generate its classes from a manifest](cem.md).
+
+## Nest children into slots
+
+Compose a tree with `.child(...)` for the default slot and `.child_in("slot", ...)` for a named one:
 
 ```python
-ns = spaday.classes("custom-elements.json")          # {"WaSwitch": <class>, ...}
-WaSwitch = spaday.classes("custom-elements.json", "WaSwitch")   # or just one class by name
-WaSwitch(checked=True).to_json()
+from spaday.components.webawesome import WaCard, WaButton, WaSwitch
+
+WaCard().child_in("header", WaButton(variant="brand")).child(WaSwitch())
 ```
 
-The same parse drives the JavaScript runtime registry (`registry(manifest)` in `spaday`'s JS
-package), so one manifest yields both the typed Python authoring API and the browser binding — the
-"one core, two bindings" model the diff engine already uses.
+`.child` returns the parent, so calls chain. Children are other components (or a raw element — below).
 
-The committed `spaday/components/webawesome.py` is checked against its source manifest by a test, so
-it can't silently drift from the generator; regenerate it with `python -m spaday.cem <manifest> -o
-spaday/components/webawesome.py` followed by `ruff format`.
+## Set text
 
-## Rendering in the browser
+`.text(...)` sets a leaf's text content — use it for labels, not alongside child nodes:
 
-A tree's JSON and the patches `spaday.diff` produces are consumed by spaday's **browser runtime** (the
-JS package): `mount(container, tree)` instantiates the web components into the DOM, and
-`applyPatch(root, patch)` applies an update **incrementally** — live element instances are preserved
-(a keyed reorder moves the same nodes rather than rebuilding them). So a UI authored and mutated in
-Python streams to the browser as minimal patches and renders without full re-draws. Wiring component
-*events* back to behavior is the declarative action DSL (a later phase); the runtime renders structure
-and props today.
+```python
+WaButton(variant="brand").text("Save")
+```
 
-[Custom Elements Manifest]: https://github.com/webcomponents/custom-elements-manifest
+## Lay out with shell components
+
+spaday does not expose `div`. Compose layout from the `spa-*` shell components, which carry their own
+encapsulated layout:
+
+```python
+from spaday.components.shell import App, Nav, Body, Gutter, Main, Footer, Stack, Row, Toolbar
+
+App().child(Nav().child(...)).child(Body().child(Gutter().child(...)).child(Main().child(...)))
+```
+
+`Stack` stacks children vertically, `Row` lays them horizontally, `Toolbar` is a control strip; `App` /
+`Nav` / `Body` / `Gutter` / `Main` / `Footer` are the page shell.
+
+## Reach for a raw element
+
+For text or a structural tag a typed class doesn't cover, use `element`:
+
+```python
+from spaday import element
+
+element("strong").text("Settings")
+element("a", href="https://example.com").text("docs")
+```
+
+A trailing underscore on a prop name is stripped, so reserved words work: `element("label", for_="x")`.
+
+## Set a prop a typed class doesn't expose
+
+`.prop(name, value)` is the escape hatch for an attribute the generated class doesn't have (a custom
+attribute, `style`, `id`, …):
+
+```python
+WaButton().prop("id", "save").prop("style", "margin-left:auto")
+```
+
+## Key for stable updates
+
+Give a node a stable `key` so the diff engine reconciles it by identity across updates (so a reordered
+list moves live elements instead of rebuilding them):
+
+```python
+WaSwitch().key("lamp")
+```
+
+## Serialize
+
+`.to_node()` returns the JSON-ready node dict; `.to_json()` returns its string form. This is the wire
+form the core's `diff` / `apply` understand and the runtime mounts:
+
+```python
+WaCard().child(WaSwitch()).to_node()
+```
+
+In a notebook you rarely call these directly — [`Widget`](notebook.md) does it for you; over a server
+they are served as the tree the browser mounts.

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -1,0 +1,98 @@
+# How spaday works
+
+This page explains the ideas behind spaday and why it is built the way it is. It is background reading,
+not a set of instructions — for those, see the [how-to guides](components.md).
+
+## The core idea: configure in Python, execute in JavaScript
+
+A spaday UI is a **tree of components** you build in Python, plus **behavior expressed as data**. Python
+never renders anything and is never in the loop for an interaction. Instead, the tree and its behavior
+are serialized and handed to spaday's JavaScript runtime, which instantiates real web components and
+interprets the behavior **in the browser**.
+
+This split is the whole point. The server holds lightweight per-session state; the UI and its logic are
+client-resident; Python is touched only when an interaction genuinely needs it (saving to a database,
+calling a REST API). That is what makes spaday suitable for **massively multi-tenant** apps — social
+feeds, dashboards, device walls — where a per-interaction round-trip to the server would never scale.
+
+## The component tree is a serializable model
+
+Each node is a tag (`wa-switch`, or a shell tag like `spa-stack`), some props, named child slots, event
+handlers, and reactive bindings. The tree is plain data, so two trees can be **diffed** into a minimal
+patch, and a patch can be **applied** to a live DOM incrementally — a keyed reorder moves the same
+elements rather than rebuilding them, so a `wa-switch`'s internal state survives an update. Authoring in
+Python and mutating over time both reduce to producing patches the runtime applies.
+
+The typed Python classes are **generated** from a [Custom Elements Manifest](https://github.com/webcomponents/custom-elements-manifest)
+— the standard description web-component libraries publish. WebAwesome is the default catalog, but the
+same generator turns *any* manifest into typed classes, and the same parse drives the browser runtime's
+registry. spaday is not tied to WebAwesome; it is a binding layer for CEM-described components.
+
+spaday deliberately operates at a **higher altitude** than an HTML builder: it does not expose `div`/`p`.
+You compose from curated shell pieces (App, Nav, gutters, Main, Stack, Row) and high-level components,
+with raw HTML elements available only as an escape hatch for text. This is what separates "a Python
+wrapper over WebAwesome" from a UI framework.
+
+## Behavior is data, not code
+
+An `onClick` in spaday is not a transpiled Python function and not arbitrary JavaScript — it is a
+**declarative action**: `Toggle(this, "open")`, `SetProp(by_id("panel"), "hidden", true)`,
+`SendPatch(model, field, value)`, `CallEndpoint("POST", url, body)`. Actions compose (`Sequence`, `If`)
+and reference values through small **expressions** (`event_value`, `prop`, `lit`, `field`, …).
+
+Because behavior is serializable data interpreted by a fixed dispatcher — never `eval`, never codegen —
+it is **safe to ship to untrusted, multi-tenant clients**, fully diffable, and identical whether it
+originated in Python or rode over the wire. The one escape hatch, `NamedJs`, invokes a *pre-registered*
+handler by name; it still never evaluates arbitrary strings.
+
+## The reactive engine
+
+Beyond one-shot actions, spaday has a small **signal store**: named state fields with subscribers.
+Component props *bind* to it:
+
+- a **field binding** keeps a prop in sync with a state field; two-way, it also writes the field back
+  when the control changes (a switch ↔ `lamp`);
+- a **computed binding** derives a prop from a *field-expression* (`not_(field("enabled"))`,
+  `eq(field("mode"), "advanced")`) and recomputes it whenever any field it reads changes.
+
+The engine runs in the browser, so a derived value or a two-way control updates immediately, with no
+round-trip. The store is the seam where UI state meets app state — see below.
+
+## One core, two bindings
+
+The component-tree model, the diff engine, the CEM parser, the action interpreter, and the reactive
+engine all live in a single **Rust core**. It compiles to two thin bindings:
+
+- **PyO3** — Python builds and validates the tree, and serializes it;
+- **wasm** — the browser reconstructs the tree, renders it, and interprets actions.
+
+Python and JavaScript therefore share *one* implementation of the diff, the wire format, and the action
+semantics — they can't drift. The Python side adds only ergonomic typed component classes; the JavaScript
+side adds only thin DOM glue. This mirrors the decision in [transports](https://github.com/1kbgz/transports),
+which spaday is built on.
+
+## The wire: transports
+
+spaday does not invent its own networking. UI state is a **transports model**, so it inherits
+transports' connection- and codec-agnostic sync: the same state moves over a WebSocket, SSE, or a Jupyter
+comm, in JSON or MessagePack, with multi-tenant sessions, without spaday reimplementing any of it.
+
+The boundary is strict and enforced in the types: spaday owns the UI (the tree, bindings, the signal
+store) and knows nothing about the wire; transports owns the wire (a `Client` that mirrors a model and
+sends edits) and knows nothing about UI. A single small adapter marries them — it sees transports only
+through a four-method interface. So you can back the same reactive store with a transports session on a
+webserver, or with the synced state of a Jupyter widget, and the UI code is identical.
+
+## Two hosts, one UI
+
+Because spaday is *a web-component runtime driven by a serialized model over a connection*, it slots into
+two places with the same tree:
+
+- a **web app** — your tree served over a WebSocket, state in a transports `Session` (or a multi-tenant
+  `Hub`); see [the transports guide](transports.md);
+- a **Jupyter notebook** (and the wider anywidget ecosystem — Marimo, Shiny, Solara, Panel) — the tree
+  packaged as an [anywidget](https://anywidget.dev), state synced over the widget's comm; see
+  [the notebook guide](notebook.md).
+
+The notebook host is the same engine with a different wire — which is exactly why the [tutorial](tutorial.md)
+can teach the whole model with no server at all.

--- a/docs/src/notebook.md
+++ b/docs/src/notebook.md
@@ -1,0 +1,83 @@
+# Use spaday in a Jupyter notebook
+
+This guide shows you how to render a spaday UI in a notebook and round-trip its state with Python — no
+server. It works in Jupyter (Lab / Notebook / Colab / VS Code) and the wider
+[anywidget](https://anywidget.dev) ecosystem (Marimo, Shiny-for-Python, Solara, Panel).
+
+Install the host:
+
+```bash
+pip install "spaday[widget]"
+```
+
+## Render a tree
+
+Wrap any component tree in `Widget` and return it from a cell:
+
+```python
+from spaday import Widget
+from spaday.components.webawesome import WaCard, WaSwitch
+
+Widget(WaCard().child(WaSwitch().text("Lamp")))
+```
+
+The full WebAwesome catalog and the spaday runtime are bundled into the widget, so `wa-*` components
+render with nothing else to load.
+
+## Update the rendered tree
+
+Keep a reference and call `update` to replace the tree; the browser applies a minimal diff (live
+elements are preserved, not rebuilt):
+
+```python
+w = Widget(WaCard().child(WaSwitch().text("Lamp")))
+w  # display it
+
+w.update(WaCard().child(WaSwitch().text("Lamp")).child(WaSwitch().text("Fan")))
+```
+
+## Back reactive bindings with state
+
+Pass a `state` dict to drive the tree's [reactive bindings](behavior.md). A two-way-bound control
+updates the state from the browser, and assigning `w.state` updates the control:
+
+```python
+from spaday import Widget
+from spaday.components.webawesome import WaSwitch
+
+w = Widget(WaSwitch().text("Lamp").bind("checked", "lamp", mode="two-way"), state={"lamp": True})
+w
+```
+
+```python
+w.state                 # -> {'lamp': True}; flip the switch, then re-read -> {'lamp': False}
+w.state = {"lamp": True}  # turns the switch back on
+```
+
+React to changes (including browser-driven ones) with `on_state`:
+
+```python
+w.on_state(lambda state: print("state:", state))
+```
+
+## Handle a SendPatch intent
+
+A [`SendPatch`](behavior.md) action surfaces an *intent* the host forwards to Python. Register a handler
+with `on_intent`:
+
+```python
+w.on_intent(lambda content: print("intent:", content))   # content is {"type": "spaday:patch", "detail": {...}}
+```
+
+For most cases prefer a two-way binding over `SendPatch` + `on_intent` — the binding already carries the
+control→state edit.
+
+## Embed in Panel
+
+Because the widget is an anywidget, Panel renders it directly:
+
+```python
+import panel as pn
+pn.extension()
+pn.panel(Widget(WaSwitch().text("Lamp")))
+```

--- a/docs/src/transports.md
+++ b/docs/src/transports.md
@@ -1,0 +1,102 @@
+# Sync a UI to a server over transports
+
+This guide shows you how to serve a spaday UI from a webserver and keep it in sync with a server-side
+state model using [transports](https://github.com/1kbgz/transports) — so a two-way control's change is
+applied on the server and fanned to every connected browser. This is the multi-tenant, no-notebook path;
+for the zero-setup version see the [notebook guide](notebook.md).
+
+The split to keep in mind: **spaday** owns the UI (the tree and its reactive `Store`); **transports**
+owns the wire (a `Client` that mirrors a model and sends edits); a single adapter, `connectStore`, is
+the only place they meet.
+
+Install both:
+
+```bash
+pip install spaday transports uvicorn
+cd js && pnpm install && pnpm build   # builds the runtime + bundles served to the browser
+```
+
+## Host a model and author the UI (Python)
+
+Host a model in a transports `Session`, author a tree whose controls are **two-way bound** to its
+fields, and serve the page, the tree, and a WebSocket:
+
+```python
+import asyncio
+
+import transports
+from pydantic import BaseModel
+from spaday import element
+from spaday.components.webawesome import WaInput, WaSwitch
+from starlette.applications import Starlette
+from starlette.responses import FileResponse, JSONResponse
+from starlette.routing import Route, WebSocketRoute
+
+class Controls(BaseModel):
+    label: str = "hello"
+    on: bool = True
+
+session = transports.Session()
+session.host(Controls())
+server = transports.Server(session)
+
+def tree() -> dict:
+    return (
+        element("div")
+        .child(WaInput().bind("value", "label", mode="two-way"))
+        .child(WaSwitch().bind("checked", "on", mode="two-way"))
+        .to_node()
+    )
+
+async def startup():
+    asyncio.create_task(transports.autosync(server))  # broadcast host-side changes to all clients
+
+app = Starlette(
+    routes=[
+        Route("/", lambda r: FileResponse("index.html")),
+        Route("/tree.json", lambda r: JSONResponse(tree())),
+        WebSocketRoute("/ws", transports.ws_endpoint(server)),
+    ],
+    on_startup=[startup],
+)
+```
+
+There are **no event handlers** in the tree — the two-way bindings carry every control→model edit.
+
+## Wire the store to the client (browser)
+
+In the page, create a spaday `Store`, a transports `Client`, and link them with `connectStore`. Then
+mount the tree with that store:
+
+```ts
+import { mount, init, Store, connectStore } from "spaday";
+import { Client, fromValue, toValue, wasm } from "@1kbgz/transports";
+
+await init();                 // spaday wasm (action interpreter)
+await wasm.default();         // transports wasm
+
+const store = new Store();
+const client = new Client();
+const ws = new WebSocket(`ws://${location.host}/ws`);
+ws.binaryType = "arraybuffer";
+
+// the seam: model fields <-> store fields; a two-way control's change becomes a server edit
+const link = connectStore(store, client, (frame) => ws.send(frame), { fromValue, toValue });
+ws.addEventListener("message", (e) =>
+  link.receive(typeof e.data === "string" ? e.data : new Uint8Array(e.data)),
+);
+
+mount(document.body, await (await fetch("/tree.json")).json(), store);
+```
+
+Inbound model patches flow `model → store → bound props`; a two-way control's change becomes a
+server-authoritative `client.edit`. Edits take effect when the server echoes them back, so **two browser
+tabs stay in sync**.
+
+A complete, runnable version of this is `spaday/examples/reactive.py` in the repository.
+
+## Go multi-tenant
+
+Swap the `Session` for a [`Hub`](https://github.com/1kbgz/transports), which routes each connection to
+its own tenant session (and can share models across tenants). The UI code is unchanged — `connectStore`
+and the bindings don't know or care whether the model is private or shared.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,0 +1,139 @@
+# Tutorial: build your first interactive UI
+
+In this tutorial you will build a small settings panel — a card with a switch and a reveal button —
+and make it interactive, all from Python. By the end you will have rendered web components, run
+behavior in the browser with no server, and wired a control two-way to state your Python code can read.
+
+We will work in a **Jupyter notebook**, because it renders a spaday UI with no setup. Everything you
+learn here applies unchanged to a web app (see [the transports guide](transports.md) afterwards).
+
+## Setup
+
+Install spaday with the notebook host, and start a notebook:
+
+```bash
+pip install "spaday[widget]"
+jupyter lab
+```
+
+## Step 1 — render a component
+
+In a cell, build a card containing a switch and display it:
+
+```python
+from spaday import Widget
+from spaday.components.webawesome import WaCard, WaSwitch
+
+panel = WaCard().child(WaSwitch().text("Lamp"))
+Widget(panel)
+```
+
+Run the cell. You should see a bordered card with a labelled toggle switch. `WaCard` and `WaSwitch` are
+typed Python classes for [WebAwesome](https://webawesome.com) components; `.child(...)` nests one inside
+another, and `Widget(...)` renders the tree in the output area.
+
+## Step 2 — add a layout
+
+Components nest, so add a second row and a heading using the same pattern. Use a `Stack` to lay the
+children out vertically:
+
+```python
+from spaday import element, Widget
+from spaday.components.shell import Stack
+from spaday.components.webawesome import WaCard, WaSwitch
+
+panel = WaCard().child(
+    Stack()
+    .child(element("strong").text("Settings"))
+    .child(WaSwitch().text("Lamp"))
+    .child(WaSwitch().text("Notifications"))
+)
+Widget(panel)
+```
+
+Run it. You should see a card titled **Settings** with two switches stacked under it. `Stack` is one of
+spaday's `spa-*` layout components; `element("strong")` is an escape hatch for a plain HTML tag.
+
+## Step 3 — make it do something, in the browser
+
+Now add a button that reveals a panel — and have it run **in the browser**, with no call back to
+Python. Attach a declarative action with `.on(...)`:
+
+```python
+from spaday import by_id, element, Toggle, Widget
+from spaday.components.shell import Stack
+from spaday.components.webawesome import WaButton, WaCallout, WaCard, WaSwitch
+
+panel = WaCard().child(
+    Stack()
+    .child(element("strong").text("Settings"))
+    .child(WaSwitch().text("Lamp"))
+    .child(WaButton(variant="brand").text("Details").on("click", Toggle(by_id("info"), "hidden")))
+    .child(WaCallout().prop("id", "info").prop("hidden", True).text("Runs entirely client-side."))
+)
+Widget(panel)
+```
+
+Run it and click **Details**. The callout appears and disappears each click. `Toggle(by_id("info"), "hidden")` is an *action* — serializable data, not Python code — that spaday's runtime interprets in the
+browser. Your Python kernel is never contacted when you click.
+
+## Step 4 — bind a control to state
+
+Client-side behavior is good; reactive *state* is better. Give the widget a state model and bind the
+switch's `checked` to a field of it, **two-way**:
+
+```python
+from spaday import element, Widget
+from spaday.components.shell import Stack
+from spaday.components.webawesome import WaCard, WaSwitch
+
+panel = WaCard().child(
+    Stack()
+    .child(element("strong").text("Settings"))
+    .child(WaSwitch().text("Lamp").bind("checked", "lamp", mode="two-way"))
+)
+w = Widget(panel, state={"lamp": True})
+w
+```
+
+Run it. The switch starts **on**, because the `lamp` field is `True`. Now read the state back in Python —
+in a new cell:
+
+```python
+w.state
+```
+
+Flip the switch in the rendered widget, then re-run `w.state`. You should see `{'lamp': False}`. The
+control wrote the field. It works the other way too — set the field from Python:
+
+```python
+w.state = {"lamp": True}
+```
+
+The switch turns back on. The binding keeps the control and the state field in sync in both directions.
+
+## Step 5 — react to changes in Python
+
+Register a callback to run whenever the state changes (including from a click in the browser):
+
+```python
+w.on_state(lambda state: print("settings:", state))
+```
+
+Now flip the switch in the widget. Your cell prints `settings: {'lamp': False}`. You have a UI whose
+interactions run in the browser *and* report back to Python.
+
+## What you built
+
+- A web-component UI authored entirely in typed Python.
+- Behavior (`Toggle`) that runs client-side with no round-trip.
+- A control two-way-bound to state, readable and writable from Python.
+
+## Next steps
+
+- [Add behavior and reactivity](behavior.md) — the full action DSL and binding kinds (including
+  *computed* props derived from state).
+- [Author a component tree](components.md) — props, slots, keys, and the shell components in depth.
+- [Sync a UI to a server over transports](transports.md) — the same panel, multi-tenant, on a webserver.
+- [How spaday works](concepts.md) — why behavior is data and how one Rust core drives both Python and
+  the browser.

--- a/docs/src/wrappers.md
+++ b/docs/src/wrappers.md
@@ -1,16 +1,16 @@
-# Wrapping an imperative library
+# Wrap an imperative JS library
 
-Some libraries aren't web components and aren't configured by attributes — they expose a JavaScript
-API you *call* (charts, data grids, editors). spaday binds these the same way it binds WebAwesome,
-with one extra step: you write a thin **custom element** that drives the library's API internally, so
-from Python it looks like any other component.
+Some libraries aren't web components and aren't configured by attributes — they expose a JavaScript API
+you *call* (charts, data grids, editors). This guide shows you how to bind one so that, from Python, it
+looks like any other component. You write a thin **custom element** that drives the library's API
+internally, then [generate a typed class](cem.md) for it.
 
-The recipe, with `LightweightChart` (TradingView lightweight-charts) as the worked example:
+The worked example is `LightweightChart` (TradingView lightweight-charts).
 
 ## 1. A custom element that drives the library
 
-The element creates the chart on connect and exposes the config you want from Python as **properties**
-whose setters call the library:
+Write an element that creates the library object on connect and exposes the config you want from Python
+as **properties** whose setters call the library:
 
 ```ts
 // js/src/ts/wrappers/lightweight-chart.ts (abridged)
@@ -30,29 +30,26 @@ export class LightweightChart extends HTMLElement {
 customElements.define("lightweight-chart", LightweightChart);
 ```
 
-It is bundled self-contained (the library included) so consumers just load it; nothing else to
-install.
+Bundle it self-contained (the library included) so consumers just load it; nothing else to install.
 
 ## 2. A hand-authored CEM → a typed Python class
 
-The library ships no `custom-elements.json`, so you write a small one describing the element's
-props, and run the generator (see [Components](components.md)):
+The library ships no `custom-elements.json`, so write a small one describing the element's props and
+[generate a class from it](cem.md):
 
 ```bash
-python -m spaday.cem spaday/components/lightweight_charts.cem.json \
-  -o spaday/components/lightweight_charts.py
+spaday-cem spaday/components/lightweight_charts.cem.json -o spaday/components/lightweight_charts.py
 ```
 
-That yields a typed class — same authoring experience as WebAwesome:
+You now author it like any other component:
 
 ```python
 from spaday.components import LightweightChart
 
-chart = LightweightChart(
+LightweightChart(
     type="line",
     data=[{"time": "2019-01-01", "value": 10}, {"time": "2019-01-02", "value": 12}],
 )
-chart.to_json()   # the wire form
 ```
 
 `type` is a typed `Literal`; `data` is free-form (`Any`) — its shape is the library's, carried through
@@ -60,13 +57,12 @@ untouched.
 
 ## 3. The runtime mounts it
 
-The browser runtime (see [Components](components.md)) instantiates
-`<lightweight-chart>` and sets its `type`/`data` properties, so the element renders the real chart —
-and a patch that changes `data` updates the live chart in place. From Python you authored typed
-components; in the browser an imperative library draws.
+The browser runtime instantiates `<lightweight-chart>` and sets its `type` / `data` properties, so the
+element renders the real chart — and a patch that changes `data` updates the live chart in place. The
+element is an ordinary custom element, so it also takes [actions and bindings](behavior.md): bind `data`
+to a state field and the chart redraws reactively as the field changes.
 
 ```{note}
 This is the seam for libraries like Perspective and regular-table too: a wrapper element exposing a
-config property whose setter calls the library (e.g. `viewer.restore(config)`). Wiring component
-*events* back to Python behavior is a separate, later capability (the action DSL).
+config property whose setter calls the library (e.g. `viewer.restore(config)`).
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,8 +221,23 @@ section-order = [
 title = "spaday"
 root = "README.md"
 pages = [
+    "docs/src/tutorial.md",
     "docs/src/components.md",
+    "docs/src/behavior.md",
+    "docs/src/notebook.md",
+    "docs/src/transports.md",
     "docs/src/wrappers.md",
+    "docs/src/cem.md",
     "docs/src/api.md",
+    "docs/src/concepts.md",
 ]
 use-autoapi = false
+exclude_patterns = [
+    "README.md",
+    "AGENTS.md",
+    "ROADMAP.md",
+    "REVIEW.md",
+    "TODO.md",
+    ".github",
+    "spaday/examples/README.md",
+]


### PR DESCRIPTION
Restructures `docs/src` into single-mode [Diátaxis](https://diataxis.fr) pages and brings them current with Phase 2 — the old pages still called the action DSL "a later phase" and had no coverage of the reactive engine, transports, or the notebook host.

Stacked on #61 (the docs reference computed bindings); GitHub will retarget to `main` when #61 merges.

## Structure (tutorial → how-to → reference → explanation)

- **Tutorial** — `tutorial.md`: build a first interactive UI in a notebook, step by step (zero setup).
- **How-to** — `components.md` (author a tree), `behavior.md` (actions + reactive bindings, incl. *computed*), `notebook.md`, `transports.md` (live multi-tenant data), `wrappers.md` (imperative JS libs), `cem.md` (generate classes).
- **Reference** — `api.md`: the full Python surface (actions, expressions, `validate`, `Widget`, …) — was missing all of the action DSL + reactive engine.
- **Explanation** — `concepts.md`: how spaday works and why (behavior-as-data, one core/two bindings, the transports boundary, the two hosts).
- **README** — a real overview + a runnable taste + links into the four sections.

Each page is single-mode (no blended tutorial/how-to/reference/explanation), per the cardinal rule.

## Verification

- `yardang build` succeeds and **autodoc resolves the entire public API**; the remaining 8 warnings are pre-existing yardang-template noise (autodoc_pydantic config + the generated index toctree caption). Added `exclude_patterns` to silence orphan-page warnings (README/AGENTS/ROADMAP/.github/examples).
- All nine pages render to HTML; `mdformat --check` clean.

(Docs are published post-merge by the `docs.yaml` workflow, not on PRs.)