### PR TITLE
examples: multi-worker cluster — one shared chart across uvicorn workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = []
 
 [project.optional-dependencies]
 widget = ["anywidget"]
+examples = ["transports", "starlette", "uvicorn", "websockets"]
+cluster = ["transports", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
 develop = [
     "anywidget",
     "build",

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -72,3 +72,16 @@ and they stay in sync. This is what the omnibus's hand-wired `SendPatch`→sink 
 reactive engine carries it.
 
 Run: `python -m spaday.examples.reactive` → http://127.0.0.1:8001
+
+## `cluster.py` — multi-worker, one shared chart
+
+The scaling/consistency counterpart to the omnibus. One shared, windowed `Chart` is fanned across
+`uvicorn --workers N` by a `RelayBroadcaster` over a `ZmqBackplane`: the **one** elected worker ticks,
+every worker keeps a replica and fans it to its own clients. So a client on **any** worker sees the same
+chart, and a refresh re-fetches the current authoritative snapshot — all tabs always match (unlike a naive
+multi-worker setup, where each worker would tick its own diverging series). The page reconnects on a drop
+(e.g. a worker restart), re-fetching state each time.
+
+Needs a `transports` with the clustering API (`RelayBroadcaster` / `ZmqBackplane`; `pip install pyzmq`).
+
+Run: `uvicorn spaday.examples.cluster:app --workers 4 --port 8003` → http://127.0.0.1:8003

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -23,7 +23,7 @@ with **transports** as the live wire.
 ## Run
 
 ```bash
-pip install transports                       # the Python wire (also: starlette, uvicorn, websockets)
+pip install "spaday[examples]"               # transports (the wire) + starlette + uvicorn + websockets
 cd js && pnpm install && pnpm build && cd .. # builds js/dist; pulls @1kbgz/transports + webawesome
 python -m spaday.examples                    # -> http://127.0.0.1:8000
 ```
@@ -82,6 +82,8 @@ chart, and a refresh re-fetches the current authoritative snapshot — all tabs 
 multi-worker setup, where each worker would tick its own diverging series). The page reconnects on a drop
 (e.g. a worker restart), re-fetching state each time.
 
-Needs a `transports` with the clustering API (`RelayBroadcaster` / `ZmqBackplane`; `pip install pyzmq`).
+Install: `pip install "spaday[cluster]"` (pulls `pyzmq` + the serving deps), with a `transports` that has
+the clustering API (`RelayBroadcaster` / `ZmqBackplane`). Set `SPADAY_CLUSTER_FRONT` / `SPADAY_CLUSTER_BACK`
+to run more than one independent cluster on a host (the default bus addresses are shared otherwise).
 
 Run: `uvicorn spaday.examples.cluster:app --workers 4 --port 8003` → http://127.0.0.1:8003

--- a/spaday/examples/cluster.html
+++ b/spaday/examples/cluster.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>spaday — multi-worker clustered chart</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 2rem; max-width: 60rem; }
+      p { color: #555; line-height: 1.5; }
+      code { background: #f0f0f0; padding: 0 3px; border-radius: 3px; }
+      #status { color: #2962ff; font-size: 0.85rem; }
+    </style>
+  </head>
+  <body>
+    <p>
+      One shared, windowed chart fanned across <code>uvicorn --workers N</code> by a
+      <code>RelayBroadcaster</code>. Only one worker ticks; every worker keeps a replica and fans it to its
+      own clients. Open two tabs (balanced across workers) or refresh — the chart is identical everywhere,
+      because each (re)connect re-fetches the current authoritative snapshot. <span id="status">connecting…</span>
+    </p>
+    <lightweight-chart id="chart" style="height: 320px; display: block"></lightweight-chart>
+    <script type="module">
+      // Only the transports wasm is needed (to decode/apply frames) + the standalone chart wrapper.
+      import "/js/dist/cdn/wrappers/lightweight-chart.js"; // defines <lightweight-chart>
+      import {
+        Client,
+        fromValue,
+        wasm,
+      } from "/js/node_modules/@1kbgz/transports/dist/cdn/index.js";
+
+      await wasm.default({
+        module_or_path:
+          "/js/node_modules/@1kbgz/transports/dist/pkg/transports_bg.wasm",
+      });
+
+      const chart = document.getElementById("chart");
+      chart.type = "area";
+      const status = document.getElementById("status");
+      const series = (d) =>
+        Object.entries(d || {})
+          .map(([time, value]) => ({ time, value }))
+          .sort((a, b) => (a.time < b.time ? -1 : 1));
+
+      const client = new Client();
+      let id = null;
+      function render() {
+        if (id === null) id = client.ids()[0];
+        if (id == null) return;
+        const m = fromValue(client.value(id)); // { data: { time: value } }
+        if (m && m.data) chart.data = series(m.data);
+      }
+
+      // Raw-WS reconnect loop: durable to a worker/server restart, and each (re)connect re-fetches the
+      // snapshot — the page stays in sync with the authoritative chart no matter which worker it lands on.
+      function connect() {
+        const ws = new WebSocket(`ws://${location.host}/ws`);
+        ws.binaryType = "arraybuffer";
+        ws.addEventListener("open", () => (status.textContent = "live"));
+        ws.addEventListener("message", (e) => {
+          client.recv(
+            typeof e.data === "string" ? e.data : new Uint8Array(e.data),
+          );
+          render();
+        });
+        ws.addEventListener("close", () => {
+          status.textContent = "reconnecting…";
+          setTimeout(connect, 1000);
+        });
+      }
+      connect();
+    </script>
+  </body>
+</html>

--- a/spaday/examples/cluster.py
+++ b/spaday/examples/cluster.py
@@ -16,6 +16,7 @@ Then open two tabs (kernel-balanced across workers) and refresh — the chart is
 """
 
 import asyncio
+import os
 import random
 from contextlib import asynccontextmanager
 from datetime import date, timedelta
@@ -43,16 +44,34 @@ class Chart(BaseModel):
 hub = Hub(key=lambda ws: "all")  # one READ tenant: every client fans from the same shared chart
 CHART_SID = hub.share(Chart(), merge=LastWriteWins)  # single writer (the ticker) — no merge conflicts
 hub.subscribe("all", CHART_SID, "read")
-relay = RelayBroadcaster(hub, ZmqBackplane())
+# The ZMQ bus addresses. Override per run (env) so two independent local clusters don't attach to the
+# same proxy and cross-talk — the shared id is deterministic, so a stray second run would corrupt state.
+_FRONT = os.environ.get("SPADAY_CLUSTER_FRONT", "tcp://127.0.0.1:5599")
+_BACK = os.environ.get("SPADAY_CLUSTER_BACK", "tcp://127.0.0.1:5600")
+relay = RelayBroadcaster(hub, ZmqBackplane(_FRONT, _BACK))
 
 
-async def ticker() -> None:
-    """The single cluster-wide ticker (runs only on the elected worker); each update fans to all workers."""
-    rng, value, day, data = random.Random(7), 100.0, date(2023, 1, 1), {}
+def _resume(current: dict):
+    """Continue the walk from the already-caught-up shared chart, or seed a fresh window if it's empty.
+    Returns ``(value, day, data, rng)``. This is what stops an elected/restarted leader from rewinding the
+    cluster to the initial series: it picks up after the last caught-up point instead of re-seeding."""
+    rng = random.Random(7)
+    data = dict(current or {})
+    if data:
+        last = max(data)  # ISO-date keys sort lexically = chronologically
+        return data[last], date.fromisoformat(last) + timedelta(days=1), data, rng
+    value, day = 100.0, date(2023, 1, 1)
     for _ in range(WINDOW):
         value += rng.uniform(-1.4, 1.5)
         data[day.isoformat()] = round(value, 2)
         day += timedelta(days=1)
+    return value, day, data, rng
+
+
+async def ticker() -> None:
+    """The single cluster-wide ticker (runs only on the elected worker); each update fans to all workers.
+    Resumes from the caught-up shared chart (``relay.start()`` ran first), so a leader restart never rewinds."""
+    value, day, data, rng = _resume(transports.from_value(hub.snapshot_shared(CHART_SID)["value"], Chart).data)
     while True:
         await relay.set_shared(CHART_SID, transports.to_value(Chart(data=dict(data))))
         await asyncio.sleep(1.0)

--- a/spaday/examples/cluster.py
+++ b/spaday/examples/cluster.py
@@ -1,0 +1,118 @@
+"""Multi-worker clustering: one shared, windowed chart fanned across ``uvicorn --workers N``.
+
+Each worker runs a :class:`~transports.Hub` holding the same shared ``Chart`` model, bridged to the other
+workers by a :class:`~transports.RelayBroadcaster` over a :class:`~transports.ZmqBackplane`. The **one**
+elected worker drives the ticker (``relay.is_leader``) and publishes each update; every worker keeps a
+replica and fans it to *its own* clients. So a client on **any** worker sees the same chart, and a refresh
+re-fetches the current authoritative snapshot — they always match (unlike a naive multi-worker setup where
+each worker would tick its own diverging series).
+
+    # one process:
+    python -m spaday.examples.cluster                       # -> http://127.0.0.1:8003
+    # the cluster (the point of this example):
+    uvicorn spaday.examples.cluster:app --workers 4 --port 8003
+
+Then open two tabs (kernel-balanced across workers) and refresh — the chart is identical everywhere.
+"""
+
+import asyncio
+import random
+from contextlib import asynccontextmanager
+from datetime import date, timedelta
+from pathlib import Path
+
+import transports
+import uvicorn
+from pydantic import BaseModel, Field
+from starlette.applications import Starlette
+from starlette.responses import FileResponse
+from starlette.routing import Mount, Route, WebSocketRoute
+from starlette.staticfiles import StaticFiles
+from starlette.websockets import WebSocket, WebSocketDisconnect
+from transports import Hub, LastWriteWins, RelayBroadcaster, ZmqBackplane
+
+HERE = Path(__file__).parent
+JS = HERE.parent.parent / "js"
+WINDOW = 120
+
+
+class Chart(BaseModel):
+    data: dict = Field(default_factory=dict)  # ISO date -> value; a time-keyed map (bounded, per-point deltas)
+
+
+hub = Hub(key=lambda ws: "all")  # one READ tenant: every client fans from the same shared chart
+CHART_SID = hub.share(Chart(), merge=LastWriteWins)  # single writer (the ticker) — no merge conflicts
+hub.subscribe("all", CHART_SID, "read")
+relay = RelayBroadcaster(hub, ZmqBackplane())
+
+
+async def ticker() -> None:
+    """The single cluster-wide ticker (runs only on the elected worker); each update fans to all workers."""
+    rng, value, day, data = random.Random(7), 100.0, date(2023, 1, 1), {}
+    for _ in range(WINDOW):
+        value += rng.uniform(-1.4, 1.5)
+        data[day.isoformat()] = round(value, 2)
+        day += timedelta(days=1)
+    while True:
+        await relay.set_shared(CHART_SID, transports.to_value(Chart(data=dict(data))))
+        await asyncio.sleep(1.0)
+        value += rng.uniform(-1.4, 1.5)
+        data[day.isoformat()] = round(value, 2)
+        day += timedelta(days=1)
+        while len(data) > WINDOW:
+            del data[next(iter(data))]
+
+
+async def _send(ws: WebSocket, msg) -> None:
+    await (ws.send_bytes(msg) if isinstance(msg, (bytes, bytearray)) else ws.send_text(msg))
+
+
+async def ws_handler(ws: WebSocket) -> None:
+    await ws.accept()
+    for msg in relay.open(ws):  # the current authoritative snapshot — a (re)connect always refetches
+        await _send(ws, msg)
+    try:
+        while True:
+            frame = await ws.receive()
+            if frame.get("type") == "websocket.disconnect":
+                break
+            data = frame.get("text") if frame.get("text") is not None else frame.get("bytes")
+            if data is None:
+                continue
+            for conn, msgs in relay.recv(ws, data).items():
+                for m in msgs:
+                    await _send(conn, m)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        relay.close(ws)
+
+
+async def homepage(_request):
+    return FileResponse(HERE / "cluster.html")
+
+
+@asynccontextmanager
+async def lifespan(app):
+    await relay.start()  # joins the cluster + catches up to the current chart before serving
+    tasks = [asyncio.create_task(transports.autosync(relay))]
+    if relay.is_leader:  # exactly one worker drives the ticker
+        tasks.append(asyncio.create_task(ticker()))
+    yield
+    for t in tasks:
+        t.cancel()
+    await relay.stop()
+
+
+app = Starlette(
+    routes=[
+        Route("/", homepage),
+        WebSocketRoute("/ws", ws_handler),
+        Mount("/js", StaticFiles(directory=JS)),
+    ],
+    lifespan=lifespan,
+)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8003)  # one worker; add `--workers N` (via the uvicorn CLI) to cluster

--- a/spaday/tests/test_cluster.py
+++ b/spaday/tests/test_cluster.py
@@ -1,0 +1,21 @@
+"""The multi-worker cluster ticker must resume from the caught-up shared chart, never rewind to the seed
+(so an elected/restarted leader doesn't reset every client). Skips unless transports has the clustering
+API installed (RelayBroadcaster/ZmqBackplane)."""
+
+import pytest
+
+cluster = pytest.importorskip("spaday.examples.cluster", reason="needs a transports with the clustering API (RelayBroadcaster/ZmqBackplane)")
+
+
+def test_resume_seeds_only_an_empty_chart():
+    value, day, data, rng = cluster._resume({})
+    assert len(data) == cluster.WINDOW
+    assert min(data) == "2023-01-01"  # a cold start seeds from the beginning
+
+
+def test_resume_continues_from_a_caught_up_chart_without_rewinding():
+    later = {"2023-09-01": 50.0, "2023-09-02": 51.0}
+    value, day, data, rng = cluster._resume(later)
+    assert data == later  # keeps the caught-up window — no rewind to 2023-01-01
+    assert day.isoformat() == "2023-09-03"  # next point is the day after the last
+    assert value == 51.0  # continues from the last value


### PR DESCRIPTION
The scaling/consistency counterpart to the omnibus — and a runnable answer to "two clients should see the same chart, and a refresh should re-fetch."

## What it shows
One shared, windowed `Chart` is fanned across `uvicorn --workers N` by a `RelayBroadcaster` over a `ZmqBackplane`:
- the **one** elected worker (`relay.is_leader`) drives the single ticker and publishes each update;
- every worker keeps a replica (catching up on join) and fans it to **its own** clients.

So a client on **any** worker sees the same chart, and a refresh (or a reconnect that lands on a different worker) re-fetches the current authoritative snapshot. Contrast a naive multi-worker setup, where each worker ticks its own diverging series and tabs drift apart. The page also reconnects on a drop (a worker restart) via a small raw-WS loop, re-fetching each time.

## Verified
Headless under `uvicorn --workers 2`: two tabs (kernel-balanced across the workers) show the **identical 120-point window**; refreshing one re-fetches and **still matches** the other; no console errors.

## Dependency
Uses the transports clustering API (`RelayBroadcaster` / `ZmqBackplane`, `pip install pyzmq`), which landed in transports main (#139) — so it runs against a transports built from main today, and against the next published release. It's an example only; nothing else in spaday imports it.
