### PR TITLE
obj() — object-composing Expr (finish Phase 2.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
 name = "spaday_js"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "serde",
  "serde-wasm-bindgen",
  "spaday",

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -14,5 +14,6 @@ crate-type = ["cdylib"]
 [dependencies]
 spaday = { path = "../rust", version = "*" }
 wasm-bindgen = "=0.2.121"
+js-sys = "0.3"
 serde = "1"
 serde-wasm-bindgen = "0.6"

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -89,7 +89,7 @@ fn run(action: &spaday::Action, host: &Host) {
 }
 
 fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
-    use spaday::Expr::{Event, Lit, Not, Prop};
+    use spaday::Expr::{Event, Lit, Not, Obj, Prop};
     match expr {
         // json_compatible: JSON objects become plain JS objects (not Maps), so they round-trip through
         // `JSON.stringify` (e.g. a CallEndpoint body) and set cleanly as props.
@@ -100,6 +100,15 @@ fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
         Not { of } => JsValue::from_bool(!truthy(&eval(of, host))),
         Prop { target, name } => {
             resolve(target, host).map_or(JsValue::NULL, |el| host.get_prop(&el, name))
+        }
+        // Compose a plain JS object from each field's evaluated value — e.g. a whole model assembled from
+        // live control values for a CallEndpoint body. Plain object => round-trips through JSON.stringify.
+        Obj { fields } => {
+            let obj = js_sys::Object::new();
+            for (name, sub) in fields {
+                let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(name), &eval(sub, host));
+            }
+            obj.into()
         }
     }
 }

--- a/js/src/ts/signals.ts
+++ b/js/src/ts/signals.ts
@@ -122,7 +122,8 @@ export function evalExpr(expr: unknown, store: Store): unknown {
         : evalExpr(e["else"], store);
     case "obj": {
       const out: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(e.fields as Record<string, unknown>)) out[k] = evalExpr(v, store);
+      for (const [k, v] of Object.entries(e.fields as Record<string, unknown>))
+        out[k] = evalExpr(v, store);
       return out;
     }
     default:

--- a/js/src/ts/signals.ts
+++ b/js/src/ts/signals.ts
@@ -120,6 +120,11 @@ export function evalExpr(expr: unknown, store: Store): unknown {
       return evalExpr(e.test, store)
         ? evalExpr(e.then, store)
         : evalExpr(e["else"], store);
+    case "obj": {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(e.fields as Record<string, unknown>)) out[k] = evalExpr(v, store);
+      return out;
+    }
     default:
       return undefined;
   }

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -269,6 +269,46 @@ test("CallEndpoint makes the REST call with the templated JSON body", async ({
   expect(seen).toEqual([{ method: "POST", body: '{"x":1}' }]);
 });
 
+test("CallEndpoint composes a JSON body from live control values via an obj expr", async ({
+  page,
+}) => {
+  const seen = [];
+  await page.route("**/api/order", (route) => {
+    seen.push(route.request().postData());
+    return route.fulfill({ status: 200, body: "ok" });
+  });
+  await page.evaluate(() => {
+    const root = window.__spaday.mount(document.body, {
+      tag: "div",
+      slots: {
+        default: [
+          { tag: "input", props: { id: { Str: "symbol" }, value: { Str: "AAPL" } } },
+          {
+            tag: "button",
+            events: {
+              click: {
+                kind: "call",
+                method: "POST",
+                url: "/api/order",
+                body: {
+                  expr: "obj",
+                  fields: {
+                    symbol: { expr: "prop", target: { ref: "id", id: "symbol" }, name: "value" },
+                    qty: { expr: "lit", value: 10 },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    root.querySelector("button").click();
+  });
+  await page.waitForTimeout(150); // let the fetch reach the route handler
+  expect(JSON.parse(seen[0])).toEqual({ symbol: "AAPL", qty: 10 }); // obj read the live input value
+});
+
 test("NamedJs invokes a pre-registered handler (the no-eval escape hatch)", async ({
   page,
 }) => {

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -282,7 +282,10 @@ test("CallEndpoint composes a JSON body from live control values via an obj expr
       tag: "div",
       slots: {
         default: [
-          { tag: "input", props: { id: { Str: "symbol" }, value: { Str: "AAPL" } } },
+          {
+            tag: "input",
+            props: { id: { Str: "symbol" }, value: { Str: "AAPL" } },
+          },
           {
             tag: "button",
             events: {
@@ -293,7 +296,11 @@ test("CallEndpoint composes a JSON body from live control values via an obj expr
                 body: {
                   expr: "obj",
                   fields: {
-                    symbol: { expr: "prop", target: { ref: "id", id: "symbol" }, name: "value" },
+                    symbol: {
+                      expr: "prop",
+                      target: { ref: "id", id: "symbol" },
+                      name: "value",
+                    },
                     qty: { expr: "lit", value: 10 },
                   },
                 },

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -9,7 +9,7 @@
 //! The wire form (matched by `spaday.actions` in Python and the runtime in JS):
 //! - `Ref`:  `{"ref":"this"}` · `{"ref":"id","id":"panel"}`
 //! - `Expr`: `{"expr":"lit","value":<json>}` · `{"expr":"event"}` · `{"expr":"not","of":<Expr>}` ·
-//!   `{"expr":"prop","target":<Ref>,"name":"checked"}`
+//!   `{"expr":"prop","target":<Ref>,"name":"checked"}` · `{"expr":"obj","fields":{<name>:<Expr>}}`
 //! - `Action`: `{"kind":"set",target,prop,value}` · `{"kind":"toggle",target,prop}` ·
 //!   `{"kind":"seq","actions":[..]}` · `{"kind":"emit","event","detail":<Expr>|null}` ·
 //!   `{"kind":"patch","model","field","value":<Expr>}` ·
@@ -46,6 +46,11 @@ pub enum Expr {
     Not { of: Box<Expr> },
     /// The current value of a `name` prop on `target` (reads live element state).
     Prop { target: Ref, name: String },
+    /// Compose a JSON object from named sub-expressions — e.g. a whole model as a `CallEndpoint` body:
+    /// `{"expr":"obj","fields":{"symbol":{"expr":"prop","target":{"ref":"id","id":"sym"},"name":"value"}}}`.
+    Obj {
+        fields: std::collections::BTreeMap<String, Expr>,
+    },
 }
 
 /// A declarative event handler, interpreted in the browser.
@@ -291,6 +296,35 @@ mod tests {
                 event: "ping".into(),
                 detail: None
             }
+        );
+    }
+
+    #[test]
+    fn call_endpoint_with_obj_body() {
+        let mut fields = std::collections::BTreeMap::new();
+        fields.insert(
+            "symbol".to_string(),
+            Expr::Prop {
+                target: Ref::Id { id: "sym".into() },
+                name: "value".into(),
+            },
+        );
+        fields.insert("qty".to_string(), Expr::Lit { value: json!(10) });
+        round(
+            &Action::CallEndpoint {
+                method: "POST".into(),
+                url: "/api/order".into(),
+                body: Some(Expr::Obj { fields }),
+            },
+            json!({
+                "kind": "call",
+                "method": "POST",
+                "url": "/api/order",
+                "body": {"expr": "obj", "fields": {
+                    "qty": {"expr": "lit", "value": 10},
+                    "symbol": {"expr": "prop", "target": {"ref": "id", "id": "sym"}, "name": "value"},
+                }},
+            }),
         );
     }
 }

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -18,6 +18,7 @@ from .actions import (
     field,
     lit,
     not_,
+    obj,
     prop,
     this,
 )
@@ -73,6 +74,7 @@ __all__ = [
     "all_",
     "any_",
     "cond",
+    "obj",
     "this",
     "by_id",
     "bind",

--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -163,6 +163,27 @@ def cond(test: Any, then: Any, otherwise: Any) -> Expr:
     return _Cond(test, then, otherwise)
 
 
+class _Obj(Expr):
+    def __init__(self, fields: Dict[str, Any]) -> None:
+        self.fields = fields
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"expr": "obj", "fields": {k: _expr(v).to_dict() for k, v in self.fields.items()}}
+
+
+def obj(fields: Dict[str, Any]) -> Expr:
+    """Compose a JSON object from named sub-expressions (each value a plain value or an :class:`Expr`).
+    Lets a whole model be POSTed declaratively as a :class:`CallEndpoint` body — composing live control
+    values without a hand-written handler::
+
+        CallEndpoint("POST", "/api/order", obj({
+            "symbol": prop(by_id("symbol"), "value"),
+            "qty": prop(by_id("qty"), "value"),
+        }))
+    """
+    return _Obj(fields)
+
+
 class Ref:
     """A reference to a DOM element an action targets."""
 

--- a/spaday/tests/test_actions.py
+++ b/spaday/tests/test_actions.py
@@ -17,6 +17,7 @@ from spaday.actions import (
     field,
     lit,
     not_,
+    obj,
     prop,
     this,
 )
@@ -62,6 +63,26 @@ def test_cond_wire_shape_coerces_branches_to_literals():
         "then": {"expr": "lit", "value": "dark"},
         "else": {"expr": "lit", "value": "light"},
     }
+
+
+def test_obj_composes_an_object_body_for_call_endpoint():
+    # an object-composing expr — POST a whole model declaratively (no NamedJs handler)
+    action = CallEndpoint("POST", "/api/order", obj({"symbol": prop(by_id("sym"), "value"), "qty": lit(10)}))
+    assert action.to_dict() == {
+        "kind": "call",
+        "method": "POST",
+        "url": "/api/order",
+        "body": {
+            "expr": "obj",
+            "fields": {
+                "symbol": {"expr": "prop", "target": {"ref": "id", "id": "sym"}, "name": "value"},
+                "qty": {"expr": "lit", "value": 10},
+            },
+        },
+    }
+    # rides the core diff/apply on a node like any other action
+    node = element("button").on("click", action).to_json()
+    assert json.loads(apply(node, diff(node, node))) == json.loads(node)
 
 
 def test_setprop_coerces_a_plain_value_to_a_literal():


### PR DESCRIPTION
Finishes the last Phase-2 partial (roadmap **2.8**): an **object-composing expression** so a whole model can be POSTed declaratively as a `CallEndpoint` body — no `NamedJs` handler.

```python
CallEndpoint("POST", "/api/order", obj({
    "symbol": prop(by_id("symbol"), "value"),
    "qty": prop(by_id("qty"), "value"),
}))
```

## Changes
- **Rust core** (`rust/src/action.rs`) — `Expr::Obj { fields: BTreeMap<String, Expr> }` (wire `{"expr":"obj","fields":{…}}`), with a round-trip test.
- **wasm interpreter** (`js/src/rust/lib.rs`) — `eval` builds a plain JS object from each field's evaluated value (via `js-sys` `Object`/`Reflect`), so it round-trips through `JSON.stringify` as a request body. (Added `js-sys` dep.)
- **`signals.ts`** — `obj` in `evalExpr` too, so it also works in a computed binding; `exprFields` tracks its deps automatically.
- **`spaday.actions.obj(...)`** (exported from `spaday`).

## Tests
- Rust: `Expr::Obj` round-trips inside a `CallEndpoint` body.
- Python: `obj()` wire shape + core diff/apply round-trip.
- JS: a `CallEndpoint` whose `obj` body reads a live `<input>` value → the POST body is `{symbol, qty}` (exercises the rebuilt wasm eval).

113 Python + 58 JS pass; ruff clean. Independent of the backends PRs (#84/#85).

## Follow-up (the capstone wiring, not this PR)
Migrating the gateway's form-submit from `NamedJs("send-order")` to `CallEndpoint(body=obj(...))` — which lets `gateway.html` go — is the csp-gateway capstone (5.3 / 4.6). The primitive it needed now exists.