### PR TITLE
mount() + path prefix: embed a spaday page in an existing app

### DIFF
--- a/spaday/backends/__init__.py
+++ b/spaday/backends/__init__.py
@@ -9,8 +9,11 @@ adds the few backend-specific conveniences that make sense. Pick your backend ex
     from spaday.backends.tornado import serve      # Tornado (async)
     from spaday.backends.flask import serve        # Flask (WSGI; static-focused — no async wire)
 
-There is deliberately no opaque top-level ``spaday.serve`` catch-all: the backend is part of the app's
-choice, and a clear seam (a little more code) beats hidden framework coupling. A backend not covered here
-is a handful of routes over :func:`spaday.bootstrap.bootstrap` / :func:`~spaday.bootstrap.tree_json` /
-:func:`~spaday.bootstrap.tree_frame` / :func:`~spaday.bootstrap.bundles_dir`.
+Each backend exposes two functions: ``mount(app, page, *, prefix="", …)`` adds spaday's routes to an
+**existing** app (so it drops into a bigger app, optionally under a path ``prefix``), and ``serve(page, …)``
+creates an app and mounts onto it. There is deliberately no opaque top-level ``spaday.serve`` catch-all:
+the backend is part of the app's choice, and a clear seam (a little more code) beats hidden framework
+coupling. A backend not covered here is a handful of routes over :func:`spaday.bootstrap.bootstrap` /
+:func:`~spaday.bootstrap.tree_json` / :func:`~spaday.bootstrap.tree_frame` /
+:func:`~spaday.bootstrap.bundles_dir`.
 """

--- a/spaday/backends/aiohttp.py
+++ b/spaday/backends/aiohttp.py
@@ -1,13 +1,13 @@
-"""aiohttp backend: ``serve(page, …) -> aiohttp.web.Application``.
+"""aiohttp backend.
 
-Wires :mod:`spaday.bootstrap` into an aiohttp app — ``GET /`` (the page), ``GET /tree.json`` or
-``GET /tree`` (the tree), a ``/js`` static route (the bundles), plus any ``routes`` you splice in and
-``background`` coroutines run for the app's lifetime. aiohttp is imported inside ``serve()`` so importing
-spaday never requires it.
+- ``mount(app, page, *, prefix="", …)`` — add spaday's routes to an **existing** ``aiohttp.web.Application``
+  (call before the app runs; the router freezes on startup).
+- ``serve(page, …) -> aiohttp.web.Application`` — create an app, ``mount`` onto it, and run ``background``
+  coroutines for its lifetime.
 
-The transports websocket is **not** generated here: aiohttp has its own websocket API, so the ``/ws``
-endpoint (when ``wire="transports"``) is yours to add via ``routes`` (e.g. a transports aiohttp adapter).
-Static pages (``wire=None``) need no websocket and run as-is.
+aiohttp is imported inside the functions so importing spaday never requires it. The transports websocket
+is **not** generated here (aiohttp owns its websocket API): add the ``{prefix}/ws`` handler via ``routes``
+when ``wire="transports"``. Static pages (``wire=None``) run as-is.
 """
 
 from __future__ import annotations
@@ -18,13 +18,15 @@ from typing import TYPE_CHECKING, Awaitable, Optional, Sequence, Union
 
 from ..bootstrap import Page, bootstrap, bundles_dir, tree_frame, tree_json
 
-if TYPE_CHECKING:  # annotations only — aiohttp is imported inside serve() (it is not a spaday dependency)
+if TYPE_CHECKING:  # annotations only — aiohttp is imported inside the functions (not a spaday dependency)
     from aiohttp import web
 
 
-def serve(
+def mount(
+    app: web.Application,
     page: Page,
     *,
+    prefix: str = "",
     routes: Sequence = (),
     js: Optional[Union[str, Path]] = None,
     title: str = "spaday",
@@ -35,20 +37,14 @@ def serve(
     reconnect: bool = False,
     scripts: Sequence[str] = (),
     head: str = "",
-    background: Sequence[Awaitable] = (),
 ) -> web.Application:
-    """Build an aiohttp application serving ``page`` (a Component or a callable returning one).
-
-    Generation options (``bundles``/``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``/``title``)
-    are passed through to :func:`spaday.bootstrap.bootstrap`. ``routes`` is a list of ``aiohttp.web``
-    route defs (``web.get(...)`` / ``web.post(...)`` — including your ``/ws`` handler when wiring
-    transports); ``js`` overrides the served bundle dir (defaults to
-    :func:`~spaday.bootstrap.bundles_dir`); ``background`` coroutines run as tasks for the app's lifetime
-    and are cancelled on cleanup.
-    """
+    """Add spaday's routes to an existing aiohttp ``app`` under ``prefix``. ``routes`` is a list of
+    ``aiohttp.web`` route defs (``web.get(...)`` — including your ``{prefix}/ws`` handler when wiring
+    transports). Returns ``app`` for chaining."""
     from aiohttp import web
 
-    body = bootstrap(bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
+    body = bootstrap(base=prefix, bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
+    js_dir = str(js) if js is not None else str(bundles_dir())
 
     async def homepage(_request):
         return web.Response(text=body, content_type="text/html")
@@ -58,13 +54,26 @@ def serve(
         async def tree_handler(_request):
             return web.Response(body=tree_frame(page), content_type="application/octet-stream")
 
-        tree_route = web.get("/tree", tree_handler)
+        tree_route = web.get(f"{prefix}/tree", tree_handler)
     else:
 
         async def tree_handler(_request):
             return web.Response(text=tree_json(page), content_type="application/json")
 
-        tree_route = web.get("/tree.json", tree_handler)
+        tree_route = web.get(f"{prefix}/tree.json", tree_handler)
+
+    app.add_routes([web.get(f"{prefix}/", homepage), tree_route, *routes])
+    app.router.add_static(f"{prefix}/js", js_dir)
+    return app
+
+
+def serve(page: Page, *, background: Sequence[Awaitable] = (), **opts) -> web.Application:
+    """Create an aiohttp app and :func:`mount` ``page`` onto it. ``background`` coroutines run for the
+    app's lifetime; all other keyword options are :func:`mount`'s."""
+    from aiohttp import web
+
+    app = web.Application()
+    mount(app, page, **opts)
 
     tasks = []  # closed over by the startup/cleanup hooks (avoids an aiohttp app-key)
 
@@ -75,9 +84,6 @@ def serve(
         for task in tasks:
             task.cancel()
 
-    app = web.Application()
-    app.add_routes([web.get("/", homepage), tree_route, *routes])
-    app.router.add_static("/js", str(js) if js is not None else str(bundles_dir()))
     app.on_startup.append(_start_bg)
     app.on_cleanup.append(_stop_bg)
     return app

--- a/spaday/backends/flask.py
+++ b/spaday/backends/flask.py
@@ -1,11 +1,12 @@
-"""Flask (WSGI) backend: ``serve(page, …) -> flask.Flask``.
+"""Flask (WSGI) backend.
 
-Wires :mod:`spaday.bootstrap` into a Flask app — ``GET /`` (the page), ``GET /tree.json`` or ``GET /tree``
-(the tree), ``GET /js/<path>`` (the bundles), plus any ``routes`` you splice in. Flask is **WSGI
-(synchronous)**, so there is no async lifecycle here: background coroutines and the transports websocket
-are out of scope — with ``wire="transports"`` the generated client still expects a ``/ws`` endpoint +
-``autosync``, which you supply with an async extension (flask-sock + a loop) or, more simply, an async
-backend (aiohttp / Starlette). Static pages (``wire=None``) run as-is.
+- ``mount(app, page, *, prefix="", …)`` — add spaday's routes to an **existing** Flask app.
+- ``serve(page, …) -> flask.Flask`` — create an app and ``mount`` onto it.
+
+Flask is **WSGI (synchronous)**, so there is no async lifecycle here: background coroutines and the
+transports websocket are out of scope — with ``wire="transports"`` the generated client still expects a
+``{prefix}/ws`` endpoint + ``autosync``, which you supply with an async extension (flask-sock + a loop)
+or, more simply, an async backend (aiohttp / Starlette). Static pages (``wire=None``) run as-is.
 """
 
 from __future__ import annotations
@@ -15,13 +16,15 @@ from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 from ..bootstrap import Page, bootstrap, bundles_dir, tree_frame, tree_json
 
-if TYPE_CHECKING:  # annotations only — flask is imported inside serve() (not a spaday dependency)
+if TYPE_CHECKING:  # annotations only — flask is imported inside the functions (not a spaday dependency)
     from flask import Flask
 
 
-def serve(
+def mount(
+    app: Flask,
     page: Page,
     *,
+    prefix: str = "",
     routes: Sequence = (),
     js: Optional[Union[str, Path]] = None,
     title: str = "spaday",
@@ -33,25 +36,30 @@ def serve(
     scripts: Sequence[str] = (),
     head: str = "",
 ) -> Flask:
-    """Build a Flask app serving ``page`` (a Component or a callable returning one).
+    """Add spaday's routes to an existing Flask ``app`` under ``prefix``. ``routes`` is a list of
+    ``(rule, endpoint, view_func)`` tuples. Endpoints are keyed by ``prefix`` so several spaday pages can
+    share one app. Returns ``app`` for chaining."""
+    from flask import Response, send_from_directory
 
-    Generation options (``bundles``/``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``/``title``)
-    are passed through to :func:`spaday.bootstrap.bootstrap`. ``routes`` is a list of
-    ``(rule, endpoint, view_func)`` tuples added via ``app.add_url_rule``; ``js`` overrides the served
-    bundle dir (defaults to :func:`~spaday.bootstrap.bundles_dir`).
-    """
-    from flask import Flask, Response, send_from_directory
-
-    body = bootstrap(bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
+    body = bootstrap(base=prefix, bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
     js_dir = str(js) if js is not None else str(bundles_dir())
+    key = prefix.strip("/").replace("/", "_") or "root"  # unique endpoint names per mount
 
-    app = Flask(__name__)
-    app.add_url_rule("/", "spaday_index", lambda: Response(body, mimetype="text/html"))
+    app.add_url_rule(f"{prefix}/", f"spaday_index_{key}", lambda: Response(body, mimetype="text/html"))
     if tree == "frame":
-        app.add_url_rule("/tree", "spaday_tree", lambda: Response(tree_frame(page), mimetype="application/octet-stream"))
+        app.add_url_rule(f"{prefix}/tree", f"spaday_tree_{key}", lambda: Response(tree_frame(page), mimetype="application/octet-stream"))
     else:
-        app.add_url_rule("/tree.json", "spaday_tree", lambda: Response(tree_json(page), mimetype="application/json"))
-    app.add_url_rule("/js/<path:path>", "spaday_js", lambda path: send_from_directory(js_dir, path))
+        app.add_url_rule(f"{prefix}/tree.json", f"spaday_tree_{key}", lambda: Response(tree_json(page), mimetype="application/json"))
+    app.add_url_rule(f"{prefix}/js/<path:path>", f"spaday_js_{key}", lambda path: send_from_directory(js_dir, path))
     for rule in routes:
         app.add_url_rule(*rule)
     return app
+
+
+def serve(page: Page, *, import_name: str = "spaday", **opts) -> Flask:
+    """Create a Flask app and :func:`mount` ``page`` onto it. ``import_name`` is Flask's (for resource
+    resolution); all other keyword options are :func:`mount`'s."""
+    from flask import Flask
+
+    app = Flask(import_name)
+    return mount(app, page, **opts)

--- a/spaday/backends/starlette.py
+++ b/spaday/backends/starlette.py
@@ -1,9 +1,13 @@
-"""Starlette (and FastAPI, which is Starlette) backend: ``serve(page, …) -> Starlette``.
+"""Starlette (and FastAPI, which is Starlette) backend.
 
-Wires :mod:`spaday.bootstrap` into a Starlette app — ``/`` (the page), ``/tree.json`` or ``/tree`` (the
-tree), ``/js`` (the bundles), plus any ``routes`` you splice in (a transports websocket, REST) and a
-lifespan for ``background`` coroutines. Starlette is the optional ``examples`` extra; it is imported
-inside ``serve()`` so ``import spaday`` stays light.
+- ``mount(app, page, *, prefix="", …)`` — add spaday's routes to an **existing** app, at ``{prefix}/`` ·
+  ``{prefix}/tree[.json]`` · ``{prefix}/js`` (so spaday drops into a bigger app, optionally under a
+  sub-path). This is the primitive.
+- ``serve(page, …) -> Starlette`` — create an app (with a lifespan for ``background`` coroutines) and
+  ``mount`` onto it.
+
+Starlette is the optional ``examples`` extra; it is imported inside the functions so ``import spaday``
+stays light.
 """
 
 from __future__ import annotations
@@ -15,15 +19,16 @@ from typing import TYPE_CHECKING, Awaitable, Callable, Optional, Sequence, Union
 
 from ..bootstrap import Page, bootstrap, bundles_dir, tree_frame, tree_json
 
-if TYPE_CHECKING:  # annotations only — the runtime starlette import lives inside serve() (optional extra)
+if TYPE_CHECKING:  # annotations only — starlette is imported inside the functions (optional extra)
     from starlette.applications import Starlette
-    from starlette.routing import BaseRoute
 
 
-def serve(
+def mount(
+    app: Starlette,
     page: Page,
     *,
-    routes: Sequence[BaseRoute] = (),
+    prefix: str = "",
+    routes: Sequence = (),
     html: Optional[Union[str, Path]] = None,
     js: Optional[Union[str, Path]] = None,
     title: str = "spaday",
@@ -34,26 +39,16 @@ def serve(
     reconnect: bool = False,
     scripts: Sequence[str] = (),
     head: str = "",
-    background: Sequence[Awaitable] = (),
-    lifespan: Optional[Callable] = None,
 ) -> Starlette:
-    """Build a Starlette app serving ``page`` (a Component or a callable returning one).
-
-    Generation options (``bundles``/``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``/``title``)
-    are passed through to :func:`spaday.bootstrap.bootstrap`. ``routes`` splices in extra endpoints (the
-    transports websocket via ``transports.ws_endpoint``, REST); ``html`` serves a hand-authored bootstrap
-    file instead of the generated one; ``js`` overrides the served bundle dir (defaults to
-    :func:`~spaday.bootstrap.bundles_dir`). ``background`` coroutines run for the app's lifetime;
-    ``lifespan`` overrides that with a custom Starlette lifespan (for startup that must order its own
-    setup, e.g. a clustering relay) — ``background`` is then unused.
-    """
-    from starlette.applications import Starlette
+    """Add spaday's routes (page, tree, ``/js``, plus ``routes``) to an existing Starlette ``app`` under
+    ``prefix``. Generation options are passed to :func:`spaday.bootstrap.bootstrap`; ``html`` serves a
+    hand-authored bootstrap instead; ``js`` overrides the bundle dir. Returns ``app`` for chaining."""
     from starlette.responses import FileResponse, HTMLResponse, Response
     from starlette.routing import Mount, Route
     from starlette.staticfiles import StaticFiles
 
+    body = bootstrap(base=prefix, bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
     js_dir = Path(js) if js is not None else bundles_dir()
-    body = bootstrap(bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
 
     async def homepage(_request):
         return FileResponse(html) if html is not None else HTMLResponse(body)
@@ -64,7 +59,17 @@ def serve(
     async def tree_route_frame(_request):
         return Response(tree_frame(page), media_type="application/octet-stream")
 
-    tree_route = Route("/tree", tree_route_frame) if tree == "frame" else Route("/tree.json", tree_route_json)
+    tree_route = Route(f"{prefix}/tree", tree_route_frame) if tree == "frame" else Route(f"{prefix}/tree.json", tree_route_json)
+    app.routes.extend([Route(f"{prefix}/", homepage), tree_route, *routes, Mount(f"{prefix}/js", StaticFiles(directory=js_dir))])
+    return app
+
+
+def serve(page: Page, *, background: Sequence[Awaitable] = (), lifespan: Optional[Callable] = None, **opts) -> Starlette:
+    """Create a Starlette app and :func:`mount` ``page`` onto it. ``background`` coroutines run for the
+    app's lifetime (or pass a custom ``lifespan`` for ordered startup, e.g. a clustering relay); all other
+    keyword options are :func:`mount`'s (``prefix``/``routes``/``html``/``js``/``title``/``bundles``/
+    ``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``)."""
+    from starlette.applications import Starlette
 
     @asynccontextmanager
     async def _background_lifespan(_app):
@@ -75,5 +80,5 @@ def serve(
             for task in tasks:
                 task.cancel()
 
-    app_routes = [Route("/", homepage), tree_route, *routes, Mount("/js", StaticFiles(directory=js_dir))]
-    return Starlette(routes=app_routes, lifespan=lifespan if lifespan is not None else _background_lifespan)
+    app = Starlette(lifespan=lifespan if lifespan is not None else _background_lifespan)
+    return mount(app, page, **opts)

--- a/spaday/backends/tornado.py
+++ b/spaday/backends/tornado.py
@@ -1,33 +1,33 @@
-"""Tornado backend: ``serve(page, …) -> tornado.web.Application``.
+"""Tornado backend.
 
-Wires :mod:`spaday.bootstrap` into a Tornado application — ``GET /`` (the page), ``GET /tree.json`` or
-``GET /tree`` (the tree), ``GET /js/(.*)`` (the bundles via ``StaticFileHandler``), plus any ``routes``
-you splice in. ``background`` coroutines are scheduled on the IOLoop (they start when you run it). Run the
-returned app the usual way::
+- ``mount(app, page, *, prefix="", …)`` — add spaday's handlers to an **existing** ``tornado.web.Application``.
+- ``serve(page, …) -> tornado.web.Application`` — create an app, ``mount`` onto it, and schedule
+  ``background`` coroutines on the IOLoop. Run it the usual way::
 
-    app = serve(page, ...)
-    app.listen(8000)
-    tornado.ioloop.IOLoop.current().start()
+      app = serve(page, ...); app.listen(8000); tornado.ioloop.IOLoop.current().start()
 
-As with aiohttp, the transports ``/ws`` endpoint (when ``wire="transports"``) is yours to add via
-``routes`` (Tornado has its own ``WebSocketHandler``); static pages need no websocket.
+tornado is imported inside the functions so importing spaday never requires it. The transports ``{prefix}/ws``
+endpoint (with ``wire="transports"``) is yours to add via ``routes`` (Tornado has its own ``WebSocketHandler``).
 """
 
 from __future__ import annotations
 
 import asyncio
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Optional, Sequence, Union
 
 from ..bootstrap import Page, bootstrap, bundles_dir, tree_frame, tree_json
 
-if TYPE_CHECKING:  # annotations only — tornado is imported inside serve() (not a spaday dependency)
+if TYPE_CHECKING:  # annotations only — tornado is imported inside the functions (not a spaday dependency)
     from tornado.web import Application
 
 
-def serve(
+def mount(
+    app: Application,
     page: Page,
     *,
+    prefix: str = "",
     routes: Sequence = (),
     js: Optional[Union[str, Path]] = None,
     title: str = "spaday",
@@ -38,21 +38,15 @@ def serve(
     reconnect: bool = False,
     scripts: Sequence[str] = (),
     head: str = "",
-    background: Sequence[Awaitable] = (),
 ) -> Application:
-    """Build a Tornado application serving ``page`` (a Component or a callable returning one).
+    """Add spaday's handlers to an existing Tornado ``app`` under ``prefix``. ``routes`` is a list of
+    Tornado handler tuples (``(pattern, Handler[, kwargs])`` — including your ``{prefix}/ws`` handler when
+    wiring transports). Returns ``app`` for chaining."""
+    from tornado.web import RequestHandler, StaticFileHandler
 
-    Generation options (``bundles``/``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``/``title``)
-    are passed through to :func:`spaday.bootstrap.bootstrap`. ``routes`` is a list of Tornado handler
-    tuples (``(pattern, Handler[, kwargs])`` — including your ``/ws`` handler when wiring transports);
-    ``js`` overrides the served bundle dir (defaults to :func:`~spaday.bootstrap.bundles_dir`);
-    ``background`` coroutines are scheduled on the IOLoop and run once it starts.
-    """
-    from tornado.ioloop import IOLoop
-    from tornado.web import Application, RequestHandler, StaticFileHandler
-
-    body = bootstrap(bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
+    body = bootstrap(base=prefix, bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title)
     js_dir = str(js) if js is not None else str(bundles_dir())
+    pre = re.escape(prefix)
 
     class _Index(RequestHandler):
         def get(self):
@@ -66,7 +60,7 @@ def serve(
                 self.set_header("Content-Type", "application/octet-stream")
                 self.write(tree_frame(page))
 
-        tree_rule = (r"/tree", _Tree)
+        tree_rule = (rf"{pre}/tree", _Tree)
     else:
 
         class _Tree(RequestHandler):
@@ -74,10 +68,21 @@ def serve(
                 self.set_header("Content-Type", "application/json")
                 self.write(tree_json(page))
 
-        tree_rule = (r"/tree\.json", _Tree)
+        tree_rule = (rf"{pre}/tree\.json", _Tree)
 
-    handlers = [(r"/", _Index), tree_rule, *routes, (r"/js/(.*)", StaticFileHandler, {"path": js_dir})]
-    app = Application(handlers)
+    handlers = [(rf"{pre}/", _Index), tree_rule, *routes, (rf"{pre}/js/(.*)", StaticFileHandler, {"path": js_dir})]
+    app.add_handlers(r".*", handlers)
+    return app
+
+
+def serve(page: Page, *, background: Sequence[Awaitable] = (), **opts) -> Application:
+    """Create a Tornado application and :func:`mount` ``page`` onto it. ``background`` coroutines are
+    scheduled on the IOLoop and run once it starts; all other keyword options are :func:`mount`'s."""
+    from tornado.ioloop import IOLoop
+    from tornado.web import Application
+
+    app = Application()
+    mount(app, page, **opts)
     for coro in background:  # scheduled now, spawned when the IOLoop runs
         IOLoop.current().add_callback(asyncio.ensure_future, coro)
     return app

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -1,6 +1,6 @@
 """Framework-agnostic bootstrapping: generate a spaday page's HTML and serialize its tree, with **no
-webserver dependency**. Nothing here imports starlette / aiohttp / flask, so any backend can serve a
-spaday app — a backend (see :mod:`spaday.backends`) is just thin glue that wires these into routes.
+webserver dependency**. Nothing here imports starlette / aiohttp / flask / tornado, so any backend can
+serve a spaday app — a backend (see :mod:`spaday.backends`) is just thin glue that wires these into routes.
 
 What an app would otherwise hand-write in HTML is declared in Python:
 
@@ -8,17 +8,20 @@ What an app would otherwise hand-write in HTML is declared in Python:
   (see :data:`BUNDLES`), instead of copy-pasting its ``<link>``/``<script>`` tags.
 - ``wire="transports"`` — generate the transports ``Client`` + ``connectStore`` + websocket bootstrap
   (what every transports example's HTML repeats); without it the page just mounts a static tree.
-- ``tree="frame"`` — fetch the tree as a transports Snapshot frame at ``/tree`` (UI tree + model data on
-  one wire), decoded in the browser, instead of JSON at ``/tree.json``.
+- ``tree="frame"`` — fetch the tree as a transports Snapshot frame at ``…/tree`` (UI tree + model data on
+  one wire), decoded in the browser, instead of JSON at ``…/tree.json``.
 - ``reconnect=True`` — re-open the websocket on drop, re-syncing from the server snapshot.
 - ``scripts=[…]`` — extra ES-module URLs to load (e.g. ``NamedJs`` handlers).
+- ``base="/dashboard"`` — mount the app under a path prefix, so it coexists with the host's other routes
+  (the tree / ``/js`` / ws URLs are all prefixed). Default ``""`` = served at the root.
 
-**The contract a backend must satisfy** — the generated HTML expects the host to serve, at these paths::
+**The contract a backend must satisfy** — the generated HTML expects the host to serve, at these paths
+(``{base}`` is the prefix, default empty)::
 
-    GET /            -> bootstrap(...)        # this HTML
-    GET /tree.json   -> tree_json(page)       # or GET /tree -> tree_frame(page) when tree="frame"
-    GET /js/*        -> the files under bundles_dir()
-    WS  /ws          -> a transports endpoint # only when wire="transports" (the backend/transports owns it)
+    GET {base}/            -> bootstrap(...)        # this HTML
+    GET {base}/tree.json   -> tree_json(page)       # or GET {base}/tree -> tree_frame(page) when tree="frame"
+    GET {base}/js/*        -> the files under bundles_dir()
+    WS  {base}/ws          -> a transports endpoint # only when wire="transports" (the backend/transports owns it)
 """
 
 from __future__ import annotations
@@ -34,33 +37,37 @@ from .spaday import encode_frame  # compiled core (always available); used by tr
 #: per request, so the tree can reflect current state).
 Page = Union[Component, "object"]
 
-_RUNTIME = "/js/dist/esm/index.js"
-_WASM = "/js/dist/pkg/spaday_bg.wasm"
-_TRANSPORTS = "/js/node_modules/@1kbgz/transports/dist/cdn/index.js"
-_TRANSPORTS_WASM = "/js/node_modules/@1kbgz/transports/dist/pkg/transports_bg.wasm"
+# Paths under the served ``/js`` mount — prefixed with ``{base}/js`` at build time (see ``_js``).
+_RUNTIME = "/dist/esm/index.js"
+_WASM = "/dist/pkg/spaday_bg.wasm"
+_TRANSPORTS = "/node_modules/@1kbgz/transports/dist/cdn/index.js"
+_TRANSPORTS_WASM = "/node_modules/@1kbgz/transports/dist/pkg/transports_bg.wasm"
 
-#: Named component-library bundles a page can pull into ``<head>`` via ``bundles=[…]`` — each value is the
-#: markup (styles + the catalog/wrapper script that registers the elements) that an example would otherwise
-#: paste into its HTML. The URLs resolve under the served ``/js`` mount (see :func:`bundles_dir`).
+#: Named component-library bundles a page can pull into ``<head>`` via ``bundles=[…]``. Each entry is a
+#: ``(kind, path)`` pair — ``kind`` is ``"css"`` or ``"js"``, ``path`` is under the served ``/js`` mount —
+#: the markup (styles + the catalog/wrapper script that registers the elements) an example would otherwise
+#: paste into its HTML.
 BUNDLES = {
     "webawesome": [
-        '<link rel="stylesheet" href="/js/node_modules/@awesome.me/webawesome/dist/styles/webawesome.css" />',
-        '<link rel="stylesheet" href="/js/node_modules/@awesome.me/webawesome/dist/styles/themes/default.css" />',
-        '<script type="module" src="/js/dist/cdn/examples/webawesome.js"></script>',
+        ("css", "/node_modules/@awesome.me/webawesome/dist/styles/webawesome.css"),
+        ("css", "/node_modules/@awesome.me/webawesome/dist/styles/themes/default.css"),
+        ("js", "/dist/cdn/examples/webawesome.js"),
     ],
-    "lightweight-charts": ['<script type="module" src="/js/dist/cdn/wrappers/lightweight-chart.js"></script>'],
-    "perspective": ['<script type="module" src="/js/dist/cdn/wrappers/perspective-workspace.js"></script>'],
+    "lightweight-charts": [("js", "/dist/cdn/wrappers/lightweight-chart.js")],
+    "perspective": [("js", "/dist/cdn/wrappers/perspective-workspace.js")],
 }
 
 
 def bundles_dir() -> Path:
-    """The directory of built JS bundles a backend serves at ``/js`` — the repo's ``js/`` (dev checkout).
-
-    The :data:`BUNDLES` and runtime URLs assume this layout mounted at ``/js``. (A pip-installed app ships
-    assets under ``spaday/extension`` in a different layout without ``node_modules``; serving an installed
-    app is a separate concern — a backend can override the dir, but the URLs would also need re-pathing.)
-    """
+    """The directory of built JS bundles a backend serves at ``{base}/js`` — the repo's ``js/`` (dev
+    checkout). The :data:`BUNDLES` and runtime URLs assume this layout. (A pip-installed app ships assets
+    under ``spaday/extension`` in a different layout without ``node_modules``; serving an installed app is
+    a separate concern — a backend can override the dir, but the URLs would also need re-pathing.)"""
     return Path(__file__).parent.parent / "js"
+
+
+def _js(base: str) -> str:
+    return f"{base}/js"
 
 
 def _resolve(page: Page) -> Component:
@@ -68,44 +75,47 @@ def _resolve(page: Page) -> Component:
 
 
 def tree_json(page: Page) -> str:
-    """The authored tree as a JSON string (serve at ``GET /tree.json``)."""
+    """The authored tree as a JSON string (serve at ``GET {base}/tree.json``)."""
     return json.dumps(_resolve(page).to_node())
 
 
 def tree_frame(page: Page, *, id: str = "spa-tree") -> bytes:
-    """The authored tree as a transports Snapshot frame (serve at ``GET /tree`` for ``tree="frame"``) —
-    the same length-prefixed, codec-tagged envelope transports uses for model state, so the UI tree and
+    """The authored tree as a transports Snapshot frame (serve at ``GET {base}/tree`` for ``tree="frame"``)
+    — the same length-prefixed, codec-tagged envelope transports uses for model state, so the UI tree and
     the model data ride one wire."""
     return encode_frame(json.dumps(_resolve(page).to_node()), id, "snapshot", 0, "application/json")
 
 
-def _bundle_head(bundles: Sequence[str]) -> str:
+def _bundle_head(bundles: Sequence[str], base: str) -> str:
     tags = []
     for name in bundles:
         if name not in BUNDLES:
             raise ValueError(f"unknown bundle {name!r}; known: {', '.join(sorted(BUNDLES))}")
-        tags.extend(BUNDLES[name])
+        for kind, path in BUNDLES[name]:
+            url = f"{_js(base)}{path}"
+            tags.append(f'<link rel="stylesheet" href="{url}" />' if kind == "css" else f'<script type="module" src="{url}"></script>')
     return "\n    ".join(tags)
 
 
-def _script(wire: Optional[str], scripts: Sequence[str], ws: str, tree: str, reconnect: bool) -> str:
+def _script(base: str, wire: Optional[str], scripts: Sequence[str], ws: str, tree: str, reconnect: bool) -> str:
     """The page's module script: imports, wasm init(s), fetch the tree, then mount — statically, or wired
     to a transports model (Store + Client + connectStore) when ``wire="transports"``."""
+    js = _js(base)
     transports = wire == "transports"
     frame = tree == "frame"
     runtime_names = ["mount", "init"] + (["Store", "connectStore"] if transports else []) + (["decodeFrame"] if frame else [])
-    lines = [f'import {{ {", ".join(runtime_names)} }} from "{_RUNTIME}";']
+    lines = [f'import {{ {", ".join(runtime_names)} }} from "{js}{_RUNTIME}";']
     if transports:
-        lines.append(f'import {{ Client, fromValue, toValue, wasm }} from "{_TRANSPORTS}";')
+        lines.append(f'import {{ Client, fromValue, toValue, wasm }} from "{js}{_TRANSPORTS}";')
     lines.extend(f'import "{s}";' for s in scripts)
-    lines.append(f'await init({{ module_or_path: "{_WASM}" }});')
+    lines.append(f'await init({{ module_or_path: "{js}{_WASM}" }});')
     if transports:
-        lines.append(f'await wasm.default({{ module_or_path: "{_TRANSPORTS_WASM}" }});')
+        lines.append(f'await wasm.default({{ module_or_path: "{js}{_TRANSPORTS_WASM}" }});')
     if frame:
-        lines.append('const framed = new Uint8Array(await (await fetch("/tree")).arrayBuffer());')
+        lines.append(f'const framed = new Uint8Array(await (await fetch("{base}/tree")).arrayBuffer());')
         lines.append("const node = JSON.parse(decodeFrame(framed)).payload;")
     else:
-        lines.append('const node = await (await fetch("/tree.json")).json();')
+        lines.append(f'const node = await (await fetch("{base}/tree.json")).json();')
     if transports and reconnect:
         lines.extend(
             [
@@ -114,7 +124,7 @@ def _script(wire: Optional[str], scripts: Sequence[str], ws: str, tree: str, rec
                 "let socket = null;",
                 "const link = connectStore(store, client, (frame) => socket && socket.send(frame), { fromValue, toValue });",
                 "function connect() {",
-                f"  socket = new WebSocket(`ws://${{location.host}}{ws}`);",
+                f"  socket = new WebSocket(`ws://${{location.host}}{base}{ws}`);",
                 '  socket.binaryType = "arraybuffer";',
                 '  socket.addEventListener("message", (event) =>',
                 '    link.receive(typeof event.data === "string" ? event.data : new Uint8Array(event.data)),',
@@ -130,7 +140,7 @@ def _script(wire: Optional[str], scripts: Sequence[str], ws: str, tree: str, rec
             [
                 "const store = new Store();",
                 "const client = new Client();",
-                f"const ws = new WebSocket(`ws://${{location.host}}{ws}`);",
+                f"const ws = new WebSocket(`ws://${{location.host}}{base}{ws}`);",
                 'ws.binaryType = "arraybuffer";',
                 "const link = connectStore(store, client, (frame) => ws.send(frame), { fromValue, toValue });",
                 'ws.addEventListener("message", (event) =>',
@@ -146,6 +156,7 @@ def _script(wire: Optional[str], scripts: Sequence[str], ws: str, tree: str, rec
 
 def bootstrap(
     *,
+    base: str = "",
     bundles: Sequence[str] = (),
     wire: Optional[str] = None,
     ws: str = "/ws",
@@ -155,10 +166,11 @@ def bootstrap(
     head: str = "",
     title: str = "spaday",
 ) -> str:
-    """The bootstrap page HTML (init the wasm core, fetch the tree, mount it). See the module docstring for
-    the options and the route contract a backend must satisfy to serve it."""
-    head_markup = "\n    ".join(p for p in (_bundle_head(bundles), head) if p)
-    script = _script(wire, scripts, ws, tree, reconnect)
+    """The bootstrap page HTML (init the wasm core, fetch the tree, mount it). ``base`` prefixes the tree /
+    ``/js`` / ws URLs so the page can be mounted under a sub-path. See the module docstring for the options
+    and the route contract a backend must satisfy."""
+    head_markup = "\n    ".join(p for p in (_bundle_head(bundles, base), head) if p)
+    script = _script(base, wire, scripts, ws, tree, reconnect)
     return f"""<!doctype html>
 <html lang="en">
   <head>

--- a/spaday/tests/test_backend_starlette.py
+++ b/spaday/tests/test_backend_starlette.py
@@ -10,7 +10,7 @@ from starlette.routing import Route  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
 from spaday import decode_frame  # noqa: E402
-from spaday.backends.starlette import serve  # noqa: E402
+from spaday.backends.starlette import mount, serve  # noqa: E402
 from spaday.components.shell import Main  # noqa: E402
 
 
@@ -29,6 +29,17 @@ def test_serve_frame_route_returns_a_decodable_frame(tmp_path):
     client = TestClient(serve(page, js=tmp_path, wire="transports", tree="frame"))
     assert json.loads(decode_frame(client.get("/tree").content))["payload"] == page.to_node()
     assert client.get("/tree.json").status_code == 404  # json route not mounted in frame mode
+
+
+def test_mount_adds_routes_to_an_existing_app_under_a_prefix(tmp_path):
+    from starlette.applications import Starlette
+
+    app = Starlette(routes=[Route("/health", lambda _r: PlainTextResponse("ok"))])
+    mount(app, Main("hi"), prefix="/dash", js=tmp_path)
+    client = TestClient(app)
+    assert client.get("/health").text == "ok"  # the host app's own route still works
+    assert "/dash/js/dist/esm/index.js" in client.get("/dash/").text  # spaday page under the prefix
+    assert client.get("/dash/tree.json").json() == Main("hi").to_node()
 
 
 def test_serve_custom_html_and_background(tmp_path):

--- a/spaday/tests/test_bootstrap.py
+++ b/spaday/tests/test_bootstrap.py
@@ -69,3 +69,12 @@ def test_tree_frame_round_trips_to_the_authored_tree():
 
 def test_bundles_dir_points_at_the_js_bundles():
     assert bundles_dir().name == "js"
+
+
+def test_base_prefixes_the_tree_js_and_ws_urls():
+    html = bootstrap(base="/dash", wire="transports", bundles=["webawesome"])
+    assert 'fetch("/dash/tree.json")' in html  # tree
+    assert "/dash/js/dist/esm/index.js" in html  # runtime
+    assert "/dash/js/node_modules/@awesome.me" in html  # bundle
+    assert "${location.host}/dash/ws" in html  # websocket
+    assert 'fetch("/tree.json")' in bootstrap()  # default base="" is unprefixed (served at root)


### PR DESCRIPTION
Makes spaday **embeddable in a bigger app** (the granular-integration seams from #84's brainstorm). Stacked on #84 (adds `mount()` to all four backends incl. flask/tornado) — review/merge that first.

## `bootstrap(base="/prefix")`
The generic generator now prefixes the tree / `/js` / ws URLs (and bundle tags) so a spaday page can live under a sub-path and coexist with a host app's other routes. `base=""` (default) is unchanged — served at root.

## `mount(app, page, *, prefix="", …)` per backend
Every backend (starlette, aiohttp, flask, tornado) now exposes **`mount()`** — add spaday's routes to an **existing** app — and `serve()` is now `create-app + mount`. This is the "drop into a bigger app" primitive:

```python
from spaday.backends.starlette import mount
mount(my_existing_app, page, prefix="/dashboard", bundles=["webawesome"])
# my_existing_app's own routes still work; spaday lives at /dashboard
```

## Also: finishes Phase 1.3 (roadmap)
No `registry(manifest)` proved necessary — the runtime's property-when-present-else-attribute heuristic (`setProp`) + wrapper-encapsulated imperative setters (chart `data`/`theme`, Perspective `config`→`restore`) cover prop-setting. Marked `DONE`.

## Tests
`test_bootstrap.py` (base prefixes tree/js/ws/bundles; default unprefixed); `test_backend_starlette.py` (mount onto an existing app under `/dash` — the host's own route still works). 116 Python pass; ruff clean.

## Roadmap 4.6 — granular integration now `PARTIAL`
`mount()` + prefix done; still planned: **fragment/embed mode** (`bootstrap(fragment=True, target=…)` → emit just the `<script>` into a host template), configurable asset prefix/CDN, bring-your-own-wire.