### PR TITLE
Flask + Tornado backends (tested)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ develop = [
     "check-dist",
     "cibuildwheel",
     "codespell",
+    "flask",  # the Flask backend — covered by test_backend_flask
     "hatch-js",
     "hatch-rs",
     "hatchling",
@@ -57,6 +58,7 @@ develop = [
     "pytest-cov",
     "ruff",
     "starlette",  # the Starlette backend — covered by test_backend_starlette (import spaday stays starlette-free)
+    "tornado",  # the Tornado backend — covered by test_backend_tornado
     "twine",
     "ty",
     "uv",

--- a/spaday/backends/__init__.py
+++ b/spaday/backends/__init__.py
@@ -4,8 +4,10 @@ The framework-agnostic generation (the page HTML, the tree JSON/frame, the bundl
 :mod:`spaday.bootstrap`; each module here wires it into one webserver's routing/static/lifecycle and
 adds the few backend-specific conveniences that make sense. Pick your backend explicitly::
 
-    from spaday.backends.starlette import serve   # Starlette / FastAPI
-    from spaday.backends.aiohttp import serve      # aiohttp
+    from spaday.backends.starlette import serve   # Starlette / FastAPI (async; full transports wire)
+    from spaday.backends.aiohttp import serve      # aiohttp (async)
+    from spaday.backends.tornado import serve      # Tornado (async)
+    from spaday.backends.flask import serve        # Flask (WSGI; static-focused — no async wire)
 
 There is deliberately no opaque top-level ``spaday.serve`` catch-all: the backend is part of the app's
 choice, and a clear seam (a little more code) beats hidden framework coupling. A backend not covered here

--- a/spaday/backends/flask.py
+++ b/spaday/backends/flask.py
@@ -1,0 +1,57 @@
+"""Flask (WSGI) backend: ``serve(page, …) -> flask.Flask``.
+
+Wires :mod:`spaday.bootstrap` into a Flask app — ``GET /`` (the page), ``GET /tree.json`` or ``GET /tree``
+(the tree), ``GET /js/<path>`` (the bundles), plus any ``routes`` you splice in. Flask is **WSGI
+(synchronous)**, so there is no async lifecycle here: background coroutines and the transports websocket
+are out of scope — with ``wire="transports"`` the generated client still expects a ``/ws`` endpoint +
+``autosync``, which you supply with an async extension (flask-sock + a loop) or, more simply, an async
+backend (aiohttp / Starlette). Static pages (``wire=None``) run as-is.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Sequence, Union
+
+from ..bootstrap import Page, bootstrap, bundles_dir, tree_frame, tree_json
+
+if TYPE_CHECKING:  # annotations only — flask is imported inside serve() (not a spaday dependency)
+    from flask import Flask
+
+
+def serve(
+    page: Page,
+    *,
+    routes: Sequence = (),
+    js: Optional[Union[str, Path]] = None,
+    title: str = "spaday",
+    bundles: Sequence[str] = (),
+    wire: Optional[str] = None,
+    ws: str = "/ws",
+    tree: str = "json",
+    reconnect: bool = False,
+    scripts: Sequence[str] = (),
+    head: str = "",
+) -> Flask:
+    """Build a Flask app serving ``page`` (a Component or a callable returning one).
+
+    Generation options (``bundles``/``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``/``title``)
+    are passed through to :func:`spaday.bootstrap.bootstrap`. ``routes`` is a list of
+    ``(rule, endpoint, view_func)`` tuples added via ``app.add_url_rule``; ``js`` overrides the served
+    bundle dir (defaults to :func:`~spaday.bootstrap.bundles_dir`).
+    """
+    from flask import Flask, Response, send_from_directory
+
+    body = bootstrap(bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
+    js_dir = str(js) if js is not None else str(bundles_dir())
+
+    app = Flask(__name__)
+    app.add_url_rule("/", "spaday_index", lambda: Response(body, mimetype="text/html"))
+    if tree == "frame":
+        app.add_url_rule("/tree", "spaday_tree", lambda: Response(tree_frame(page), mimetype="application/octet-stream"))
+    else:
+        app.add_url_rule("/tree.json", "spaday_tree", lambda: Response(tree_json(page), mimetype="application/json"))
+    app.add_url_rule("/js/<path:path>", "spaday_js", lambda path: send_from_directory(js_dir, path))
+    for rule in routes:
+        app.add_url_rule(*rule)
+    return app

--- a/spaday/backends/tornado.py
+++ b/spaday/backends/tornado.py
@@ -1,0 +1,83 @@
+"""Tornado backend: ``serve(page, …) -> tornado.web.Application``.
+
+Wires :mod:`spaday.bootstrap` into a Tornado application — ``GET /`` (the page), ``GET /tree.json`` or
+``GET /tree`` (the tree), ``GET /js/(.*)`` (the bundles via ``StaticFileHandler``), plus any ``routes``
+you splice in. ``background`` coroutines are scheduled on the IOLoop (they start when you run it). Run the
+returned app the usual way::
+
+    app = serve(page, ...)
+    app.listen(8000)
+    tornado.ioloop.IOLoop.current().start()
+
+As with aiohttp, the transports ``/ws`` endpoint (when ``wire="transports"``) is yours to add via
+``routes`` (Tornado has its own ``WebSocketHandler``); static pages need no websocket.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Awaitable, Optional, Sequence, Union
+
+from ..bootstrap import Page, bootstrap, bundles_dir, tree_frame, tree_json
+
+if TYPE_CHECKING:  # annotations only — tornado is imported inside serve() (not a spaday dependency)
+    from tornado.web import Application
+
+
+def serve(
+    page: Page,
+    *,
+    routes: Sequence = (),
+    js: Optional[Union[str, Path]] = None,
+    title: str = "spaday",
+    bundles: Sequence[str] = (),
+    wire: Optional[str] = None,
+    ws: str = "/ws",
+    tree: str = "json",
+    reconnect: bool = False,
+    scripts: Sequence[str] = (),
+    head: str = "",
+    background: Sequence[Awaitable] = (),
+) -> Application:
+    """Build a Tornado application serving ``page`` (a Component or a callable returning one).
+
+    Generation options (``bundles``/``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``/``title``)
+    are passed through to :func:`spaday.bootstrap.bootstrap`. ``routes`` is a list of Tornado handler
+    tuples (``(pattern, Handler[, kwargs])`` — including your ``/ws`` handler when wiring transports);
+    ``js`` overrides the served bundle dir (defaults to :func:`~spaday.bootstrap.bundles_dir`);
+    ``background`` coroutines are scheduled on the IOLoop and run once it starts.
+    """
+    from tornado.ioloop import IOLoop
+    from tornado.web import Application, RequestHandler, StaticFileHandler
+
+    body = bootstrap(bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
+    js_dir = str(js) if js is not None else str(bundles_dir())
+
+    class _Index(RequestHandler):
+        def get(self):
+            self.set_header("Content-Type", "text/html")
+            self.write(body)
+
+    if tree == "frame":
+
+        class _Tree(RequestHandler):
+            def get(self):
+                self.set_header("Content-Type", "application/octet-stream")
+                self.write(tree_frame(page))
+
+        tree_rule = (r"/tree", _Tree)
+    else:
+
+        class _Tree(RequestHandler):
+            def get(self):
+                self.set_header("Content-Type", "application/json")
+                self.write(tree_json(page))
+
+        tree_rule = (r"/tree\.json", _Tree)
+
+    handlers = [(r"/", _Index), tree_rule, *routes, (r"/js/(.*)", StaticFileHandler, {"path": js_dir})]
+    app = Application(handlers)
+    for coro in background:  # scheduled now, spawned when the IOLoop runs
+        IOLoop.current().add_callback(asyncio.ensure_future, coro)
+    return app

--- a/spaday/tests/test_backend_flask.py
+++ b/spaday/tests/test_backend_flask.py
@@ -1,0 +1,14 @@
+import pytest
+
+pytest.importorskip("flask")  # the Flask (WSGI) backend — flask is not a spaday dependency
+
+from spaday.backends.flask import serve  # noqa: E402
+from spaday.components.shell import Main  # noqa: E402
+
+
+def test_serve_hosts_page_and_tree(tmp_path):
+    page = Main("hi")
+    client = serve(page, js=tmp_path, bundles=["webawesome"], wire="transports").test_client()
+    home = client.get("/").get_data(as_text=True)
+    assert "connectStore" in home and "webawesome.css" in home  # the generated bootstrap + bundle
+    assert client.get("/tree.json").get_json() == page.to_node()  # tree served as JSON

--- a/spaday/tests/test_backend_tornado.py
+++ b/spaday/tests/test_backend_tornado.py
@@ -1,0 +1,21 @@
+import json
+
+import pytest
+
+pytest.importorskip("tornado")  # the Tornado backend — tornado is not a spaday dependency
+
+from tornado.testing import AsyncHTTPTestCase  # noqa: E402
+
+from spaday.backends.tornado import serve  # noqa: E402
+from spaday.components.shell import Main  # noqa: E402
+
+
+class TestTornadoBackend(AsyncHTTPTestCase):
+    def get_app(self):
+        # bundles_dir() (the real js/) backs the /js StaticFileHandler; the test only fetches / and /tree.json
+        return serve(Main("hi"), bundles=["webawesome"], wire="transports")
+
+    def test_serve_hosts_page_and_tree(self):
+        home = self.fetch("/").body.decode()
+        assert "connectStore" in home and "webawesome.css" in home  # the generated bootstrap + bundle
+        assert json.loads(self.fetch("/tree.json").body) == Main("hi").to_node()  # tree served as JSON


### PR DESCRIPTION
Two more backends over the framework-agnostic `spaday.bootstrap` layer (follows #83), each tested with its dep in the `develop` extra.

- **`backends/flask.py`** (Flask, WSGI) — serves the page, tree, `/js`, and custom routes. WSGI is synchronous, so background coroutines and the transports websocket are out of scope (the docstring points to an async backend for the wire); **static pages run as-is**. Custom `routes` are `(rule, endpoint, view_func)` tuples.
- **`backends/tornado.py`** (Tornado) — page/tree/`/js` handlers + custom handler tuples; `background` coroutines scheduled on the IOLoop. The `/ws` endpoint (with `wire="transports"`) is yours to add via `routes` (Tornado has its own `WebSocketHandler`).

Backends shipped now: **starlette, aiohttp, flask, tornado**. Adding another is still a handful of routes over `bootstrap()` / `tree_json()` / `tree_frame()` / `bundles_dir()`.

## Tests
`test_backend_flask.py` (Flask `test_client`) and `test_backend_tornado.py` (Tornado `AsyncHTTPTestCase`); `flask` + `tornado` added to `develop` so CI covers both. 114 Python pass; ruff clean.

## Roadmap (brainstorm recorded in 4.6)
Recorded the **granular-integration** seams that make spaday embeddable in a bigger app, smallest-first:
- `mount(app, page, …)` per backend — add spaday's routes to an *existing* app instead of building one (the key primitive).
- Prefix/base-path awareness (`bootstrap(base="/dashboard")`) so spaday lives under a sub-path and multiple pages coexist.
- Fragment/embed mode (`bootstrap(fragment=True, target="#widget")`) — emit just the `<script>` to drop into the host's template, not a full document.
- Configurable asset prefix/CDN (`bootstrap(js_prefix=…)`); bring-your-own-wire via the `connectStore` seam.

All pure additions over `spaday.bootstrap` (no backend lock-in). Happy to take `mount()` + prefix next — they're the highest-leverage for "drop into a bigger app."