### PR TITLE
Remove roadmap phase references from the codebase

### DIFF
--- a/js/src/ts/shell.ts
+++ b/js/src/ts/shell.ts
@@ -1,4 +1,4 @@
-// spaday's high-level layout/shell primitives — Phase 4.1. These are the "higher altitude" authoring
+// spaday's high-level layout/shell primitives. These are the "higher altitude" authoring
 // surface: instead of building layout from raw `div`s, you compose real `spa-*` web components whose
 // layout (flex/grid, spacing, surfaces) is encapsulated in shadow DOM. Each is a thin custom element
 // with one default `<slot>` and a `:host` style; structure comes from how you nest them

--- a/js/src/ts/signals.ts
+++ b/js/src/ts/signals.ts
@@ -2,7 +2,7 @@
 // engine. The runtime binds component props to fields (a node's `bindings`, authored via `Component.bind`
 // in Python); setting a field notifies every bound prop, and a two-way-bound control writes its field
 // back on change. The same store can later be backed by a transports model or the anywidget model so UI
-// state and app/server state mirror (Phase 2.4).
+// state and app/server state mirror.
 
 export type Field = string;
 type Subscriber = (value: unknown) => void;

--- a/js/tests/shell.spec.js
+++ b/js/tests/shell.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-// The Phase 4.1 shell primitives (spa-app/nav/body/gutter/main/footer/stack/row/toolbar). They are real
+// The shell primitives (spa-app/nav/body/gutter/main/footer/stack/row/toolbar). They are real
 // custom elements defined on import of the runtime — each a shadow root with one default slot and
 // encapsulated layout CSS — so layout is authored by composing them, not by hand-writing div markup.
 

--- a/rust/python/lib.rs
+++ b/rust/python/lib.rs
@@ -10,10 +10,10 @@ pub use example::Example;
 fn spaday(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     // Example
     m.add_class::<Example>().unwrap();
-    // Component-tree diff/patch (Phase 0.3) — JSON wire bridge over the shared core.
+    // Component-tree diff/patch — JSON wire bridge over the shared core.
     m.add_function(wrap_pyfunction!(patch::diff, m)?)?;
     m.add_function(wrap_pyfunction!(patch::apply, m)?)?;
-    // Custom Elements Manifest parser (Phase 1) — manifest JSON -> component schemas JSON.
+    // Custom Elements Manifest parser — manifest JSON -> component schemas JSON.
     m.add_function(wrap_pyfunction!(patch::parse_cem, m)?)?;
     Ok(())
 }

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -1,7 +1,7 @@
-//! The declarative action DSL — behavior as serializable data (Phase 2).
+//! The declarative action DSL — behavior as serializable data.
 //!
-//! An [`Action`] is the typed event-handler model the component tree carries (replacing the Phase 0
-//! `Action(Value)` placeholder). It is *data, not code*: authored in Python, serialized as the
+//! An [`Action`] is the typed event-handler model the component tree carries. It is *data, not code*:
+//! authored in Python, serialized as the
 //! canonical wire form defined here, and evaluated in the browser by the wasm interpreter (the `js`
 //! crate) against DOM primitives the browser supplies — there is no `eval`. The core owns the model
 //! and the wire format so both bindings agree on the shape.

--- a/rust/src/cem.rs
+++ b/rust/src/cem.rs
@@ -1,4 +1,4 @@
-//! Custom Elements Manifest (CEM) parser — the Phase 1 binding-generator foundation.
+//! Custom Elements Manifest (CEM) parser — the binding-generator foundation.
 //!
 //! Web-component libraries publish a `custom-elements.json` (the [Custom Elements Manifest]) that
 //! describes every element: its tag, attributes (with types and defaults), events, and slots.
@@ -8,7 +8,7 @@
 //! same "one core, two bindings" shape as the diff engine.
 //!
 //! This layer is deliberately about *binding* only: attribute/slot/event structure. Event *handlers*
-//! (the declarative action DSL) are Phase 2.
+//! (the declarative action DSL) live in the [`crate::action`] module.
 //!
 //! [Custom Elements Manifest]: https://github.com/webcomponents/custom-elements-manifest
 

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -8,7 +8,7 @@
 //! ```
 //!
 //! which the test suite exercises exhaustively (including a deterministic fuzz). This mirrors the
-//! shape of the `transports` patch engine (ROADMAP Phase 0.2); when transports lands its core, the
+//! shape of the `transports` patch engine; when transports lands its core, the
 //! tree becomes a transports model and this delegates rather than re-implements.
 //!
 //! ## Reconciliation

--- a/rust/src/json.rs
+++ b/rust/src/json.rs
@@ -1,8 +1,8 @@
 //! JSON wire bridge — the bring-up codec for trees and patches.
 //!
 //! This is the minimal wire format so the PyO3 and wasm bindings can exchange trees and patches
-//! today. It is deliberately thin: `transports` will own real, pluggable codecs (transports ROADMAP
-//! Phase 2), at which point this becomes one codec among several rather than the only path.
+//! today. It is deliberately thin: `transports` will own real, pluggable codecs, at which point this
+//! becomes one codec among several rather than the only path.
 //!
 //! Both bindings call straight through to these two functions, which is what makes "one core, two
 //! bindings" concrete: a patch produced by [`diff_json`] in Python is consumed by [`apply_json`] in

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate is the single source of truth for the component tree and its diff/patch engine; it
 //! compiles into the PyO3 (`rust/python`) and wasm (`js`) bindings so Python (build-time) and
-//! JavaScript (run-time) share one implementation. See `spaday/ROADMAP.md`, Phase 0.
+//! JavaScript (run-time) share one implementation.
 //!
 //! Layers (built bottom-up):
 //! - [`value`] — the prop/state value type.
@@ -10,7 +10,7 @@
 //! - [`node`] — the serializable component tree ([`Node`], slots, events).
 //! - [`diff`] — structural diff/patch with keyed child reconciliation.
 //! - [`json`] — the JSON wire bridge the bindings call (`diff_json`/`apply_json`).
-//! - [`cem`] — the Custom Elements Manifest parser (Phase 1 binding generator).
+//! - [`cem`] — the Custom Elements Manifest parser (the binding generator).
 
 mod action;
 mod cem;

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -1,9 +1,9 @@
 //! The scalar/structured value type used for component props and (later) reactive state.
 //!
-//! `Value` is a small tagged union mirroring the shape the `transports` core will own
-//! (see transports ROADMAP Phase 0). For now spaday carries its own copy so the component
+//! `Value` is a small tagged union mirroring the shape the `transports` core will own.
+//! For now spaday carries its own copy so the component
 //! tree and its diff/patch engine can be built without blocking on transports; the two
-//! will be reconciled when transports Phase 0 lands.
+//! will be reconciled when transports' core lands.
 
 use std::collections::BTreeMap;
 

--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -18,8 +18,8 @@ Actions: ``SetProp`` / ``Toggle`` / ``Sequence`` / ``Emit`` (client-side); ``Sen
 intent the app routes to its wire, e.g. transports); ``If`` (conditionals); ``CallEndpoint`` (a REST
 round-trip); and ``NamedJs`` (a no-``eval`` escape hatch to a pre-registered handler). Expressions:
 ``lit`` / ``event_value`` / ``not_`` / ``prop`` (read live element state); targets ``this`` / ``by_id``.
-``bind`` is a one-way reactive-binding helper. The signal-graph reactive engine (derived state, two-way
-binding) is the remaining Phase 2 work.
+``bind`` here is a one-way event-driven helper; reactive prop↔state bindings (one- or two-way) are
+authored with ``Component.bind`` and interpreted by the runtime's signal store.
 """
 
 from typing import Any, Dict, List, Optional

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -1,4 +1,4 @@
-"""High-level layout / shell components — Phase 4.1.
+"""High-level layout / shell components.
 
 spaday's "higher altitude" authoring surface: compose pages from these ``spa-*`` web components instead
 of building layout out of raw ``div``s. Each wraps a shadow-DOM layout primitive defined by the spaday

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -9,8 +9,8 @@ runtime (``js/src/ts/shell.ts``); structure comes from nesting them and spacing 
         Body(...).child(Gutter(...)).child(Main(...))
     ).child(Footer(...))
 
-First cut — pure structural containers (no typed props yet). :class:`Main` is the page's content region
-(the roadmap's "Page"); a single :class:`Gutter` becomes a left or right gutter by where it sits in a
+First cut — pure structural containers (no typed props yet). :class:`Main` is the page's content region;
+a single :class:`Gutter` becomes a left or right gutter by where it sits in a
 :class:`Body`. Tune spacing/surfaces with CSS custom properties (``--spa-gap``, ``--spa-gutter-width``)
 via ``.prop("style", ...)``.
 """
@@ -53,7 +53,7 @@ class Gutter(Component):
 
 
 class Main(Component):
-    """The primary content region (the roadmap's "Page")."""
+    """The primary content region."""
 
     tag = "spa-main"
 

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -45,7 +45,7 @@ is independent per tab.
   (correct, not minimal); per-point deltas need the series modeled as tree state — later.
 - **TradingView logo** is disabled in the chart wrapper; attribution is in the page footer.
 
-## `reactive.py` — declarative two-way binding over transports (Phase 2.4)
+## `reactive.py` — declarative two-way binding over transports
 
 A second, focused app showing the spaday ↔ transports boundary at its cleanest. A `Controls` model lives
 in a `transports.Session`; the page authors controls **bound** to its fields

--- a/spaday/tests/test_all.py
+++ b/spaday/tests/test_all.py
@@ -4,7 +4,7 @@ from spaday import apply, diff
 
 
 # The wire form of a prop value is the externally-tagged `Value` enum, e.g. {"Bool": true},
-# {"Int": 3}, {"Str": "x"}. The ergonomic typed component classes (Phase 1) will hide this; for
+# {"Int": 3}, {"Str": "x"}. The ergonomic typed component classes will hide this; for
 # now the tests speak the raw wire contract directly.
 def _switch(checked: bool) -> str:
     return json.dumps({"tag": "wa-switch", "props": {"checked": {"Bool": checked}}})


### PR DESCRIPTION
Phase numbers (`Phase 0.3`, `Phase 2.4`, `Phase 4.1`, …) are internal roadmap bookkeeping and don't belong in source comments or docstrings — they go stale and mean nothing to a reader of the code. This rewrites every such reference **topically** (describing the thing, not the roadmap step) across 13 files: the Rust core (`action`/`cem`/`json`/`value`/`lib`/`diff`), the PyO3 entry, the JS runtime (`shell`/`signals`), the Python package (`shell`/`actions`/a test), and the examples README.

Two of them were also **stale** and are refreshed: the action DSL and the reactive engine are no longer 'remaining Phase 2 work'.

The roadmap doc itself (`ROADMAP.md` / `AGENTS.md`) is untouched — phases are its organizing principle.

Comment/docstring-only; no behavior change. `cargo check` + rustfmt, `ruff format`, and prettier all clean; a repo-wide grep for `phase` (excluding the roadmap) is now empty.