### PR TITLE
form: per-field customization (FormField) + nested sub-models

### DIFF
--- a/js/src/ts/signals.ts
+++ b/js/src/ts/signals.ts
@@ -4,8 +4,28 @@
 // back on change. The same store can later be backed by a transports model or the anywidget model so UI
 // state and app/server state mirror.
 
-export type Field = string;
+export type Field = string; // a field name, or a dotted path into nested state (e.g. "address.street")
 type Subscriber = (value: unknown) => void;
+
+const isObj = (v: unknown): v is Record<string, unknown> =>
+  v != null && typeof v === "object" && !Array.isArray(v);
+
+/** Is `a` a strict ancestor path of `b`? e.g. "address" of "address.street". */
+const isAncestor = (a: Field, b: Field): boolean => b.startsWith(a + ".");
+
+/** Immutably set a path within `obj`, cloning each level so every parent gets a fresh identity. */
+function setPath(
+  obj: Record<string, unknown>,
+  parts: string[],
+  value: unknown,
+): Record<string, unknown> {
+  const [head, ...rest] = parts;
+  const clone = { ...obj };
+  clone[head] = rest.length
+    ? setPath(isObj(clone[head]) ? clone[head] : {}, rest, value)
+    : value;
+  return clone;
+}
 
 export class Store {
   private values: Map<Field, unknown>;
@@ -15,20 +35,55 @@ export class Store {
     this.values = new Map(Object.entries(initial));
   }
 
+  /** Read a field; a dotted `field` walks into nested objects (undefined if the path breaks). */
   get(field: Field): unknown {
-    return this.values.get(field);
+    const [head, ...rest] = field.split(".");
+    let v = this.values.get(head);
+    for (const p of rest) {
+      if (!isObj(v)) return undefined;
+      v = v[p];
+    }
+    return v;
   }
 
   has(field: Field): boolean {
-    return this.values.has(field);
+    const [head, ...rest] = field.split(".");
+    if (!this.values.has(head)) return false;
+    let v = this.values.get(head);
+    for (const p of rest) {
+      if (!isObj(v) || !(p in v)) return false;
+      v = v[p];
+    }
+    return true;
   }
 
-  /** Set a field and notify its subscribers; a no-op if the value is unchanged. */
+  /**
+   * Set a field and notify subscribers; a no-op if unchanged. A dotted `field` sets a nested leaf,
+   * rebuilding its parents immutably, and notifies the leaf plus its ancestors (whose identity changed)
+   * and any subscribed descendant whose value changed.
+   */
   set(field: Field, value: unknown): void {
-    if (Object.is(this.values.get(field), value)) return;
-    this.values.set(field, value);
-    const subs = this.subscribers.get(field);
-    if (subs) for (const cb of [...subs]) cb(value);
+    if (Object.is(this.get(field), value)) return;
+    const related = [...this.subscribers.keys()].filter(
+      (k) => k === field || isAncestor(k, field) || isAncestor(field, k),
+    );
+    const before = new Map(related.map((k) => [k, this.get(k)]));
+    const parts = field.split(".");
+    if (parts.length === 1) {
+      this.values.set(field, value);
+    } else {
+      const head = parts[0];
+      const root = isObj(this.values.get(head)) ? this.values.get(head) : {};
+      this.values.set(
+        head,
+        setPath(root as Record<string, unknown>, parts.slice(1), value),
+      );
+    }
+    for (const k of related) {
+      const now = this.get(k);
+      if (!Object.is(before.get(k), now))
+        for (const cb of [...this.subscribers.get(k)!]) cb(now);
+    }
   }
 
   /** Subscribe to a field; returns an unsubscribe function. */

--- a/js/src/ts/store-sync.ts
+++ b/js/src/ts/store-sync.ts
@@ -34,11 +34,40 @@ export interface StoreLink {
   dispose(): void;
 }
 
+const isObj = (v: unknown): v is Record<string, unknown> =>
+  v != null && typeof v === "object" && !Array.isArray(v);
+
+/** Flatten a model to [dotted-path, leaf] pairs — recursing plain objects (sub-models), not arrays. */
+function* leaves(
+  obj: Record<string, unknown>,
+  prefix = "",
+): Generator<[string, unknown]> {
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (isObj(v)) yield* leaves(v, path);
+    else yield [path, v];
+  }
+}
+
+/** Immutably set a dotted path within a plain model, cloning each level. */
+function setPath(
+  obj: Record<string, unknown>,
+  parts: string[],
+  value: unknown,
+): Record<string, unknown> {
+  const [head, ...rest] = parts;
+  const clone = { ...obj };
+  clone[head] = rest.length
+    ? setPath(isObj(clone[head]) ? clone[head] : {}, rest, value)
+    : value;
+  return clone;
+}
+
 /**
- * Bidirectionally sync a `Store` with a transports-mirrored model. Top-level model fields map by name
- * to store fields: inbound frames pull them into the store; a store field change (e.g. from a two-way
- * control) is pushed back as a `client.edit`, sent via `send`. Edits are server-authoritative — the
- * change takes effect when the server echoes it back through `receive`.
+ * Bidirectionally sync a `Store` with a transports-mirrored model. Model fields map by name to store
+ * fields — and a nested sub-model flattens to dotted `parent.child` fields: inbound frames pull them
+ * into the store; a store field change (e.g. from a two-way control) is pushed back as a `client.edit`,
+ * sent via `send`. Edits are server-authoritative — it takes effect when the server echoes it back.
  */
 export function connectStore(
   store: Store,
@@ -59,15 +88,20 @@ export function connectStore(
       const model = codec.fromValue(client.value(id));
       if (!model) return;
       inbound = true;
-      for (const [field, value] of Object.entries(model)) {
-        store.set(field, value); // model → store (→ any bound props)
+      for (const [field, value] of leaves(model)) {
+        store.set(field, value); // model → store (→ any bound props); nested → a dotted field
         if (!wired.has(field)) {
           wired.add(field);
           unsubs.push(
             store.subscribe(field, (v) => {
               if (inbound || id === undefined) return; // ignore echoes of an inbound update
               const current = codec.fromValue(client.value(id)) ?? {};
-              send(client.edit(id, codec.toValue({ ...current, [field]: v })));
+              send(
+                client.edit(
+                  id,
+                  codec.toValue(setPath(current, field.split("."), v)),
+                ),
+              );
             }),
           );
         }

--- a/js/tests/signals.spec.js
+++ b/js/tests/signals.spec.js
@@ -145,3 +145,55 @@ test("a computed binding derives a prop from fields and recomputes reactively", 
   expect(result.initial).toEqual({ disabled: false, hidden: false }); // not(true); eq(basic,advanced)
   expect(result.after).toEqual({ disabled: true, hidden: true }); // recomputed when the fields changed
 });
+
+test("nested-path fields: set/get a dotted path; notify the leaf and its ancestor, not a sibling", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { Store } = window.__spaday;
+    const store = new Store({ address: { street: "Main", city: "NYC" } });
+    const seen = { leaf: [], parent: 0, sibling: 0 };
+    store.subscribe("address.street", (v) => seen.leaf.push(v));
+    store.subscribe("address", () => (seen.parent += 1));
+    store.subscribe("address.city", () => (seen.sibling += 1));
+    const before = store.get("address.street");
+    store.set("address.street", "Oak"); // write one nested leaf
+    return {
+      before,
+      after: store.get("address.street"),
+      siblingValue: store.get("address.city"), // sibling preserved through the immutable set
+      leaf: seen.leaf,
+      parentFired: seen.parent, // ancestor identity changed → notified
+      siblingFired: seen.sibling, // unchanged → not notified
+    };
+  });
+  expect(result.before).toBe("Main");
+  expect(result.after).toBe("Oak");
+  expect(result.siblingValue).toBe("NYC");
+  expect(result.leaf).toEqual(["Oak"]);
+  expect(result.parentFired).toBe(1);
+  expect(result.siblingFired).toBe(0);
+});
+
+test("a binding to a dotted path reacts to nested state, two-way", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ address: { street: "Main" } });
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "input",
+        bindings: { value: { field: "address.street", mode: "two-way" } },
+      },
+      store,
+    );
+    const initial = root.value; // nested field → prop on mount
+    root.value = "Oak";
+    root.dispatchEvent(new Event("change")); // two-way: control → nested field
+    return { initial, stored: store.get("address.street") };
+  });
+  expect(result.initial).toBe("Main");
+  expect(result.stored).toBe("Oak");
+});

--- a/js/tests/store-sync.spec.js
+++ b/js/tests/store-sync.spec.js
@@ -110,3 +110,53 @@ test("inbound updates a two-way control, and applying an inbound frame does not 
   expect(result.checked).toBe(true); // the inbound value reached the bound control
   expect(result.echoes).toBe(0); // echo guard: inbound updates are not sent straight back out
 });
+
+test("inbound: a nested sub-model field flows to a dotted-path binding", async ({
+  page,
+}) => {
+  const text = await page.evaluate((makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { mount, Store, connectStore } = window.__spaday;
+    const store = new Store();
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "span",
+        bindings: { textContent: { field: "address.street", mode: "one-way" } },
+      },
+      store,
+    );
+    const link = connectStore(store, client, () => {}, codec);
+    link.receive(JSON.stringify({ address: { street: "Main", city: "NYC" } }));
+    return root.textContent;
+  }, FAKE.toString());
+  expect(text).toBe("Main"); // the sub-model flattened to a dotted field and reached the bound prop
+});
+
+test("outbound: editing a nested control sends a deep-set edit preserving siblings", async ({
+  page,
+}) => {
+  const result = await page.evaluate((makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { mount, Store, connectStore } = window.__spaday;
+    const store = new Store();
+    const input = mount(
+      document.createElement("div"),
+      {
+        tag: "input",
+        bindings: { value: { field: "address.street", mode: "two-way" } },
+      },
+      store,
+    );
+    const sent = [];
+    const link = connectStore(store, client, (f) => sent.push(f), codec);
+    link.receive(JSON.stringify({ address: { street: "Main", city: "NYC" } }));
+    input.value = "Oak";
+    input.dispatchEvent(new Event("change")); // two-way: nested control → deep-set edit
+    return { sent: sent.map((f) => JSON.parse(f)) };
+  }, FAKE.toString());
+  // the whole model goes out with only the nested leaf changed — the sibling city is preserved
+  expect(result.sent).toContainEqual({
+    address: { street: "Oak", city: "NYC" },
+  });
+});

--- a/spaday/components/__init__.py
+++ b/spaday/components/__init__.py
@@ -8,7 +8,7 @@ for an *imperative* library (TradingView lightweight-charts), bound via a hand-a
 """
 
 from . import shell, webawesome
-from .form import form  # noqa: F401  (form-from-schema generator)
+from .form import FormField, form  # noqa: F401  (form-from-schema generator + per-field overrides)
 from .lightweight_charts import LightweightChart  # noqa: F401  (an imperative-library wrapper)
 from .shell import *  # noqa: F401,F403  (high-level layout/shell components)
 from .webawesome import *  # noqa: F401,F403  (re-export the generated component classes)

--- a/spaday/components/form.py
+++ b/spaday/components/form.py
@@ -11,6 +11,9 @@ field → control mapping:
 - ``int`` / ``float`` → ``wa-input`` (number)
 - ``Enum`` / ``Literal[...]`` → ``wa-select`` with a ``wa-option`` per choice
 
+Customize per field with `FormField` (drop, relabel, or swap the control) — co-located via
+``Annotated[T, FormField(...)]`` or at the call site via ``form(model, overrides={...})``.
+
 The returned `Stack` is an ordinary component — add a submit `WaButton` with a ``CallEndpoint`` action,
 or wrap it in a card, as you like. Richer schema constraints (min/max/pattern from field metadata) are a
 later refinement; required-ness is surfaced today.
@@ -19,11 +22,32 @@ later refinement; required-ness is surfaced today.
 from __future__ import annotations
 
 import enum
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, Literal, Union, get_args, get_origin
 
 from ..component import Component
 from .shell import Stack
 from .webawesome import WaInput, WaOption, WaSelect, WaSwitch
+
+
+@dataclass(frozen=True)
+class FormField:
+    """Per-field overrides for :func:`form`.
+
+    Attach one of two ways — co-located on the model with ``Annotated[T, FormField(...)]``, or at the
+    call site with ``form(model, overrides={name: FormField(...)})`` (the call-site one wins). Use it to:
+
+    - **drop** a field — ``exclude=True``
+    - **relabel** it — ``label="…"``
+    - **replace its control** — ``control=`` either a ready `Component` (two-way bound to the field on
+      ``value`` for you — good for inputs/selects/radios), or a ``(name, annotation, required) ->
+      Component`` factory you bind yourself (for anything else, e.g. a ``checked`` binding).
+    """
+
+    label: str | None = None
+    exclude: bool = False
+    control: Component | Callable[[str, Any, bool], Component] | None = None
 
 
 def _unwrap_optional(ann: Any) -> Any:
@@ -44,28 +68,50 @@ def _choices(ann: Any):
     return None
 
 
-def _control(name: str, annotation: Any, required: bool) -> Component:
+def _hint(info: Any, override: FormField | None) -> FormField | None:
+    """The effective override for a field — a call-site one wins over an ``Annotated`` one."""
+    if override is not None:
+        return override
+    return next((m for m in info.metadata if isinstance(m, FormField)), None)
+
+
+def _control(name: str, annotation: Any, required: bool, hint: FormField | None) -> Component:
+    if hint is not None and hint.control is not None:
+        control = hint.control
+        if isinstance(control, Component):
+            return control.bind("value", name, mode="two-way")
+        return control(name, annotation, required)
+
+    label = (hint.label if hint else None) or name
     ann = _unwrap_optional(annotation)
     req = required or None  # pass the prop only when True, so it's omitted otherwise
 
     choices = _choices(ann)
     if choices is not None:
-        select = WaSelect(label=name, required=req).bind("value", name, mode="two-way")
-        for value, label in choices:
-            select = select.child(WaOption(value=str(value)).text(str(label)))
+        select = WaSelect(label=label, required=req).bind("value", name, mode="two-way")
+        for value, opt_label in choices:
+            select = select.child(WaOption(value=str(value)).text(str(opt_label)))
         return select
     if ann is bool:
-        return WaSwitch().text(name).bind("checked", name, mode="two-way")
+        return WaSwitch().text(label).bind("checked", name, mode="two-way")
     input_type = "number" if ann in (int, float) else "text"
-    return WaInput(label=name, type=input_type, required=req).bind("value", name, mode="two-way")
+    return WaInput(label=label, type=input_type, required=req).bind("value", name, mode="two-way")
 
 
-def form(model: Any, *, exclude: tuple = ()) -> Stack:
-    """A two-way-bound form for a pydantic model (class or instance); fields in `exclude` are skipped."""
+def form(model: Any, *, exclude: tuple = (), overrides: dict[str, FormField] | None = None) -> Stack:
+    """A two-way-bound form for a pydantic model (class or instance).
+
+    Fields in ``exclude`` are skipped. Per-field tweaks come from `FormField` — either ``Annotated`` on
+    the model, or supplied/overridden here via ``overrides={name: FormField(...)}`` (which wins).
+    """
+    overrides = overrides or {}
     fields = (model if isinstance(model, type) else type(model)).model_fields
     stack = Stack()
     for name, info in fields.items():
         if name in exclude:
             continue
-        stack = stack.child(_control(name, info.annotation, info.is_required()))
+        hint = _hint(info, overrides.get(name))
+        if hint is not None and hint.exclude:
+            continue
+        stack = stack.child(_control(name, info.annotation, info.is_required(), hint))
     return stack

--- a/spaday/components/form.py
+++ b/spaday/components/form.py
@@ -10,9 +10,11 @@ field → control mapping:
 - ``str`` / other → ``wa-input`` (text)
 - ``int`` / ``float`` → ``wa-input`` (number)
 - ``Enum`` / ``Literal[...]`` → ``wa-select`` with a ``wa-option`` per choice
+- a nested **pydantic model** → an expand/collapse ``wa-details`` section whose controls bind to the
+  dotted path ``parent.child`` (the reactive `Store` and ``connectStore`` address nested state by path)
 
-Customize per field with `FormField` (drop, relabel, or swap the control) — co-located via
-``Annotated[T, FormField(...)]`` or at the call site via ``form(model, overrides={...})``.
+Customize per field with `FormField` (drop, relabel, swap the control, or wrap a sub-model group) —
+co-located via ``Annotated[T, FormField(...)]`` or at the call site via ``form(model, overrides={...})``.
 
 The returned `Stack` is an ordinary component — add a submit `WaButton` with a ``CallEndpoint`` action,
 or wrap it in a card, as you like. Richer schema constraints (min/max/pattern from field metadata) are a
@@ -22,13 +24,15 @@ later refinement; required-ness is surfaced today.
 from __future__ import annotations
 
 import enum
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Any, Literal, Union, get_args, get_origin
 
+from pydantic import BaseModel
+
 from ..component import Component
 from .shell import Stack
-from .webawesome import WaInput, WaOption, WaSelect, WaSwitch
+from .webawesome import WaDetails, WaInput, WaOption, WaSelect, WaSwitch
 
 
 @dataclass(frozen=True)
@@ -36,18 +40,23 @@ class FormField:
     """Per-field overrides for :func:`form`.
 
     Attach one of two ways — co-located on the model with ``Annotated[T, FormField(...)]``, or at the
-    call site with ``form(model, overrides={name: FormField(...)})`` (the call-site one wins). Use it to:
+    call site with ``form(model, overrides={path: FormField(...)})`` (the call-site one wins; ``path``
+    is the field name, or a dotted ``parent.child`` to reach a nested field). Use it to:
 
     - **drop** a field — ``exclude=True``
     - **relabel** it — ``label="…"``
     - **replace its control** — ``control=`` either a ready `Component` (two-way bound to the field on
-      ``value`` for you — good for inputs/selects/radios), or a ``(name, annotation, required) ->
-      Component`` factory you bind yourself (for anything else, e.g. a ``checked`` binding).
+      ``value`` for you — good for inputs/selects/radios), or a ``(field, annotation, required) ->
+      Component`` factory you bind yourself (for anything else, e.g. a ``checked`` binding)
+    - **wrap a sub-model group** — ``group=`` a ``(label, inner: Stack) -> Component`` factory; the
+      default is an open ``wa-details`` (expand/collapse). Return a `WaCard`, a `WaDrawer`, or a
+      collapsed ``WaDetails(summary=label)`` to present the nested section differently.
     """
 
     label: str | None = None
     exclude: bool = False
     control: Component | Callable[[str, Any, bool], Component] | None = None
+    group: Callable[[str, Stack], Component] | None = None
 
 
 def _unwrap_optional(ann: Any) -> Any:
@@ -75,43 +84,70 @@ def _hint(info: Any, override: FormField | None) -> FormField | None:
     return next((m for m in info.metadata if isinstance(m, FormField)), None)
 
 
-def _control(name: str, annotation: Any, required: bool, hint: FormField | None) -> Component:
+def _label(name: str, hint: FormField | None) -> str:
+    return (hint.label if hint and hint.label else None) or name
+
+
+def _control(field: str, label: str, annotation: Any, required: bool, hint: FormField | None) -> Component:
     if hint is not None and hint.control is not None:
         control = hint.control
         if isinstance(control, Component):
-            return control.bind("value", name, mode="two-way")
-        return control(name, annotation, required)
+            return control.bind("value", field, mode="two-way")
+        return control(field, annotation, required)
 
-    label = (hint.label if hint else None) or name
     ann = _unwrap_optional(annotation)
     req = required or None  # pass the prop only when True, so it's omitted otherwise
 
     choices = _choices(ann)
     if choices is not None:
-        select = WaSelect(label=label, required=req).bind("value", name, mode="two-way")
+        select = WaSelect(label=label, required=req).bind("value", field, mode="two-way")
         for value, opt_label in choices:
             select = select.child(WaOption(value=str(value)).text(str(opt_label)))
         return select
     if ann is bool:
-        return WaSwitch().text(label).bind("checked", name, mode="two-way")
+        return WaSwitch().text(label).bind("checked", field, mode="two-way")
     input_type = "number" if ann in (int, float) else "text"
-    return WaInput(label=label, type=input_type, required=req).bind("value", name, mode="two-way")
+    return WaInput(label=label, type=input_type, required=req).bind("value", field, mode="two-way")
+
+
+def _group(label: str, prefix: str, submodel: type[BaseModel], exclude, overrides, hint: FormField | None) -> Component:
+    """A nested sub-model → an expand/collapse `wa-details` (or a `FormField.group` wrapper) holding its
+    controls, each bound to the dotted path ``prefix.child``."""
+    inner = Stack()
+    for child in _controls_for(submodel, prefix, exclude, overrides):
+        inner = inner.child(child)
+    if hint is not None and hint.group is not None:
+        return hint.group(label, inner)
+    return WaDetails(summary=label, open=True).child(inner)
+
+
+def _controls_for(model_cls: type[BaseModel], prefix: str, exclude, overrides) -> Iterator[Component]:
+    """The controls for a model's fields, binding each to ``prefix + name`` (recursing sub-models)."""
+    for name, info in model_cls.model_fields.items():
+        path = f"{prefix}{name}"
+        if path in exclude:
+            continue
+        hint = _hint(info, overrides.get(path))
+        if hint is not None and hint.exclude:
+            continue
+        ann = _unwrap_optional(info.annotation)
+        if (hint is None or hint.control is None) and isinstance(ann, type) and issubclass(ann, BaseModel):
+            yield _group(_label(name, hint), f"{path}.", ann, exclude, overrides, hint)
+        else:
+            yield _control(path, _label(name, hint), info.annotation, info.is_required(), hint)
 
 
 def form(model: Any, *, exclude: tuple = (), overrides: dict[str, FormField] | None = None) -> Stack:
     """A two-way-bound form for a pydantic model (class or instance).
 
-    Fields in ``exclude`` are skipped. Per-field tweaks come from `FormField` — either ``Annotated`` on
-    the model, or supplied/overridden here via ``overrides={name: FormField(...)}`` (which wins).
+    Fields in ``exclude`` are skipped (by name, or dotted ``parent.child`` for a nested one). Per-field
+    tweaks come from `FormField` — either ``Annotated`` on the model, or supplied/overridden here via
+    ``overrides={path: FormField(...)}`` (which wins). A nested model field becomes an expand/collapse
+    ``wa-details`` section whose controls bind to ``parent.child`` paths.
     """
     overrides = overrides or {}
-    fields = (model if isinstance(model, type) else type(model)).model_fields
+    model_cls = model if isinstance(model, type) else type(model)
     stack = Stack()
-    for name, info in fields.items():
-        if name in exclude:
-            continue
-        hint = _hint(info, overrides.get(name))
-        if hint is not None and hint.exclude:
-            continue
-        stack = stack.child(_control(name, info.annotation, info.is_required(), hint))
+    for child in _controls_for(model_cls, "", exclude, overrides):
+        stack = stack.child(child)
     return stack

--- a/spaday/tests/test_form.py
+++ b/spaday/tests/test_form.py
@@ -1,9 +1,9 @@
 import enum
-from typing import Literal, Optional
+from typing import Annotated, Literal, Optional
 
 from pydantic import BaseModel
 
-from spaday.components import form
+from spaday.components import FormField, WaInput, form
 
 
 class Color(enum.Enum):
@@ -72,3 +72,42 @@ def test_exclude_skips_fields():
 
 def test_accepts_an_instance():
     assert set(_controls(Settings(name="x"))) == set(Settings.model_fields)
+
+
+class Hinted(BaseModel):
+    name: str = "x"
+    secret: Annotated[str, FormField(exclude=True)] = ""
+    size: Annotated[str, FormField(label="Box size")] = "m"
+    color: Annotated[str, FormField(control=WaInput(label="Pick"))] = "red"
+
+
+def test_annotated_formfield_excludes_and_relabels():
+    c = _controls(Hinted)
+    assert "secret" not in c  # FormField(exclude=True)
+    assert "name" in c
+    assert c["size"]["props"]["label"] == {"Str": "Box size"}  # FormField(label=...)
+
+
+def test_annotated_formfield_swaps_the_control():
+    c = _controls(Hinted)["color"]  # FormField(control=WaInput(label="Pick"))
+    assert c["props"]["label"] == {"Str": "Pick"}
+    assert c["bindings"]["value"]["field"] == "color"  # auto-bound two-way to the field
+    assert c["bindings"]["value"]["mode"] == "two-way"
+
+
+def test_call_site_overrides_win_over_annotated():
+    c = _controls(Hinted, overrides={"size": FormField(label="CALL")})
+    assert c["size"]["props"]["label"] == {"Str": "CALL"}  # call-site beats the Annotated label
+    assert "name" not in _controls(Hinted, overrides={"name": FormField(exclude=True)})
+
+
+def test_control_factory_receives_field_info_and_is_used_as_is():
+    seen = {}
+
+    def factory(name, annotation, required):
+        seen["call"] = (name, annotation, required)
+        return WaInput(label="factory").bind("value", name, mode="two-way")
+
+    c = _controls(Hinted, overrides={"name": FormField(control=factory)})["name"]
+    assert c["props"]["label"] == {"Str": "factory"}
+    assert seen["call"] == ("name", str, False)  # has a default → not required

--- a/spaday/tests/test_form.py
+++ b/spaday/tests/test_form.py
@@ -111,3 +111,46 @@ def test_control_factory_receives_field_info_and_is_used_as_is():
     c = _controls(Hinted, overrides={"name": FormField(control=factory)})["name"]
     assert c["props"]["label"] == {"Str": "factory"}
     assert seen["call"] == ("name", str, False)  # has a default → not required
+
+
+class Address(BaseModel):
+    street: str = "Main"
+    city: str = "NYC"
+
+
+class Person(BaseModel):
+    name: str = "Ada"
+    address: Address = Address()
+
+
+def _children(node):
+    return node["slots"]["default"]
+
+
+def test_sub_model_becomes_an_expand_collapse_group():
+    top = _children(form(Person).to_node())
+    assert top[0]["tag"] == "wa-input"  # name
+    group = top[1]
+    assert group["tag"] == "wa-details"  # a sub-model is a disclosure (expand/collapse) section
+    assert group["props"]["summary"] == {"Str": "address"}
+    assert group["props"]["open"] == {"Bool": True}
+
+
+def test_sub_model_controls_bind_to_dotted_paths():
+    group = _children(form(Person).to_node())[1]
+    inner = _children(group["slots"]["default"][0])  # the wa-details holds a stack of controls
+    assert [next(iter(c["bindings"].values()))["field"] for c in inner] == ["address.street", "address.city"]
+    assert [c["props"]["label"]["Str"] for c in inner] == ["street", "city"]  # child name, not the path
+
+
+def test_nested_field_excluded_by_dotted_path():
+    group = _children(form(Person, exclude=("address.city",)).to_node())[1]
+    inner = _children(group["slots"]["default"][0])
+    assert [next(iter(c["bindings"].values()))["field"] for c in inner] == ["address.street"]
+
+
+def test_group_override_wraps_the_sub_model():
+    from spaday.components import WaCard
+
+    top = _children(form(Person, overrides={"address": FormField(group=lambda label, inner: WaCard().child(inner))}).to_node())
+    assert top[1]["tag"] == "wa-card"  # the custom group wrapper, instead of the default wa-details


### PR DESCRIPTION
Two related steps that take `form()` past flat primitives.

## 1. Per-field customization — `FormField`

`form()` inferred every control from the field type and only let you drop whole fields. `FormField(label=, exclude=, control=, group=)` overrides one field — drop, relabel, swap the control, or wrap a sub-model group — delivered two ways with one type:

```python
# co-located on a model you own:
size: Annotated[Size, FormField(label="Box size")] = Size.medium

# or at the call site (model stays pure — good for config models you don't own):
form(GatewayConfig, overrides={"secret": FormField(exclude=True),
                               "size":   FormField(control=my_radio_group)})
```

The **call-site override wins** over an `Annotated` one. `control=` takes a ready `Component` (two-way bound on `value` for you) or a `(field, annotation, required) -> Component` factory.

## 2. Nested sub-models — nested-path reactive bindings

A sub-model field used to fall through to a text input bound to the *whole* sub-object (broken). Now a nested pydantic model becomes an **expand/collapse `wa-details`** section whose controls bind to dotted `parent.child` paths — and the reactive engine addresses nested state by path:

- `Store.get/set/subscribe` take a dotted path; `set` rebuilds parents immutably and notifies the leaf, its ancestors, and any changed descendant (`signals.ts`)
- `connectStore` flattens an inbound sub-model to dotted fields and deep-sets the path on an outbound edit — the whole model is sent, siblings preserved (`store-sync.ts`)
- `FormField.group=` swaps the default `wa-details` for a `WaCard`, a `WaDrawer`, or a collapsed disclosure

No Rust/transports change — transports already nests, and an edit sends the whole model for the server to diff. The nested-path `Store`/`connectStore` work also benefits hand-authored trees, not just forms.

## Verification

- 14 Python form tests (flat + customization + nested groups / dotted bindings / group override)
- 4 new headless specs (nested `Store` get/set/notify, nested two-way binding, nested inbound flatten, nested outbound deep-set) — **48 JS specs green**
- real transports: hosting a nested model detects a nested mutation; **two-browser end-to-end** — editing a nested field in one fans the nested patch to the other (`street → Oak`, `city` preserved)
