### PR TITLE
fix: chart compacted on initial load (re-fit time scale on resize)

### DIFF
--- a/js/src/ts/wrappers/lightweight-chart.ts
+++ b/js/src/ts/wrappers/lightweight-chart.ts
@@ -38,6 +38,7 @@ export class LightweightChart extends HTMLElement {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- data shape varies by series type
   private _data: any[] = [];
   private _theme: "light" | "dark" = "light";
+  private resizeObserver?: ResizeObserver;
 
   connectedCallback(): void {
     if (!this.style.display) this.style.display = "block";
@@ -50,9 +51,19 @@ export class LightweightChart extends HTMLElement {
     this.applyTheme();
     this.addSeries();
     this.draw();
+    // `autoSize` keeps the canvas matched to the element, but it does not re-fit the time scale. While
+    // the tree is mounting the element can still have zero width, so the initial `fitContent()` in
+    // draw() leaves the series compacted until the next draw(); re-fit on resize so it spans the full
+    // width on the first real layout (and stays fitted on later resizes).
+    this.resizeObserver = new ResizeObserver(() =>
+      this.chart?.timeScale().fitContent(),
+    );
+    this.resizeObserver.observe(this);
   }
 
   disconnectedCallback(): void {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = undefined;
     this.chart?.remove();
     this.chart = undefined;
     this.series = undefined;

--- a/js/tests/lightweight-chart.spec.js
+++ b/js/tests/lightweight-chart.spec.js
@@ -76,3 +76,32 @@ test("a SetProp patch updates the chart's data", async ({ page }) => {
 
   expect(len).toBe(4); // the runtime set the live element's `data` property
 });
+
+test("re-fits the time scale on resize, so it isn't left compacted from a zero-width mount", async ({
+  page,
+}) => {
+  await page.evaluate(
+    (n) => {
+      window.__el = window.__spaday.mount(document.body, n);
+    },
+    node("line", LINE),
+  );
+  await page.waitForFunction(() =>
+    document.querySelector("lightweight-chart canvas"),
+  );
+
+  const fits = await page.evaluate(async () => {
+    const el = window.__el;
+    const ts = el.chart.timeScale(); // TS `private` is compile-time only — the field is live at runtime
+    let count = 0;
+    const orig = ts.fitContent.bind(ts);
+    ts.fitContent = () => {
+      count += 1;
+      return orig();
+    };
+    el.style.width = "200px"; // a real size change → ResizeObserver → the wrapper re-fits
+    await new Promise((r) => setTimeout(r, 150));
+    return count;
+  });
+  expect(fits).toBeGreaterThan(0); // without the resize→fitContent the series stays compacted
+});


### PR DESCRIPTION
**Symptom:** on initial page load a `<lightweight-chart>` renders compacted — the whole series crammed into a narrow band on the right — and only switching the chart's `type` makes it render across the full width.

**Cause:** the wrapper calls `fitContent()` in `draw()` from `connectedCallback`, but while the tree is mounting the element can still have **zero width**, so the series is fitted to ~0px. `autoSize` later widens the *canvas* but never re-fits the *time scale*, so it stays compacted until the next `draw()` — which a `type` switch happens to trigger.

**Fix:** re-fit on resize via a `ResizeObserver`, so the series spans the full width on the first real layout (and stays fitted on later resizes).

**Verified** headless (screenshots): both omnibus charts render full-width on fresh load with no interaction. New regression test asserts the wrapper re-fits when the element resizes. 49 JS specs green.

Found while reviewing the omnibus example (#69), but this is a wrapper-level fix independent of it.