### PR TITLE
Reactive structural rendering: a Show wrapper that creates/removes elements from a signal

### DIFF
--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -133,19 +133,79 @@ function unwireBinding(el: Element, prop: string): void {
   }
 }
 
+// `spa-show`: a structural binding. Its default-slot children are MOUNTED when the `when` condition is
+// truthy and TORN DOWN + removed (not merely hidden) when it is falsy — reactive creation/removal of real
+// elements. The wrapper itself stays put (authored `display:contents`), so sibling paths don't shift as
+// children come and go.
+function wireShow(el: Element, node: Node, store?: Store): void {
+  const cond = node.bindings?.when;
+  const childDefs = node.slots?.[DEFAULT_SLOT] ?? [];
+  if (!store || !cond) {
+    for (const c of childDefs) appendInSlot(el, DEFAULT_SLOT, build(c, store)); // inert: render always
+    return;
+  }
+  const evaluate = (): boolean =>
+    cond.compute !== undefined
+      ? !!evalExpr(cond.compute, store)
+      : !!store.get(cond.field!);
+  let mounted: Element[] = [];
+  const render = (): void => {
+    if (evaluate()) {
+      if (mounted.length === 0) {
+        for (const c of childDefs) {
+          const ce = build(c, store);
+          appendInSlot(el, DEFAULT_SLOT, ce);
+          mounted.push(ce);
+        }
+      }
+    } else if (mounted.length) {
+      for (const ce of mounted) {
+        teardownTree(ce);
+        ce.remove();
+      }
+      mounted = [];
+    }
+  };
+  render(); // initial state
+  const deps =
+    cond.compute !== undefined ? [...exprFields(cond.compute)] : [cond.field!];
+  const subs = deps.map((f) => store.subscribe(f, render));
+  let map = bindings.get(el); // record teardown so removing the spa-show unsubscribes (via teardownTree)
+  if (!map) bindings.set(el, (map = new Map()));
+  map.set("when", () => subs.forEach((u) => u()));
+}
+
+// Tear down the reactive bindings (store subscriptions) registered across an element subtree, so removing
+// it doesn't leak subscriptions that keep detached elements alive. DOM event listeners are released when
+// the element itself is garbage-collected.
+function teardownTree(el: Element): void {
+  for (const e of [el, ...el.querySelectorAll("*")]) {
+    const map = bindings.get(e);
+    if (map) {
+      for (const teardown of map.values()) teardown();
+      bindings.delete(e);
+    }
+  }
+}
+
 function build(node: Node, store?: Store): Element {
   const el = document.createElement(node.tag);
   for (const [name, value] of Object.entries(node.props ?? {})) {
     setProp(el, name, untag(value));
   }
-  for (const [slot, children] of Object.entries(node.slots ?? {})) {
-    for (const child of children) appendInSlot(el, slot, build(child, store));
+  if (node.tag === "spa-show") {
+    wireShow(el, node, store); // conditionally mounts the node's default-slot children
+  } else {
+    for (const [slot, children] of Object.entries(node.slots ?? {})) {
+      for (const child of children) appendInSlot(el, slot, build(child, store));
+    }
   }
   for (const [name, action] of Object.entries(node.events ?? {})) {
     bindEvent(el, name, action); // actions ride the wire as the core's DSL form (plain JSON)
   }
   if (store) {
     for (const [prop, spec] of Object.entries(node.bindings ?? {})) {
+      if (node.tag === "spa-show" && prop === "when") continue; // structural — handled by wireShow
       wireBinding(el, prop, spec, store);
     }
   }
@@ -248,7 +308,9 @@ function applyOp(root: Element, op: Op, store?: Store): Element {
     insertInSlot(resolve(root, path), slot, index, build(node, store));
   } else if ("RemoveChild" in op) {
     const { path, slot, index } = op.RemoveChild;
-    childrenInSlot(resolve(root, path), slot)[index].remove();
+    const child = childrenInSlot(resolve(root, path), slot)[index];
+    teardownTree(child); // release the subtree's store subscriptions before detaching it
+    child.remove();
   } else if ("MoveChild" in op) {
     const { path, slot, from, to } = op.MoveChild;
     const parent = resolve(root, path);
@@ -257,6 +319,7 @@ function applyOp(root: Element, op: Op, store?: Store): Element {
     insertInSlot(parent, slot, to, moving);
   } else if ("Replace" in op) {
     const target = resolve(root, op.Replace.path);
+    teardownTree(target); // release the replaced subtree's store subscriptions
     const replacement = build(op.Replace.node, store);
     target.replaceWith(replacement);
     if (op.Replace.path.length === 0) return replacement; // the root element itself was swapped

--- a/js/tests/show.spec.js
+++ b/js/tests/show.spec.js
@@ -1,0 +1,107 @@
+import fs from "fs";
+import { test, expect } from "@playwright/test";
+import { initSync } from "../dist/pkg/spaday";
+
+// Structural reactivity: a `spa-show` MOUNTS its children when a store condition is truthy and REMOVES
+// them (real DOM create/destroy, not hide) when falsy. The wrapper stays put; only its children toggle.
+
+test.beforeAll(() => {
+  initSync({ module: fs.readFileSync("./dist/pkg/spaday_bg.wasm") });
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/tests/runtime.html");
+  await page.waitForFunction(() => window.__spaday);
+});
+
+test("spa-show creates and removes children as its field toggles", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ on: false });
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "spa-show",
+        bindings: { when: { field: "on", mode: "one-way" } },
+        slots: {
+          default: [
+            { tag: "section", props: { textContent: { Str: "chart" } } },
+          ],
+        },
+      },
+      store,
+    );
+    const count = () => root.querySelectorAll("section").length;
+    const steps = [count()]; // 0 — falsy initially, children not mounted
+    store.set("on", true);
+    steps.push(count()); // 1 — created
+    store.set("on", false);
+    steps.push(count()); // 0 — removed (not hidden)
+    store.set("on", true);
+    steps.push(count()); // 1 — created again
+    return steps;
+  });
+  expect(result).toEqual([0, 1, 0, 1]);
+});
+
+test("a compute condition shows children when the expression is truthy", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ hidden: true });
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "spa-show",
+        bindings: {
+          when: {
+            compute: { expr: "not", of: { expr: "field", name: "hidden" } },
+            mode: "one-way",
+          },
+        },
+        slots: { default: [{ tag: "p" }] },
+      },
+      store,
+    );
+    const before = root.querySelectorAll("p").length; // not(true) → 0
+    store.set("hidden", false); // not(false) → shown
+    return { before, after: root.querySelectorAll("p").length };
+  });
+  expect(result.before).toBe(0);
+  expect(result.after).toBe(1);
+});
+
+test("re-shown children are freshly bound to the current store value", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ on: true, label: "a" });
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "spa-show",
+        bindings: { when: { field: "on", mode: "one-way" } },
+        slots: {
+          default: [
+            {
+              tag: "span",
+              bindings: { textContent: { field: "label", mode: "one-way" } },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    const first = root.querySelector("span").textContent; // "a"
+    store.set("on", false); // unmount + tear down the span's binding
+    store.set("label", "b"); // changes while unmounted
+    store.set("on", true); // remount — a fresh build picks up the current value
+    return { first, second: root.querySelector("span").textContent };
+  });
+  expect(result.first).toBe("a");
+  expect(result.second).toBe("b");
+});

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -15,11 +15,11 @@ a single :class:`Gutter` becomes a left or right gutter by where it sits in a
 via ``.prop("style", ...)``.
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from ..component import Component
 
-__all__ = ["App", "Nav", "Body", "Gutter", "Main", "Footer", "Stack", "Row", "Toolbar"]
+__all__ = ["App", "Nav", "Body", "Gutter", "Main", "Footer", "Stack", "Row", "Toolbar", "Show"]
 
 
 class App(Component):
@@ -90,3 +90,30 @@ class Toolbar(Component):
 
     def __init__(self, *, gap: Optional[str] = None, align: Optional[str] = None, justify: Optional[str] = None, key: Optional[str] = None) -> None:
         super().__init__(key=key, props={"gap": gap, "align": align, "justify": justify})
+
+
+class Show(Component):
+    """Conditionally render children from a reactive store field — they are *mounted* when the condition
+    is truthy and *removed* (not merely hidden) when it is falsy, so a toggle can create and destroy real
+    elements client-side.
+
+    Unlike the layout components above this is not a shadow-DOM element but a runtime **structural
+    binding** (``js/src/ts/runtime.ts``); the wrapper renders ``display:contents`` and is transparent.
+    Pass ``field`` for a plain store field, or ``when`` for a field-expression
+    (:func:`~spaday.actions.field` / ``not_`` / ``eq`` / ``all_`` / ``any_``)::
+
+        Show(field="show_chart").child(LightweightChart(...))
+
+    Active only when the tree is mounted with a signal ``Store`` (``mount(body, tree, store)``).
+    """
+
+    tag = "spa-show"
+
+    def __init__(self, *, field: Optional[str] = None, when: Optional[Any] = None, key: Optional[str] = None) -> None:
+        super().__init__(key=key, props={"style": "display:contents"})
+        if field is not None:
+            self._bindings["when"] = {"field": field, "mode": "one-way"}
+        elif when is not None:
+            self._bindings["when"] = {"compute": when.to_dict(), "mode": "one-way"}
+        else:
+            raise ValueError("Show requires field= (a store field) or when= (a field-expression)")

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -8,6 +8,9 @@ with **transports** as the live wire.
 - **Action DSL (client-side)** — controls carry declarative actions (`Component.on` + `spaday.actions`)
   interpreted in the browser: Toggle, SetProp bound to the event value, Sequence, and buttons that
   switch a chart's series type. No event listeners are written, and the server is never called for these.
+- **Reactive structure (client-side)** — a "Show chart" switch is two-way bound to a signal; a `Show`
+  wrapper mounts a chart when it's on and removes it (real DOM create/destroy, not hide) when off — no
+  server and no event listeners, via the runtime's structural binding.
 - **transports (server-authoritative, multi-tenant)** — two live charts mirror Python models over
   `@1kbgz/transports`: a **global** model (shared `transports.Server`) syncs to every browser; a
   **per-session** model (`transports.Hub`) is private to each tab. Control changes are edits applied on

--- a/spaday/examples/__main__.py
+++ b/spaday/examples/__main__.py
@@ -39,7 +39,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 from spaday import element
 from spaday.actions import SendPatch, Sequence, SetProp, Toggle, bind, by_id, event_value, lit, not_
 from spaday.components.lightweight_charts import LightweightChart
-from spaday.components.shell import App, Body, Footer, Gutter, Main, Nav, Row, Stack, Toolbar
+from spaday.components.shell import App, Body, Footer, Gutter, Main, Nav, Row, Show, Stack, Toolbar
 from spaday.components.webawesome import WaButton, WaCallout, WaCard, WaOption, WaSelect, WaSwitch
 
 HERE = Path(__file__).parent
@@ -139,6 +139,28 @@ def dsl_card() -> object:
     )
 
 
+def structure_card() -> object:
+    """Reactive structure — a toggle that creates and removes a real chart element, client-side.
+
+    The switch is two-way bound to a signal ``show_chart``; a :class:`~spaday.components.shell.Show`
+    wrapper mounts the chart when it is on and removes it (real DOM create/destroy, not hide) when off —
+    no server, no event listeners, just the signal store.
+    """
+    return WaCard(appearance="outlined").child(
+        Stack()
+        .child(element("strong").text("Reactive structure — create/remove elements"))
+        .child(
+            element("p").text(
+                "The switch is two-way bound to a signal; a Show wrapper mounts the chart when it is on "
+                "and removes it (real DOM create/destroy, not merely hidden) when off — entirely "
+                "client-side, no server and no event listeners."
+            )
+        )
+        .child(WaSwitch().prop("id", "chart-toggle").bind("checked", "show_chart", mode="two-way").text("Show chart"))
+        .child(Show(field="show_chart").child(LightweightChart(type="area", data=random_walk(120)).prop("style", "height:260px;display:block")))
+    )
+
+
 def transports_panel(prefix: str, title: str, chart_type: str) -> object:
     """One live chart + its controls. Edits are declarative SendPatch actions (routed to transports in
     index.html); the ids remain so the inbound update can reflect the model back onto the controls."""
@@ -196,11 +218,12 @@ def page() -> dict:
                     .child(element("strong").text("Shows"))
                     .child(element("span").text("spa-* shell layout"))
                     .child(element("span").text("action DSL (client-side)"))
+                    .child(element("span").text("reactive structure (create/remove)"))
                     .child(element("span").text("transports live + edits"))
                     .child(element("span").text("global vs per-session"))
                 )
             )
-            .child(Main().child(dsl_card()).child(transports_card()))
+            .child(Main().child(dsl_card()).child(structure_card()).child(transports_card()))
         )
         .child(
             Footer()

--- a/spaday/examples/index.html
+++ b/spaday/examples/index.html
@@ -38,7 +38,7 @@
       // The whole page (shell layout + each control's Action) is authored by spaday/examples/__main__.py.
       // Mounting renders it and binds the action DSL — note there is NO addEventListener for the DSL card.
       // The only hand-written glue is for the two transports charts (edits aren't a declarative action yet).
-      import { mount, init } from "/js/dist/esm/index.js";
+      import { mount, init, Store } from "/js/dist/esm/index.js";
       import "/js/dist/cdn/wrappers/lightweight-chart.js"; // defines <lightweight-chart>
       import {
         Client,
@@ -53,7 +53,10 @@
       });
 
       const node = await (await fetch("/tree.json")).json();
-      mount(document.body, node); // shell + both cards; the action DSL is wired automatically
+      // a signal store backs the reactive-structure card: the "Show chart" switch is two-way bound to
+      // `show_chart`, and a Show wrapper mounts/removes the chart from it — client-side, no server.
+      const store = new Store({ show_chart: false });
+      mount(document.body, node, store); // shell + cards; the action DSL + bindings are wired automatically
 
       const byId = (id) => document.getElementById(id);
 

--- a/spaday/tests/test_shell.py
+++ b/spaday/tests/test_shell.py
@@ -1,7 +1,10 @@
 import json
 
-from spaday import apply, diff
-from spaday.components.shell import App, Body, Footer, Gutter, Main, Nav, Row, Stack, Toolbar
+import pytest
+
+from spaday import apply, diff, element
+from spaday.actions import field, not_
+from spaday.components.shell import App, Body, Footer, Gutter, Main, Nav, Row, Show, Stack, Toolbar
 
 
 def test_shell_classes_emit_spa_tags():
@@ -42,3 +45,23 @@ def test_shell_layout_props_become_attributes():
     assert Row(justify="space-between").to_node()["props"] == {"justify": {"Str": "space-between"}}
     # unset kwargs are omitted, so an unstyled primitive stays prop-free
     assert "props" not in Stack().to_node()
+
+
+def test_show_field_authors_a_when_binding():
+    node = Show(field="on").child(element("span")).to_node()
+    assert node["tag"] == "spa-show"
+    assert node["bindings"]["when"] == {"field": "on", "mode": "one-way"}
+    assert node["props"]["style"] == {"Str": "display:contents"}  # transparent wrapper
+    assert node["slots"]["default"][0]["tag"] == "span"
+
+
+def test_show_when_authors_a_compute_binding():
+    node = Show(when=not_(field("hidden"))).child(element("p")).to_node()
+    binding = node["bindings"]["when"]
+    assert binding["mode"] == "one-way"
+    assert binding["compute"] == {"expr": "not", "of": {"expr": "field", "name": "hidden"}}
+
+
+def test_show_requires_a_condition():
+    with pytest.raises(ValueError):
+        Show()


### PR DESCRIPTION
Adds client-side **structural reactivity** — conditionally mounting/removing a subtree from a signal,
the missing piece next to the existing prop-level reactive bindings. Answers "can spaday create/remove
DOM elements dynamically?" with a first-class, declarative, no-server primitive.

## The primitive
`Show` (a `spa-show` wrapper) renders its children only while a store condition is truthy: they are
**mounted** when it becomes true and **removed** (real DOM create/destroy, not merely hidden) when false.

```python
from spaday.components.shell import Show
Show(field="show_chart").child(LightweightChart(...))          # a plain store field
Show(when=not_(field("collapsed"))).child(...)                 # or a field-expression
```

It needs no Rust change — `spa-show` rides the generic `Node`/`bindings`/`slots` the diff already
handles; only the **runtime** interprets it:

- `runtime.ts`: `wireShow` evaluates the `when` condition (field or `compute` expr), subscribes to its
  fields, and mounts/unmounts the children reactively. The wrapper renders `display:contents` and keeps
  a stable DOM position, so sibling paths don't shift as children come and go.
- `teardownTree` releases a removed subtree's store subscriptions on unmount; `RemoveChild`/`Replace`
  now call it too (fixing a latent subscription leak for any patched-away bound element).

## Demo: the omnibus gains a "Show chart" toggle
A switch two-way-bound to a `show_chart` signal; a `Show` wraps a `LightweightChart`. Flipping it
**creates and destroys the real chart element** — client-side, no server, no event listeners. Verified
headless: `{before: 0, after-on: 1, after-off: 0}` chart elements inside the `spa-show`.

## Tests
- `show.spec.js` (3): create/remove on toggle, a compute condition, and fresh re-binding on remount.
- `test_shell.py` (3): `Show` authoring (field, field-expr, the missing-condition error).
- Full suites green: Playwright 44, Python 53.

Independent of the transports convergence (#64) — branched off `main`.