### PR TITLE
Perspective panel follows the host light/dark theme

### DIFF
--- a/js/src/ts/wrappers/perspective-workspace.ts
+++ b/js/src/ts/wrappers/perspective-workspace.ts
@@ -27,6 +27,7 @@ export interface PerspectiveConfig {
 }
 
 const ready = perspective_viewer.init_client(CLIENT_WASM); // one-time wasm init for the viewer/workspace
+const THEMES: Record<string, string> = { light: "Pro Light", dark: "Pro Dark" }; // host theme → Perspective theme
 let stylesInjected = false;
 
 function injectStyles(): void {
@@ -55,6 +56,7 @@ class PerspectivePanel extends HTMLElement {
   #config: PerspectiveConfig = {};
   #connectedUrl: string | null = null;
   #lastLayout: string | null = null; // last restored layout (JSON), to skip redundant restores
+  #theme = "Pro Light"; // current Perspective theme (the viewers/workspace don't follow a wa-dark class)
   #queue: Promise<unknown> = Promise.resolve(); // serialize applies so rapid pushes don't race restore()
 
   connectedCallback(): void {
@@ -65,8 +67,32 @@ class PerspectivePanel extends HTMLElement {
         "perspective-workspace",
       ) as never;
       this.appendChild(this.#workspace as HTMLElement);
+      // a viewer added later (a layout push, or the user dragging in a table) must pick up the theme too
+      this.#workspace.addEventListener("workspace-new-view", () =>
+        this.#applyTheme(),
+      );
     }
     this.#apply();
+  }
+
+  /** The Perspective theme, set by the host's light/dark toggle. Accepts ``"light"``/``"dark"`` (mapped to
+   * ``"Pro Light"``/``"Pro Dark"``) or a literal Perspective theme name; applied to the workspace + every
+   * viewer, since Perspective has its own theme system and won't follow a page ``wa-dark`` class. */
+  set theme(name: string) {
+    this.#theme = THEMES[name] ?? name;
+    this.#applyTheme();
+  }
+  get theme(): string {
+    return this.#theme;
+  }
+
+  #applyTheme(): void {
+    const ws = this.#workspace;
+    if (!ws) return;
+    ws.setAttribute("theme", this.#theme); // the workspace chrome (tabs/dock)
+    for (const v of ws.querySelectorAll("perspective-viewer")) {
+      v.setAttribute("theme", this.#theme);
+    }
   }
 
   /** The transports-synced config. Re-setting it (a server push) re-applies — a new layout re-`restore`s. */
@@ -98,6 +124,7 @@ class PerspectivePanel extends HTMLElement {
             await ws.restore(config.layout); // wipe a user's manual arrangement; a pushed new layout applies
           }
         }
+        this.#applyTheme(); // re-assert the current theme over any theme baked into the (re)stored layout
       });
   }
 

--- a/spaday/examples/index.html
+++ b/spaday/examples/index.html
@@ -69,14 +69,18 @@
           .sort((a, b) => (a.time < b.time ? -1 : 1));
 
       // Light/dark toggle: flip the `wa-dark` class on <html> (WebAwesome + the shell follow it), and
-      // recolor the charts, which are canvases that can't read CSS. (Class/root toggling and the chart
-      // theme are page chrome the action DSL doesn't model yet, so they're wired here.)
+      // recolor the charts + Perspective, which have their own theme systems and can't read the class.
+      // (Class/root toggling and these element themes are page chrome the action DSL doesn't model yet.)
       byId("theme-toggle").addEventListener("change", (e) => {
         const dark = e.target.checked;
+        const theme = dark ? "dark" : "light";
         document.documentElement.classList.toggle("wa-dark", dark);
         document
           .querySelectorAll("lightweight-chart")
-          .forEach((c) => (c.theme = dark ? "dark" : "light"));
+          .forEach((c) => (c.theme = theme));
+        document
+          .querySelectorAll("perspective-panel")
+          .forEach((p) => (p.theme = theme));
       });
 
       // The controls' edits are now declarative `SendPatch` actions; each fires a `spaday:patch`


### PR DESCRIPTION
**Reported:** in the omnibus, toggling light/dark re-themed the lightweight charts but the Perspective panel stayed light.

**Cause:** Perspective has its own theme system (`"Pro Light"` / `"Pro Dark"`) and doesn't follow the page's `wa-dark` class — same situation as the canvas charts, which the toggle already handles explicitly.

**Fix:** `PerspectivePanel` gains a `theme` setter (mirroring `LightweightChart`'s): accepts `"light"`/`"dark"` (→ `"Pro Light"`/`"Pro Dark"`) or a literal theme name, and sets the `theme` attribute on the workspace (chrome) and every `<perspective-viewer>`. It re-applies after a layout push/restore and on `workspace-new-view`, so a pushed or user-dragged view stays themed. The omnibus toggle now drives `perspective-panel.theme` next to the charts.

**Verified** headless: toggling flips both the `workspace` and `viewer` theme attributes `Pro Light` ↔ `Pro Dark` live, and the chrome visibly re-themes.