### PR TITLE
Validate form input client-side from the schema

### DIFF
--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -155,7 +155,15 @@ function wireBinding(
     if (store.has(spec.field)) setProp(el, prop, store.get(spec.field)); // initial field → prop
     teardowns.push(store.subscribe(spec.field, (v) => setProp(el, prop, v)));
     if (spec.mode === "two-way") {
-      const onChange = () => store.set(spec.field!, readProp(el, prop));
+      const onChange = () => {
+        // Don't propagate an invalid value (e.g. a non-numeric or out-of-range entry in a constrained
+        // control): the store/server keep the last good value and the control shows its own invalid
+        // state. Server-side validation (transports) is still the authority; this just avoids the
+        // doomed round-trip. Controls without constraint validation always pass.
+        const v = el as unknown as { checkValidity?: () => boolean };
+        if (typeof v.checkValidity === "function" && !v.checkValidity()) return;
+        store.set(spec.field!, readProp(el, prop));
+      };
       for (const ev of VALUE_EVENTS) el.addEventListener(ev, onChange);
       teardowns.push(() => {
         for (const ev of VALUE_EVENTS) el.removeEventListener(ev, onChange);

--- a/js/tests/signals.spec.js
+++ b/js/tests/signals.spec.js
@@ -66,6 +66,32 @@ test("two-way binding: a control writes its field, updating other props bound to
   expect(result.bChecked).toBe(true); // ...which flowed to the other bound control
 });
 
+test("two-way binding skips an invalid value (gated on the control's validity)", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ n: 5 });
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "input",
+        props: { type: { Str: "number" }, required: { Bool: true } },
+        bindings: { value: { field: "n", mode: "two-way" } },
+      },
+      store,
+    );
+    root.value = ""; // empty + required → checkValidity() is false: the field must NOT be overwritten
+    root.dispatchEvent(new Event("input"));
+    const afterInvalid = store.get("n");
+    root.value = "42"; // a valid number → written through
+    root.dispatchEvent(new Event("input"));
+    return { afterInvalid, afterValid: store.get("n") };
+  });
+  expect(result.afterInvalid).toBe(5); // the invalid value was not propagated (no doomed edit)
+  expect(result.afterValid).toBe("42"); // a valid value still writes
+});
+
 test("an incremental SetBinding patch wires a binding on a live element", async ({
   page,
 }) => {

--- a/spaday/components/form.py
+++ b/spaday/components/form.py
@@ -17,8 +17,14 @@ Customize per field with `FormField` (drop, relabel, swap the control, or wrap a
 co-located via ``Annotated[T, FormField(...)]`` or at the call site via ``form(model, overrides={...})``.
 
 The returned `Stack` is an ordinary component — add a submit `WaButton` with a ``CallEndpoint`` action,
-or wrap it in a card, as you like. Richer schema constraints (min/max/pattern from field metadata) are a
-later refinement; required-ness is surfaced today.
+or wrap it in a card, as you like.
+
+Validation is surfaced from the schema as native control constraints, so a bad value is caught in the
+browser before it is sent (the runtime's two-way binding won't write/send a value its control reports
+invalid): a non-``Optional`` number or select is ``required`` (it can't be cleared to an empty value the
+model would reject), and ``ge``/``le`` → ``min``/``max``, ``min_length``/``max_length`` →
+``minlength``/``maxlength``, and ``pattern`` become input constraints. Server-side validation (transports)
+remains the authority; this just avoids the doomed round-trip and shows the error inline.
 """
 
 from __future__ import annotations
@@ -28,6 +34,7 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Any, Literal, Union, get_args, get_origin
 
+import annotated_types as at
 from pydantic import BaseModel
 
 from ..component import Component
@@ -68,6 +75,47 @@ def _unwrap_optional(ann: Any) -> Any:
     return ann
 
 
+def _is_optional(ann: Any) -> bool:
+    """True if ``None`` is allowed (``Optional[X]`` / ``X | None``) — the field may be left empty."""
+    return get_origin(ann) is Union and type(None) in get_args(ann)
+
+
+def _required(info: Any) -> bool:
+    """Whether the control must not be left empty. A number or a select can't accept an empty value, so a
+    non-``Optional`` one is required even when it has a default (the bug: clearing a defaulted ``int`` sent
+    ``""``, which the model rejects). For other fields — notably ``str``, where ``""`` is a valid value —
+    keep pydantic's own required-ness (a ``min_length`` still adds a `minlength` constraint below)."""
+    ann = _unwrap_optional(info.annotation)
+    if ann in (int, float) or _choices(ann) is not None:
+        return not _is_optional(info.annotation)
+    return info.is_required()
+
+
+def _constraints(annotation: Any, metadata: Any) -> dict:
+    """Native validation attributes from the field's type + pydantic constraints, so the browser/control
+    validates before an edit is sent: ``ge``/``gt`` → ``min``, ``le``/``lt`` → ``max``,
+    ``min_length``/``max_length`` → ``minlength``/``maxlength``, ``pattern`` → ``pattern``; ints get ``step=1``."""
+    attrs: dict = {}
+    for m in metadata:
+        if isinstance(m, at.Ge):
+            attrs["min"] = m.ge
+        elif isinstance(m, at.Gt):
+            attrs["min"] = m.gt
+        elif isinstance(m, at.Le):
+            attrs["max"] = m.le
+        elif isinstance(m, at.Lt):
+            attrs["max"] = m.lt
+        elif isinstance(m, at.MinLen):
+            attrs["minlength"] = m.min_length
+        elif isinstance(m, at.MaxLen):
+            attrs["maxlength"] = m.max_length
+        elif getattr(m, "pattern", None):
+            attrs["pattern"] = m.pattern
+    if _unwrap_optional(annotation) is int:
+        attrs["step"] = 1  # integers only — no decimals
+    return attrs
+
+
 def _choices(ann: Any):
     """The `(value, label)` choices for an Enum or `Literal[...]`, else `None`."""
     if isinstance(ann, type) and issubclass(ann, enum.Enum):
@@ -88,7 +136,7 @@ def _label(name: str, hint: FormField | None) -> str:
     return (hint.label if hint and hint.label else None) or name
 
 
-def _control(field: str, label: str, annotation: Any, required: bool, hint: FormField | None) -> Component:
+def _control(field: str, label: str, annotation: Any, required: bool, hint: FormField | None, metadata: Any = ()) -> Component:
     if hint is not None and hint.control is not None:
         control = hint.control
         if isinstance(control, Component):
@@ -107,7 +155,10 @@ def _control(field: str, label: str, annotation: Any, required: bool, hint: Form
     if ann is bool:
         return WaSwitch().text(label).bind("checked", field, mode="two-way")
     input_type = "number" if ann in (int, float) else "text"
-    return WaInput(label=label, type=input_type, required=req).bind("value", field, mode="two-way")
+    inp = WaInput(label=label, type=input_type, required=req)
+    for name, value in _constraints(annotation, metadata).items():
+        inp = inp.prop(name, value)  # min / max / step / minlength / maxlength / pattern
+    return inp.bind("value", field, mode="two-way")
 
 
 def _group(label: str, prefix: str, submodel: type[BaseModel], exclude, overrides, hint: FormField | None) -> Component:
@@ -134,7 +185,7 @@ def _controls_for(model_cls: type[BaseModel], prefix: str, exclude, overrides) -
         if (hint is None or hint.control is None) and isinstance(ann, type) and issubclass(ann, BaseModel):
             yield _group(_label(name, hint), f"{path}.", ann, exclude, overrides, hint)
         else:
-            yield _control(path, _label(name, hint), info.annotation, info.is_required(), hint)
+            yield _control(path, _label(name, hint), info.annotation, _required(info), hint, info.metadata)
 
 
 def form(model: Any, *, exclude: tuple = (), overrides: dict[str, FormField] | None = None) -> Stack:

--- a/spaday/tests/test_form.py
+++ b/spaday/tests/test_form.py
@@ -1,7 +1,7 @@
 import enum
 from typing import Annotated, Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from spaday.components import FormField, WaInput, form
 
@@ -50,10 +50,31 @@ def test_numeric_fields_use_number_inputs():
     assert c["name"]["props"]["type"] == {"Str": "text"}
 
 
-def test_required_is_surfaced_from_the_schema():
+def test_required_blocks_empty_where_the_model_cannot_accept_it():
     c = _controls(Settings)
-    assert c["name"]["props"].get("required") == {"Bool": True}  # no default → required
-    assert "required" not in c["count"].get("props", {})  # has a default → not required
+    # A non-Optional number or select can't be left empty — clearing it would send '' (the reported
+    # server crash), so it's required even with a default. A str (where '' is valid) is required only if
+    # it has no default, and an Optional field is never forced required.
+    assert c["name"]["props"]["required"] == {"Bool": True}  # str, no default → required
+    assert c["count"]["props"]["required"] == {"Bool": True}  # int with a default → still required
+    assert c["ratio"]["props"]["required"] == {"Bool": True}  # float → required
+    assert c["color"]["props"]["required"] == {"Bool": True}  # enum select → required
+    assert "required" not in c["note"].get("props", {})  # Optional[str] → may be left empty
+
+
+def test_schema_constraints_become_native_validation_attributes():
+    class Constrained(BaseModel):
+        level: Annotated[int, Field(ge=0, le=100)] = 50
+        short: Annotated[str, Field(min_length=2, max_length=8)] = "ab"
+        code: Annotated[str, Field(pattern="[A-Z]+")] = "AB"
+
+    c = _controls(Constrained)
+    assert c["level"]["props"]["min"] == {"Int": 0}
+    assert c["level"]["props"]["max"] == {"Int": 100}
+    assert c["level"]["props"]["step"] == {"Int": 1}  # int → integer steps only
+    assert c["short"]["props"]["minlength"] == {"Int": 2}
+    assert c["short"]["props"]["maxlength"] == {"Int": 8}
+    assert c["code"]["props"]["pattern"] == {"Str": "[A-Z]+"}
 
 
 def test_enum_and_literal_become_options():


### PR DESCRIPTION
The client-side companion to transports [#143](https://github.com/1kbgz/transports/pull/143) (server-side reject). Together they make the round-trip validation story whole: **catch a bad value in the browser before it's sent**, with the server reject as the authoritative safety net.

The reported crash was clearing the defaulted `int` brightness field → `""` → pydantic `ValidationError`. The form generated a `type="number"` input but, because the field had a default, didn't mark it `required` — so an empty value was "valid" HTML yet invalid for the non-`Optional` `int`.

## Changes
- **`form.py` — validation from the schema as native constraints.** A non-`Optional` **number or select is now `required`** (it can't be cleared to an empty value the model rejects, default or not); `str` keeps pydantic's own required-ness (empty string is valid). And `ge`/`le` → `min`/`max`, `min_length`/`max_length` → `minlength`/`maxlength`, `pattern` → `pattern`; ints get `step=1`. (Closes the form's own "richer constraints are a later refinement" TODO.)
- **`runtime.ts` — validity-gated two-way binding.** On a control change, if the control reports invalid (`checkValidity()` is false), the value is **not** written to the store or sent — the store/server keep the last good value and the control shows its own invalid state. Controls without constraint validation are unaffected.

## Result
Clearing/typing a letter into brightness → the input is invalid → no edit is sent (no doomed round-trip), and the field shows inline. Server-side validation (transports #143) is still the authority for anything the client can't express or a buggy client.

## Tests
- `test_form.py`: a non-Optional number/select is `required` even with a default; schema constraints (`min`/`max`/`step`/`minlength`/`maxlength`/`pattern`) become control attributes.
- `signals.spec.js`: a two-way binding skips an invalid value and still writes a valid one.
- **88 Python + 54 Playwright pass.**