### PR TITLE
Form-from-schema: a two-way-bound wa-* form from a pydantic model (Phase 4.3)

### DIFF
--- a/spaday/components/__init__.py
+++ b/spaday/components/__init__.py
@@ -8,6 +8,7 @@ for an *imperative* library (TradingView lightweight-charts), bound via a hand-a
 """
 
 from . import shell, webawesome
+from .form import form  # noqa: F401  (form-from-schema generator)
 from .lightweight_charts import LightweightChart  # noqa: F401  (an imperative-library wrapper)
 from .shell import *  # noqa: F401,F403  (high-level layout/shell components)
 from .webawesome import *  # noqa: F401,F403  (re-export the generated component classes)

--- a/spaday/components/form.py
+++ b/spaday/components/form.py
@@ -1,0 +1,71 @@
+"""Form-from-schema: generate a two-way-bound ``wa-*`` form from a pydantic model.
+
+:func:`form` introspects a model's fields and emits a labeled control per field, each **two-way bound**
+to a signal-store field of the same name. Mount the result with a `Store` (seeded from the model) and
+``connectStore`` to a hosted ``transports`` model and you have a server-authoritative form — the same
+reactive pattern as ``examples/reactive.py``, generated from the schema instead of hand-authored. The
+field → control mapping:
+
+- ``bool`` → ``wa-switch`` (bound ``checked``)
+- ``str`` / other → ``wa-input`` (text)
+- ``int`` / ``float`` → ``wa-input`` (number)
+- ``Enum`` / ``Literal[...]`` → ``wa-select`` with a ``wa-option`` per choice
+
+The returned `Stack` is an ordinary component — add a submit `WaButton` with a ``CallEndpoint`` action,
+or wrap it in a card, as you like. Richer schema constraints (min/max/pattern from field metadata) are a
+later refinement; required-ness is surfaced today.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any, Literal, Union, get_args, get_origin
+
+from ..component import Component
+from .shell import Stack
+from .webawesome import WaInput, WaOption, WaSelect, WaSwitch
+
+
+def _unwrap_optional(ann: Any) -> Any:
+    """`Optional[X]` / `X | None` → `X` (so the control matches the underlying type)."""
+    if get_origin(ann) is Union:
+        non_none = [a for a in get_args(ann) if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return ann
+
+
+def _choices(ann: Any):
+    """The `(value, label)` choices for an Enum or `Literal[...]`, else `None`."""
+    if isinstance(ann, type) and issubclass(ann, enum.Enum):
+        return [(e.value, e.name) for e in ann]
+    if get_origin(ann) is Literal:
+        return [(a, str(a)) for a in get_args(ann)]
+    return None
+
+
+def _control(name: str, annotation: Any, required: bool) -> Component:
+    ann = _unwrap_optional(annotation)
+    req = required or None  # pass the prop only when True, so it's omitted otherwise
+
+    choices = _choices(ann)
+    if choices is not None:
+        select = WaSelect(label=name, required=req).bind("value", name, mode="two-way")
+        for value, label in choices:
+            select = select.child(WaOption(value=str(value)).text(str(label)))
+        return select
+    if ann is bool:
+        return WaSwitch().text(name).bind("checked", name, mode="two-way")
+    input_type = "number" if ann in (int, float) else "text"
+    return WaInput(label=name, type=input_type, required=req).bind("value", name, mode="two-way")
+
+
+def form(model: Any, *, exclude: tuple = ()) -> Stack:
+    """A two-way-bound form for a pydantic model (class or instance); fields in `exclude` are skipped."""
+    fields = (model if isinstance(model, type) else type(model)).model_fields
+    stack = Stack()
+    for name, info in fields.items():
+        if name in exclude:
+            continue
+        stack = stack.child(_control(name, info.annotation, info.is_required()))
+    return stack

--- a/spaday/examples/form.html
+++ b/spaday/examples/form.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>spaday — form from a pydantic model</title>
+    <!-- WebAwesome: base styles + theme, and spaday's self-contained catalog bundle registers <wa-*>. -->
+    <link rel="stylesheet" href="/js/node_modules/@awesome.me/webawesome/dist/styles/webawesome.css" />
+    <link rel="stylesheet" href="/js/node_modules/@awesome.me/webawesome/dist/styles/themes/default.css" />
+    <script type="module" src="/js/dist/cdn/widget.webawesome.js"></script>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 2rem;
+        max-width: 22rem;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module">
+      // The form tree is generated from the pydantic model by form(Settings); spaday owns the UI,
+      // transports owns the wire, connectStore is the seam. No control is authored or wired by hand.
+      import { mount, init, Store, connectStore } from "/js/dist/esm/index.js";
+      import {
+        Client,
+        fromValue,
+        toValue,
+        wasm,
+      } from "/js/node_modules/@1kbgz/transports/dist/cdn/index.js";
+
+      await init({ module_or_path: "/js/dist/pkg/spaday_bg.wasm" });
+      await wasm.default({
+        module_or_path:
+          "/js/node_modules/@1kbgz/transports/dist/pkg/transports_bg.wasm",
+      });
+
+      const node = await (await fetch("/tree.json")).json();
+
+      const store = new Store();
+      const client = new Client();
+      const ws = new WebSocket(`ws://${location.host}/ws`);
+      ws.binaryType = "arraybuffer";
+
+      const link = connectStore(store, client, (frame) => ws.send(frame), {
+        fromValue,
+        toValue,
+      });
+      ws.addEventListener("message", (event) =>
+        link.receive(
+          typeof event.data === "string"
+            ? event.data
+            : new Uint8Array(event.data),
+        ),
+      );
+
+      mount(document.body, node, store); // the generated controls' two-way bindings do the rest
+    </script>
+  </body>
+</html>

--- a/spaday/examples/form.py
+++ b/spaday/examples/form.py
@@ -1,0 +1,72 @@
+"""A form generated from a pydantic model, two-way-bound over transports — no hand-authored controls.
+
+``form(Settings)`` turns the model's fields into bound ``wa-*`` controls; ``connectStore`` syncs them
+with the hosted model. Edit a field in the browser and the server-side model updates (and fans to other
+tabs) — the same reactive seam as ``examples/reactive.py``, but the controls come from the schema.
+
+Run: ``python -m spaday.examples.form`` then open http://127.0.0.1:8002/.
+"""
+
+import asyncio
+from pathlib import Path
+from typing import Literal
+
+import transports
+import uvicorn
+from pydantic import BaseModel
+from starlette.applications import Starlette
+from starlette.responses import FileResponse, JSONResponse
+from starlette.routing import Mount, Route, WebSocketRoute
+from starlette.staticfiles import StaticFiles
+
+from spaday.components import form
+
+HERE = Path(__file__).parent
+JS = HERE.parent.parent / "js"
+
+
+class Settings(BaseModel):
+    name: str = "lamp"
+    enabled: bool = True
+    brightness: int = 50
+    # a Literal (a plain str field) becomes a <wa-select>; an Enum would too, but transports'
+    # bigbrother deep-watch can't observe enum field values (enums aren't subclassable) — Literal sidesteps it
+    size: Literal["small", "medium", "large"] = "medium"
+
+
+session = transports.Session()
+settings = Settings()
+session.host(settings)
+server = transports.Server(session)
+
+
+def tree() -> dict:
+    """The form, generated from the model — no controls authored by hand."""
+    return form(Settings).to_node()
+
+
+async def homepage(_request):
+    return FileResponse(HERE / "form.html")
+
+
+async def tree_json(_request):
+    return JSONResponse(tree())
+
+
+async def startup():
+    asyncio.create_task(transports.autosync(server))
+
+
+app = Starlette(
+    routes=[
+        Route("/", homepage),
+        Route("/tree.json", tree_json),
+        WebSocketRoute("/ws", transports.ws_endpoint(server)),
+        Mount("/js", StaticFiles(directory=JS)),
+    ],
+    on_startup=[startup],
+)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8002)

--- a/spaday/tests/test_form.py
+++ b/spaday/tests/test_form.py
@@ -1,0 +1,74 @@
+import enum
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+from spaday.components import form
+
+
+class Color(enum.Enum):
+    red = "r"
+    green = "g"
+
+
+class Settings(BaseModel):
+    name: str  # required (no default)
+    enabled: bool = True
+    count: int = 0
+    ratio: float = 1.0
+    color: Color = Color.red
+    mode: Literal["a", "b"] = "a"
+    note: Optional[str] = None
+
+
+def _controls(model, **kw):
+    """{field name: control node} for a generated form, keyed by each control's bound field."""
+    out = {}
+    for c in form(model, **kw).to_node()["slots"]["default"]:
+        binding = next(iter(c.get("bindings", {}).values()))
+        out[binding["field"]] = c
+    return out
+
+
+def test_field_types_map_to_controls_and_two_way_bindings():
+    c = _controls(Settings)
+    assert (c["name"]["tag"], next(iter(c["name"]["bindings"]))) == ("wa-input", "value")
+    assert (c["enabled"]["tag"], next(iter(c["enabled"]["bindings"]))) == ("wa-switch", "checked")
+    assert c["count"]["tag"] == "wa-input"
+    assert c["color"]["tag"] == "wa-select"
+    assert c["mode"]["tag"] == "wa-select"  # Literal → select
+    assert c["note"]["tag"] == "wa-input"  # Optional[str] unwrapped to str
+    # every control is two-way bound to its own field
+    for control in c.values():
+        assert next(iter(control["bindings"].values()))["mode"] == "two-way"
+
+
+def test_numeric_fields_use_number_inputs():
+    c = _controls(Settings)
+    assert c["count"]["props"]["type"] == {"Str": "number"}
+    assert c["ratio"]["props"]["type"] == {"Str": "number"}
+    assert c["name"]["props"]["type"] == {"Str": "text"}
+
+
+def test_required_is_surfaced_from_the_schema():
+    c = _controls(Settings)
+    assert c["name"]["props"].get("required") == {"Bool": True}  # no default → required
+    assert "required" not in c["count"].get("props", {})  # has a default → not required
+
+
+def test_enum_and_literal_become_options():
+    c = _controls(Settings)
+    enum_opts = c["color"]["slots"]["default"]
+    assert [o["props"]["value"]["Str"] for o in enum_opts] == ["r", "g"]  # enum values
+    assert [o["props"]["textContent"]["Str"] for o in enum_opts] == ["red", "green"]  # names as labels
+    literal_opts = c["mode"]["slots"]["default"]
+    assert [o["props"]["value"]["Str"] for o in literal_opts] == ["a", "b"]
+
+
+def test_exclude_skips_fields():
+    assert "note" not in _controls(Settings, exclude=("note",))
+    assert "name" in _controls(Settings, exclude=("note",))
+
+
+def test_accepts_an_instance():
+    assert set(_controls(Settings(name="x"))) == set(Settings.model_fields)


### PR DESCRIPTION
`form(Model)` introspects a pydantic model and emits a labeled, two-way-bound `wa-*` control per field —
the "higher altitude" Phase 4.3 component, and the csp-gateway unlock (POST a typed model).

## Mapping
- `bool` → `wa-switch` (bound `checked`)
- `str` / other → `wa-input` (text); `int` / `float` → `wa-input` (number)
- `Enum` / `Literal[...]` → `wa-select` with a `wa-option` per choice
- `Optional[X]` unwraps to `X`; **required-ness is surfaced** from the schema

Each control is two-way bound to a signal-store field of the same name, so mounting with a `Store` +
`connectStore` to a hosted transports model gives a server-authoritative form with zero hand-authored
controls. The returned `Stack` is an ordinary component — add a submit `WaButton` with a `CallEndpoint`,
wrap in a card, etc.

## Verified
- `examples/form.py` serves a generated form over transports; **headless-checked** that all four controls
  render and `connectStore` syncs the hosted `Settings` model into them (`name="lamp"`, `brightness="50"`,
  `enabled=true`, `size="medium"`).
- `test_form.py` (6): field→control mapping + two-way bindings, number inputs, required surfaced,
  enum/Literal options, `Optional` unwrap, `exclude`. Full suite green.

## Note (not a Form bug)
Hosting a model with an **`Enum`** field in a `transports.Session` fails — bigbrother's deep-watcher tries
to subclass the enum (enums aren't subclassable). `form()` generates the select fine; the example uses a
`Literal` to sidestep it. Worth a transports follow-up (deep-watch should skip enum leaves).