### PR TITLE
Finish Phase 3: theming + SSR/hydration

### DIFF
--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -46,7 +46,8 @@ export { parseCem, registry } from "./cem";
 export type { ComponentSchema, PropSchema, PropType } from "./cem";
 
 // Browser runtime: render a component tree to the DOM and apply tree patches incrementally.
-export { mount, applyPatch } from "./runtime";
+// `hydrate` adopts server-rendered HTML (Python `spaday.render_html`) instead of rebuilding.
+export { mount, applyPatch, hydrate } from "./runtime";
 export type { Binding, Node } from "./runtime";
 
 // Reactive engine: a signal store whose fields back the tree's reactive `bindings` (prop ↔ field).

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -58,6 +58,49 @@ export function applyPatch(
   return current;
 }
 
+/**
+ * Hydrate server-rendered HTML (see Python `spaday.render_html`): adopt the existing DOM under
+ * `container` for `tree` instead of rebuilding it — attach event handlers + reactive bindings and
+ * (re)set props (so complex props the HTML couldn't carry, like a chart's data, are applied), reusing
+ * the live elements. Returns the root. Falls back to a full `mount` if nothing was pre-rendered.
+ */
+export function hydrate(
+  container: Element,
+  tree: Node,
+  store?: Store,
+): Element {
+  const el = container.firstElementChild;
+  if (!el) return mount(container, tree, store);
+  hydrateNode(el, tree, store);
+  return el;
+}
+
+function hydrateNode(el: Element, node: Node, store?: Store): void {
+  for (const [name, value] of Object.entries(node.props ?? {})) {
+    setProp(el, name, untag(value)); // re-affirm props; sets complex/property-only ones the HTML omitted
+  }
+  if (node.tag === "spa-show") {
+    wireShow(el, node, store); // structural children are client-mounted (the HTML rendered none)
+  } else {
+    for (const [slot, children] of Object.entries(node.slots ?? {})) {
+      const existing = childrenInSlot(el, slot);
+      children.forEach((child, i) => {
+        if (existing[i]) hydrateNode(existing[i], child, store);
+        else appendInSlot(el, slot, build(child, store)); // HTML missing this child → build it
+      });
+    }
+  }
+  for (const [name, action] of Object.entries(node.events ?? {})) {
+    bindEvent(el, name, action);
+  }
+  if (store) {
+    for (const [prop, spec] of Object.entries(node.bindings ?? {})) {
+      if (node.tag === "spa-show" && prop === "when") continue; // structural — handled by wireShow
+      wireBinding(el, prop, spec, store);
+    }
+  }
+}
+
 // Live action listeners per element, so an incremental patch can update them: the diff engine emits
 // `SetEvent` when an action is added/changed and `RemoveEvent` when one is removed on an existing node.
 const listeners = new WeakMap<Element, Map<string, EventListener>>();

--- a/js/tests/hydrate.spec.js
+++ b/js/tests/hydrate.spec.js
@@ -1,0 +1,105 @@
+import { test, expect } from "@playwright/test";
+
+// `hydrate` adopts server-rendered HTML (Python `spaday.render_html`) instead of rebuilding the tree:
+// it attaches events + bindings and sets non-attribute props on the *existing* DOM elements. These
+// tests pre-populate a container's innerHTML (standing in for the SSR'd HTML) and assert adoption.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/tests/runtime.html");
+  await page.waitForFunction(() => window.__spaday);
+});
+
+const TOGGLE = { kind: "toggle", target: { ref: "this" }, prop: "hidden" };
+
+test("adopts the pre-rendered element (no rebuild) and binds events", async ({
+  page,
+}) => {
+  const result = await page.evaluate(
+    ({ TOGGLE }) => {
+      const { hydrate } = window.__spaday;
+      const c = document.createElement("div");
+      c.innerHTML = "<button>Go</button>"; // the server-rendered HTML
+      const original = c.firstElementChild;
+      original.__orig = true; // a non-serialized marker — survives only if the element is reused
+
+      const root = hydrate(c, {
+        tag: "button",
+        props: { textContent: { Str: "Go" } },
+        events: { click: TOGGLE },
+      });
+      root.click(); // the event the patch-free hydrate bound
+      return {
+        sameElement: root === original && root.__orig === true,
+        hidden: root.hidden,
+      };
+    },
+    { TOGGLE },
+  );
+  expect(result.sameElement).toBe(true); // adopted, not rebuilt
+  expect(result.hidden).toBe(true); // the bound action ran
+});
+
+test("wires two-way bindings to a pre-rendered control", async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const { hydrate, Store } = window.__spaday;
+    const c = document.createElement("div");
+    c.innerHTML = "<input>";
+    const input = c.firstElementChild;
+    const store = new Store();
+    store.set("name", "init");
+
+    hydrate(
+      c,
+      { tag: "input", bindings: { value: { field: "name", mode: "two-way" } } },
+      store,
+    );
+    const initial = input.value; // store field → prop on hydrate
+    input.value = "typed";
+    input.dispatchEvent(new Event("input")); // two-way: control change → store field
+    return { initial, stored: store.get("name") };
+  });
+  expect(result.initial).toBe("init");
+  expect(result.stored).toBe("typed");
+});
+
+test("falls back to a full mount when nothing was pre-rendered", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { hydrate } = window.__spaday;
+    const c = document.createElement("div"); // empty — no SSR
+    const root = hydrate(c, {
+      tag: "section",
+      props: { textContent: { Str: "x" } },
+    });
+    return { tag: root.tagName.toLowerCase(), html: c.innerHTML };
+  });
+  expect(result.tag).toBe("section");
+  expect(result.html).toBe("<section>x</section>");
+});
+
+test("client-mounts spa-show children on hydrate (rendered empty by SSR)", async ({
+  page,
+}) => {
+  const text = await page.evaluate(() => {
+    const { hydrate, Store } = window.__spaday;
+    const c = document.createElement("div");
+    c.innerHTML = '<spa-show style="display:contents"></spa-show>'; // SSR renders the element empty
+    const store = new Store();
+    store.set("on", true);
+    hydrate(
+      c,
+      {
+        tag: "spa-show",
+        props: { style: { Str: "display:contents" } },
+        bindings: { when: { field: "on", mode: "one-way" } },
+        slots: {
+          default: [{ tag: "span", props: { textContent: { Str: "shown" } } }],
+        },
+      },
+      store,
+    );
+    return c.querySelector("spa-show").textContent;
+  });
+  expect(text).toBe("shown"); // the structural subtree was mounted client-side
+});

--- a/js/tests/runtime.html
+++ b/js/tests/runtime.html
@@ -7,6 +7,7 @@
       import {
         mount,
         applyPatch,
+        hydrate,
         interpret,
         tag,
         init,
@@ -18,6 +19,7 @@
       window.__spaday = {
         mount,
         applyPatch,
+        hydrate,
         interpret,
         tag,
         registerHandler,

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -22,7 +22,9 @@ from .actions import (
 )
 from .cem import classes, generate
 from .component import Component, element
+from .render import render_html
 from .spaday import apply, decode_frame, diff, encode_frame, parse_cem  # compiled Rust extension (rust/python)
+from .theme import SHELL_TOKENS
 from .validate import ValidationError, validate
 
 __version__ = "0.1.0"
@@ -41,6 +43,10 @@ __all__ = [
     "classes",
     "Component",
     "element",
+    # server-side rendering (light-DOM HTML for first paint; client hydrates)
+    "render_html",
+    # theming token reference (css custom properties are set via Component.css)
+    "SHELL_TOKENS",
     # build-time validation
     "validate",
     "ValidationError",

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -43,6 +43,13 @@ def _as_node(child: Child) -> dict:
     return child.to_node() if isinstance(child, Component) else child
 
 
+def _css_name(name: str) -> str:
+    """A Python kwarg → its CSS name: drop one trailing ``_``, then ``_`` → ``-`` (``font_size`` → ``font-size``)."""
+    if name.endswith("_"):
+        name = name[:-1]
+    return name.replace("_", "-")
+
+
 class Component:
     """Base for a node in the spaday component tree.
 
@@ -59,6 +66,8 @@ class Component:
         self._slots: Dict[str, List[Child]] = {}
         self._events: Dict[str, dict] = {}
         self._bindings: Dict[str, dict] = {}
+        self._style: Dict[str, str] = {}  # inline CSS declarations + custom properties (theming)
+        self._classes: List[str] = []  # CSS classes (variants / states)
 
     def key(self, key: str) -> "Component":
         """Set the reconciliation key (for keyed child diffing)."""
@@ -87,6 +96,30 @@ class Component:
         """Set an arbitrary prop (escape hatch for attributes a typed class doesn't expose)."""
         if value is not None:
             self._props[name] = value
+        return self
+
+    def style(self, **decls: Any) -> "Component":
+        """Set inline CSS declarations, e.g. ``.style(padding="1rem", font_size="2rem")``.
+
+        Keys are kebab-cased (``font_size`` → ``font-size``; a trailing ``_`` is dropped so reserved
+        words work, ``float_`` → ``float``). Composes with :meth:`css` and any literal ``style`` prop.
+        """
+        self._style.update({_css_name(k): str(v) for k, v in decls.items() if v is not None})
+        return self
+
+    def css(self, **variables: Any) -> "Component":
+        """Set CSS **custom properties** — the theming knob, e.g. ``.css(background_color="navy")`` →
+        ``--background-color: navy``. This is how a web component's documented `--*` theme tokens are
+        set from Python (per component), and how the ``spa-*`` shell is re-themed at the app level
+        (``App().css(spa_surface="#111", spa_border="#333")`` cascades to the whole shell). WebAwesome's
+        own tokens (``--wa-color-*``) are set the same way. See :mod:`spaday.theme`.
+        """
+        self._style.update({"--" + _css_name(k): str(v) for k, v in variables.items() if v is not None})
+        return self
+
+    def classes(self, *names: str) -> "Component":
+        """Add CSS classes (component variants / theme states), e.g. ``.classes("wa-dark")``."""
+        self._classes.extend(n for n in names if n)
         return self
 
     def on(self, event: str, action: Any) -> "Component":
@@ -120,13 +153,26 @@ class Component:
         self._bindings[prop] = {"compute": expr.to_dict(), "mode": "one-way"}
         return self
 
+    def _final_props(self) -> Dict[str, Any]:
+        """Props with theming folded in: ``style``/``class`` merged from :meth:`style`/:meth:`css`/
+        :meth:`classes` (after any literal ``style``/``class`` prop)."""
+        props = dict(self._props)
+        if self._style:
+            decls = "; ".join(f"{k}: {v}" for k, v in self._style.items())
+            props["style"] = f"{props['style']}; {decls}" if props.get("style") else decls
+        if self._classes:
+            names = " ".join(self._classes)
+            props["class"] = f"{props['class']} {names}" if props.get("class") else names
+        return props
+
     def to_node(self) -> dict:
         """The node as the core's JSON-ready dict (empty fields omitted, like the Rust core)."""
         node: dict = {"tag": self.tag}
         if self._key is not None:
             node["key"] = self._key
-        if self._props:
-            node["props"] = {name: _tag(v) for name, v in self._props.items()}
+        props = self._final_props()
+        if props:
+            node["props"] = {name: _tag(v) for name, v in props.items()}
         if self._slots:
             node["slots"] = {slot: [_as_node(c) for c in children] for slot, children in self._slots.items()}
         if self._events:

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -87,3 +87,20 @@ the clustering API (`RelayBroadcaster` / `ZmqBackplane`). Set `SPADAY_CLUSTER_FR
 to run more than one independent cluster on a host (the default bus addresses are shared otherwise).
 
 Run: `uvicorn spaday.examples.cluster:app --workers 4 --port 8003` → http://127.0.0.1:8003
+
+## `ssr.py` — server-side rendering + hydration, with theming
+
+Phase 3.5/3.4. The server renders the tree to **light-DOM HTML** with `spaday.render_html` and ships it
+in the page body, so the structure and text paint immediately (view source — the markup is all there,
+not an empty `<div id="app">`). The browser then **hydrates** with `hydrate(container, tree, store)`: the
+web components upgrade and the runtime *adopts* the existing elements — attaching the button's action and
+the two-way input binding instead of rebuilding the tree. No flash, no double render. Theming is authored
+in Python: `App().css(spa_surface=…, spa_border=…)` re-themes the whole shell via its `--spa-*` tokens,
+and a component's own `.css(background_color=…)` / `.classes(…)` set its CSS custom properties and classes.
+
+This is light-DOM SSR: the elements' shadow-DOM internals render on upgrade in the browser (full
+Declarative-Shadow-DOM SSR would need the component library running server-side). `spa-show` subtrees stay
+client-mounted (structural reactivity is a runtime concern), so the element renders empty and its children
+mount during hydrate.
+
+Run: `python -m spaday.examples.ssr` → http://127.0.0.1:8005

--- a/spaday/examples/ssr.py
+++ b/spaday/examples/ssr.py
@@ -1,0 +1,99 @@
+"""Server-side rendering + hydration (Phase 3.5), with per-component theming (Phase 3.4).
+
+The server renders the component tree to **light-DOM HTML** with :func:`spaday.render_html` and ships it
+in the page body, so the structure and text paint immediately (view source — it's all there, no empty
+``<div id="app">``). The browser then **hydrates**: the web components upgrade and the runtime adopts the
+existing elements, attaching the button's action and the two-way input binding instead of rebuilding the
+tree. Theming is authored in Python — ``App().css(...)`` re-themes the whole shell via its ``--spa-*``
+tokens, and a component's own ``.css()`` sets its CSS custom properties.
+
+Run: ``python -m spaday.examples.ssr`` then open http://127.0.0.1:8005/ (and view source to see the SSR'd
+markup the browser hydrates).
+"""
+
+import json
+from pathlib import Path
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse
+from starlette.routing import Mount, Route
+from starlette.staticfiles import StaticFiles
+
+from spaday import element, render_html
+from spaday.actions import Toggle, by_id
+from spaday.components.shell import App, Body, Main, Nav, Row, Stack
+from spaday.components.webawesome import WaButton
+
+HERE = Path(__file__).parent
+JS = HERE.parent.parent / "js"
+
+
+def build_tree():
+    """The UI: SSR'd structure, with behavior (an action + two-way binding) attached on hydrate."""
+    return (
+        App()
+        .css(spa_surface="#0f172a", spa_surface_2="#1e293b", spa_border="#334155", spa_muted="#94a3b8")  # retheme the shell
+        .style(color="#e2e8f0", min_height="100vh")
+        .child(Nav().child(element("strong").text("spaday SSR — server-rendered, then hydrated")))
+        .child(
+            Body().child(
+                Main().child(
+                    Stack()
+                    .child(element("p").text("This markup was rendered on the server (view source). Behavior attaches on hydrate."))
+                    .child(
+                        Row().child(
+                            WaButton(variant="brand")
+                            .text("Toggle details")
+                            .css(background_color="#6366f1")
+                            .on("click", Toggle(by_id("info"), "hidden"))
+                        )
+                    )
+                    .child(
+                        element("div", id="info")
+                        .style(padding="0.75rem", background="#1e293b", border_radius="8px")
+                        .text("Hidden until you click — the action was attached during hydration, not in the HTML.")
+                    )
+                    .child(
+                        Row()
+                        .child(element("label").text("Name"))
+                        .child(element("input", id="name", type="text").bind("value", "name", mode="two-way"))
+                    )
+                    .child(Row().child(element("span").text("Echo: ")).child(element("strong").bind("textContent", "name")))
+                )
+            )
+        )
+    )
+
+
+PAGE = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>spaday — SSR + hydration</title>
+  </head>
+  <body>
+    <div id="app">{ssr}</div>
+    <script type="application/json" id="tree">{tree}</script>
+    <script type="module">
+      import {{ hydrate, init, Store }} from "/js/dist/esm/index.js";
+      await init({{ module_or_path: "/js/dist/pkg/spaday_bg.wasm" }});
+      const tree = JSON.parse(document.getElementById("tree").textContent);
+      const store = new Store();
+      store.set("name", "world"); // seed the bound state; hydrate writes it onto the live input + echo
+      hydrate(document.getElementById("app"), tree, store);
+    </script>
+  </body>
+</html>"""
+
+
+async def homepage(_request):
+    node = build_tree().to_node()
+    return HTMLResponse(PAGE.format(ssr=render_html(node), tree=json.dumps(node)))
+
+
+app = Starlette(routes=[Route("/", homepage), Mount("/js", StaticFiles(directory=JS))])
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8005)

--- a/spaday/render.py
+++ b/spaday/render.py
@@ -1,0 +1,82 @@
+"""Server-side rendering: a spaday component tree → an HTML string for fast first paint.
+
+:func:`render_html` emits the tree's **light DOM** — tags, scalar props as attributes, text, and
+slotted children — so the page shows structured content immediately. The browser then *hydrates* it
+(``hydrate(container, tree, store)`` in the JS runtime): the web components upgrade and render their own
+shadow DOM client-side, and the runtime **adopts** the existing elements — attaching event handlers and
+reactive bindings and setting non-attribute props — instead of rebuilding the tree. So there is no flash
+and no double render.
+
+What is intentionally *not* rendered here:
+
+- **Web-component shadow DOM.** This is light-DOM SSR; the elements' internals render on upgrade in the
+  browser (full Declarative-Shadow-DOM SSR would need the component library running server-side).
+- **Events / bindings.** Attached on hydrate, not present in the HTML.
+- **Complex props** (lists / maps, e.g. a chart's ``data``) — can't be attributes; set on hydrate.
+- **``spa-show`` children** — structural reactivity is client-side, so the element renders empty and its
+  subtree is mounted during hydrate.
+"""
+
+import html
+from typing import Any, Union
+
+from .component import DEFAULT_SLOT, Component
+
+#: Raw-HTML void elements (no close tag). Web components are never void.
+_VOID = {"area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"}
+
+
+def render_html(tree: Union[Component, dict]) -> str:
+    """Render a component (or an already-built node dict) to a light-DOM HTML string for hydration."""
+    return _render(tree.to_node() if isinstance(tree, Component) else tree, None)
+
+
+def _render(node: dict, slot: str) -> str:
+    tag = node["tag"]
+    attrs = ""
+    if slot and slot != DEFAULT_SLOT:
+        attrs += f' slot="{html.escape(slot, quote=True)}"'  # structural slot position → the slot attribute
+    text = None
+    for name, tagged in node.get("props", {}).items():
+        value = _untag(tagged)
+        if name == "textContent":
+            text = value
+            continue
+        attrs += _attr(name, value)
+    open_close = f"<{tag}{attrs}>"
+    if tag in _VOID:
+        return open_close
+    inner = ""
+    if text is not None:
+        inner = html.escape(str(text))
+    elif tag != "spa-show":  # spa-show children are mounted client-side during hydrate
+        for slot_name, children in node.get("slots", {}).items():
+            for child in children:
+                inner += _render(child, slot_name)
+    return f"{open_close}{inner}</{tag}>"
+
+
+def _attr(name: str, value: Any) -> str:
+    """One prop → its HTML attribute string (``""`` to omit). Complex values are set client-side."""
+    if value is None or isinstance(value, (list, dict)):
+        return ""
+    if value is True:
+        return f" {name}"  # boolean attribute present
+    if value is False:
+        return ""
+    return f' {name}="{html.escape(str(value), quote=True)}"'
+
+
+def _untag(tagged: Any) -> Any:
+    """Decode the core's externally-tagged ``Value`` back to a plain Python value (inverse of ``_tag``)."""
+    if tagged == "Null":
+        return None
+    if isinstance(tagged, dict):
+        for key in ("Bool", "Int", "Float", "Str"):
+            if key in tagged:
+                return tagged[key]
+        if "List" in tagged:
+            return [_untag(v) for v in tagged["List"]]
+        if "Map" in tagged:
+            return {k: _untag(v) for k, v in tagged["Map"].items()}
+    return tagged

--- a/spaday/tests/test_render.py
+++ b/spaday/tests/test_render.py
@@ -1,0 +1,49 @@
+"""Server-side rendering: a component tree → light-DOM HTML for first paint (hydrated client-side)."""
+
+from spaday import element, render_html
+from spaday.actions import Toggle, this
+from spaday.components.shell import App, Main, Show, Stack
+
+
+def test_renders_tag_attrs_and_text():
+    html = render_html(element("div", id="root").child(element("span").text("hi")))
+    assert html == '<div id="root"><span>hi</span></div>'  # matches a mount's innerHTML
+
+
+def test_named_slots_get_the_slot_attribute():
+    card = element("wa-card").child_in("header", element("h3").text("T")).child(element("p").text("B"))
+    html = render_html(card)
+    assert '<h3 slot="header">T</h3>' in html
+    assert "<p>B</p>" in html  # default slot has no slot attribute
+
+
+def test_boolean_and_complex_props_and_behavior():
+    node = (
+        element("input", type="checkbox")
+        .prop("checked", True)
+        .prop("data", [1, 2, 3])  # complex value can't be an attribute — set on hydrate, omitted here
+        .bind("checked", "on", mode="two-way")  # bindings attach on hydrate
+        .on("change", Toggle(this(), "checked"))  # events attach on hydrate
+    )
+    html = render_html(node)
+    assert html == '<input type="checkbox" checked>'  # void element, no close tag; behavior/complex omitted
+
+
+def test_spa_show_renders_empty():
+    # structural reactivity is client-side: the element renders, its subtree is mounted on hydrate
+    html = render_html(Show(field="on").child(element("span").text("x")))
+    assert html == '<spa-show style="display:contents"></spa-show>'
+
+
+def test_escapes_attributes_and_text():
+    html = render_html(element("div", title='a"b<c').text("x<y&z"))
+    assert html == '<div title="a&quot;b&lt;c">x&lt;y&amp;z</div>'
+
+
+def test_renders_a_shell_tree():
+    html = render_html(App().child(Main().child(Stack().child(element("p").text("body")))))
+    assert html == "<spa-app><spa-main><spa-stack><p>body</p></spa-stack></spa-main></spa-app>"
+
+
+def test_accepts_an_already_built_node():
+    assert render_html(element("b").text("x").to_node()) == "<b>x</b>"

--- a/spaday/tests/test_theme.py
+++ b/spaday/tests/test_theme.py
@@ -1,0 +1,37 @@
+"""Per-component theming: CSS custom properties, inline declarations, and classes from Python."""
+
+from spaday import SHELL_TOKENS, element
+
+
+def test_css_sets_custom_properties():
+    props = element("wa-button").css(background_color="navy").to_node()["props"]
+    assert props["style"] == {"Str": "--background-color: navy"}
+
+
+def test_style_sets_inline_declarations_kebab_cased():
+    props = element("div").style(padding="1rem", font_size="2rem").to_node()["props"]
+    assert props["style"] == {"Str": "padding: 1rem; font-size: 2rem"}
+
+
+def test_classes_accumulate():
+    props = element("div").classes("a", "b").classes("c").to_node()["props"]
+    assert props["class"] == {"Str": "a b c"}
+
+
+def test_theming_composes_with_a_literal_style_prop():
+    # a literal style prop (e.g. spa-show's display:contents) survives; theming appends to it
+    props = element("div", style="display:contents").css(spa_surface="#111").to_node()["props"]
+    assert props["style"] == {"Str": "display:contents; --spa-surface: #111"}
+
+
+def test_trailing_underscore_escape():
+    props = element("div").style(float_="left").to_node()["props"]
+    assert props["style"] == {"Str": "float: left"}
+
+
+def test_unthemed_component_stays_prop_free():
+    assert "props" not in element("div").to_node()
+
+
+def test_shell_tokens_reference_is_exposed():
+    assert SHELL_TOKENS["spa_surface"][0] == "--spa-surface"  # css(spa_surface=...) drives this property

--- a/spaday/theme.py
+++ b/spaday/theme.py
@@ -1,0 +1,31 @@
+"""Theming reference for spaday.
+
+Theming is authored on any component with :meth:`~spaday.component.Component.css` (CSS custom
+properties — the theme knobs), :meth:`~spaday.component.Component.style` (inline declarations), and
+:meth:`~spaday.component.Component.classes` (variant/state classes). There is no separate theme object;
+a custom property set on a container cascades, so an **app-level** theme is just ``.css(...)`` on the
+``App`` root.
+
+``SHELL_TOKENS`` documents the ``spa-*`` shell's own override tokens (the ``css()`` kwarg → the CSS
+custom property it drives and what it controls). Each falls back to a WebAwesome ``--wa-color-*`` token,
+so the shell follows the active WebAwesome theme unless overridden::
+
+    from spaday.components.shell import App
+    App().css(spa_surface="#111", spa_border="#333", spa_muted="#999")  # retheme the whole shell
+    WaButton(...).css(background_color="navy")  # a single component's own --background-color token
+"""
+
+#: ``css()`` kwarg → (CSS custom property, what it controls). The shell reads these (see ``js shell.ts``).
+SHELL_TOKENS = {
+    "spa_surface": ("--spa-surface", "nav / footer / app surface color (← --wa-color-surface-default)"),
+    "spa_surface_2": ("--spa-surface-2", "gutter / toolbar surface color (← --wa-color-surface-lowered)"),
+    "spa_border": ("--spa-border", "shell border color (← --wa-color-surface-border)"),
+    "spa_muted": ("--spa-muted", "footer / muted text color (← --wa-color-text-quiet)"),
+    "spa_gap": ("--spa-gap", "default gap between shell children"),
+    "spa_align": ("--spa-align", "cross-axis alignment for Stack / Row / Toolbar"),
+    "spa_justify": ("--spa-justify", "main-axis justification for Row"),
+    "spa_gutter_width": ("--spa-gutter-width", "Gutter width"),
+}
+
+#: WebAwesome design-token prefix; its ``--wa-color-*`` / ``--wa-space-*`` tokens are set via ``css()`` too.
+WA_TOKEN_PREFIX = "--wa-"


### PR DESCRIPTION
Completes spaday **Phase 3 (JS runtime & rendering)** — the two unbuilt pieces, theming and SSR, plus the event-plumbing status. Pure Python + TS; **no Rust/wasm change** (the action interpreter already runs in wasm).

## 3.4 Theming
- `Component.css(**vars)` — CSS **custom properties** (the theme knob): `.css(background_color="navy")` → `--background-color: navy`.
- `Component.style(**decls)` — inline declarations; `Component.classes(*names)` — variant/state classes.
- These fold into the `style`/`class` props. A custom property cascades, so an **app-level** theme is `.css(...)` on the `App` root re-driving the shell's `--spa-*` tokens (each falling back to a WebAwesome `--wa-color-*` token). `spaday.theme.SHELL_TOKENS` documents the shell tokens; `::part` styling stays reachable via an app `<style>`.

## 3.5 SSR + hydration
- **`spaday.render_html(tree)`** (Python) renders the tree's **light DOM** — tags, scalar props → attributes, text, slotted children — for immediate first paint.
- **`hydrate(container, tree, store)`** (TS) **adopts** the existing elements: attaches events + bindings and sets complex/property-only props instead of rebuilding. No flash, no double render. Reuses `build`/`bindEvent`/`wireBinding`/`wireShow`; falls back to `mount` when nothing was pre-rendered.
- Scope: **light-DOM** SSR — web-component shadow DOM and `spa-show` subtrees render client-side on hydrate. Full Declarative-Shadow-DOM SSR (needs the component library server-side) is deferred.
- Example: `spaday/examples/ssr.py` (`python -m spaday.examples.ssr`).

## 3.3 Event plumbing
Complete — the interpreter runs in the wasm core and binds to each node's events on mount/patch (incremental `SetEvent`/`RemoveEvent`). Typed event-`detail` validation is the one deferred refinement (low value, like 2.1's deferred prop-name validation).

## Tests
- Python: `test_render.py` (SSR HTML: attrs/text/slots/boolean+complex omission/`spa-show` empty/escaping/shell tree) + `test_theme.py` (css/style/classes/merge/kebab).
- Browser: `hydrate.spec.js` (adopts existing DOM without rebuild, binds events, wires two-way bindings, `spa-show` client-mount, mount fallback).
- **87 Python + 53 Playwright pass.**

Roadmap updated (Phase 3 → DONE; also marked the now-complete Form 4.3).