### PR TITLE
examples: window the live chart series (time-keyed map → per-point deltas, bounded snapshot)

### DIFF
--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -51,8 +51,10 @@ is independent per tab.
 
 - **Client-side vs round-trip**: the DSL card runs entirely in the browser; the transports cards
   round-trip edits to the server (authoritative) and fan patches to every client.
-- **Wholesale data patches**: a chart's series is one opaque prop, so each change resends `data`
-  (correct, not minimal); per-point deltas need the series modeled as tree state — later.
+- **Per-point deltas + bounded snapshot**: the live series is a time-keyed **map** capped at a window,
+  so each tick diffs to a 2-op delta (`Set` newest + `Remove` oldest) and every new client's snapshot
+  stays bounded. A positional *list* would resend the whole series on a windowed slide — transports'
+  list diff is positional, so dropping the front re-`Set`s every shifted element.
 - **TradingView logo** is disabled in the chart wrapper; attribution is in the page footer.
 
 ## `reactive.py` — declarative two-way binding over transports

--- a/spaday/examples/__main__.py
+++ b/spaday/examples/__main__.py
@@ -53,6 +53,11 @@ HERE = Path(__file__).parent
 JS = HERE.parent.parent / "js"
 # value-shaped series only — the ticker emits {time, value}; candlestick/bar need OHLC points
 TYPES = ["line", "area", "histogram"]
+# A live series is a time-keyed map capped at WINDOW points. The per-tick patch is already a granular
+# delta either way, but an unbounded list would grow the snapshot every new client downloads forever
+# (the real wholesale cost). A *map* (not a list) is also what keeps the windowed slide granular: dropping
+# the oldest key diffs to one Remove + one Set, where a sliding list re-Sets every shifted element.
+WINDOW = 120
 
 
 def random_walk(n: int, *, seed: int = 7, start: float = 100.0) -> list:
@@ -68,26 +73,36 @@ def random_walk(n: int, *, seed: int = 7, start: float = 100.0) -> list:
 class Chart(BaseModel):
     type: str = "area"
     live: bool = True
-    data: list = Field(default_factory=list)
+    # a time(str) -> value map (not a list): a windowed slide then diffs to Set(newest) + Remove(oldest),
+    # a per-point delta, instead of a positional list shift that re-Sets every element
+    data: dict = Field(default_factory=dict)
 
 
 class ChartSource:
-    """A `Chart` model plus the running state that appends points to it."""
+    """A `Chart` model plus the running state that windows points into it."""
 
     def __init__(self, type: str = "area", seed: int = 0) -> None:
         self._rng = random.Random(seed)
         self._value, self._day = 100.0, date(2023, 1, 1)
-        self.model = Chart(type=type, data=[self._point() for _ in range(60)])
+        self.model = Chart(type=type, data=dict(self._point() for _ in range(WINDOW)))
 
-    def _point(self) -> dict:
+    def _point(self) -> tuple[str, float]:
         self._value += self._rng.uniform(-1.4, 1.5)
-        point = {"time": self._day.isoformat(), "value": round(self._value, 2)}
+        t = self._day.isoformat()
         self._day += timedelta(days=1)
-        return point
+        return t, round(self._value, 2)
 
     def tick(self) -> None:
         if self.model.live:
-            self.model.data = self.model.data + [self._point()]  # reassign so the Session observes it
+            # add the newest point and drop the oldest, keeping the series to WINDOW entries. Because it's
+            # a time-keyed map, the Session diffs this to Set(newest) + Remove(oldest) — a 2-op per-point
+            # delta — and the snapshot every new client downloads stays bounded (not an ever-growing list).
+            data = dict(self.model.data)
+            t, v = self._point()
+            data[t] = v
+            while len(data) > WINDOW:
+                del data[next(iter(data))]
+            self.model.data = data
 
 
 global_src = ChartSource(type="area", seed=7)
@@ -208,7 +223,7 @@ def transports_panel(prefix: str, title: str, chart_type: str) -> object:
             Toolbar()
             .child(select)
             .child(WaSwitch(checked=True).prop("id", f"{prefix}-live").text("Live").on("change", SendPatch(prefix, "live", event_value())))
-            .child(WaButton(variant="neutral").prop("id", f"{prefix}-clear").text("Clear").on("click", SendPatch(prefix, "data", lit([]))))
+            .child(WaButton(variant="neutral").prop("id", f"{prefix}-clear").text("Clear").on("click", SendPatch(prefix, "data", lit({}))))
         )
         .child(LightweightChart(type=chart_type).prop("id", f"{prefix}-chart"))
     )

--- a/spaday/examples/index.html
+++ b/spaday/examples/index.html
@@ -59,6 +59,12 @@
       mount(document.body, node, store); // shell + cards; the action DSL + bindings are wired automatically
 
       const byId = (id) => document.getElementById(id);
+      // The chart series rides the wire as a time-keyed map (so a windowed slide stays a 2-op delta);
+      // lightweight-charts wants a time-sorted array.
+      const series = (d) =>
+        Object.entries(d || {})
+          .map(([time, value]) => ({ time, value }))
+          .sort((a, b) => (a.time < b.time ? -1 : 1));
 
       // Light/dark toggle: flip the `wa-dark` class on <html> (WebAwesome + the shell follow it), and
       // recolor the charts, which are canvases that can't read CSS. (Class/root toggling and the chart
@@ -109,7 +115,7 @@
           const m = model();
           if (!m) return;
           chart.type = m.type;
-          chart.data = m.data;
+          chart.data = series(m.data);
           if (typeSel.value !== m.type) typeSel.value = m.type; // reflect model -> control
           if (liveSw.checked !== m.live) liveSw.checked = m.live;
           status.textContent = "live";


### PR DESCRIPTION
Follow-up to the connection benchmark: cut the per-connection wholesale cost so the omnibus's capacity doesn't decay with uptime.

## Finding

Measured the wire: the per-tick patch is **already** a granular per-point delta — a single `Insert`, 186 B. (The README's "wholesale data patches" note was stale.) The real wholesale cost is the **snapshot** every new connection downloads, and the hosted list grew **unbounded** (1 pt/s, forever).

A naive sliding-window *list* makes it worse: transports' list diff is **positional**, so dropping the front shifts every element → a 120-point slide diffs to **240 `Set` ops** (verified).

## Fix

Model the live series as a **time-keyed map** (`{time: value}`) capped at a window. A windowed slide then diffs to **`Set`(newest) + `Remove`(oldest)** — a 2-op per-point delta — and the snapshot stays **bounded** (~4 KB, constant). Bonus: the map is *smaller* than the list form (no repeated `time`/`value` labels per point). The browser glue sorts the map into the time-sorted array lightweight-charts wants.

## Verified

- Slide patch = `{Set:1, Remove:1}` (in-process `transports.diff`); series stays bounded at 120.
- Headless: the transports chart renders and **slides** (`lastTime` advances while len stays 120), dsl-chart static, no console errors.
