### PR TITLE
field expr in actions → declarative gateway form-submit (csp-gateway capstone)

### DIFF
--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -16,6 +16,8 @@ extern "C" {
     fn set_prop(this: &Host, el: &JsValue, name: &str, value: JsValue);
     #[wasm_bindgen(method, js_name = eventValue)]
     fn event_value(this: &Host) -> JsValue;
+    #[wasm_bindgen(method, js_name = getField)]
+    fn get_field(this: &Host, name: &str) -> JsValue;
     #[wasm_bindgen(method)]
     fn emit(this: &Host, event: &str, detail: JsValue);
     #[wasm_bindgen(method, js_name = sendPatch)]
@@ -89,7 +91,7 @@ fn run(action: &spaday::Action, host: &Host) {
 }
 
 fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
-    use spaday::Expr::{Event, Lit, Not, Obj, Prop};
+    use spaday::Expr::{Event, Field, Lit, Not, Obj, Prop};
     match expr {
         // json_compatible: JSON objects become plain JS objects (not Maps), so they round-trip through
         // `JSON.stringify` (e.g. a CallEndpoint body) and set cleanly as props.
@@ -97,6 +99,7 @@ fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
             .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
             .unwrap_or(JsValue::UNDEFINED),
         Event => host.event_value(),
+        Field { name } => host.get_field(name),
         Not { of } => JsValue::from_bool(!truthy(&eval(of, host))),
         Prop { target, name } => {
             resolve(target, host).map_or(JsValue::NULL, |el| host.get_prop(&el, name))

--- a/js/src/ts/actions.ts
+++ b/js/src/ts/actions.ts
@@ -8,12 +8,15 @@
 import { interpret as wasmInterpret } from "../../dist/pkg/spaday";
 import { getHandler } from "./handlers";
 import { setProp } from "./runtime";
+import type { Store } from "./signals";
 import { assertReady } from "./wasm-ready";
 
-/** The context an action runs in: the DOM event and the element the listener is bound to. */
+/** The context an action runs in: the DOM event, the listener's element, and the mounted signal store
+ *  (when the tree was mounted with one) — so an action's `field` expr can read reactive state. */
 export interface ActionContext {
   event: Event;
   currentTarget: Element;
+  store?: Store;
 }
 
 /** Run one action (the core's plain DSL wire form) against the DOM in the given event context. */
@@ -44,6 +47,8 @@ function host(ctx: ActionContext) {
       if (target && "value" in target) return target.value;
       return (ctx.event as CustomEvent).detail;
     },
+    // a reactive state field from the mounted signal store (undefined if the tree has no store)
+    getField: (name: string) => ctx.store?.get(name),
     emit: (event: string, detail: unknown) =>
       ctx.currentTarget.dispatchEvent(
         new CustomEvent(event, { detail, bubbles: true }),

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -91,7 +91,7 @@ function hydrateNode(el: Element, node: Node, store?: Store): void {
     }
   }
   for (const [name, action] of Object.entries(node.events ?? {})) {
-    bindEvent(el, name, action);
+    bindEvent(el, name, action, store); // actions ride the wire as the core's DSL form (plain JSON)
   }
   if (store) {
     for (const [prop, spec] of Object.entries(node.bindings ?? {})) {
@@ -105,13 +105,18 @@ function hydrateNode(el: Element, node: Node, store?: Store): void {
 // `SetEvent` when an action is added/changed and `RemoveEvent` when one is removed on an existing node.
 const listeners = new WeakMap<Element, Map<string, EventListener>>();
 
-function bindEvent(el: Element, name: string, action: unknown): void {
+function bindEvent(
+  el: Element,
+  name: string,
+  action: unknown,
+  store?: Store,
+): void {
   let map = listeners.get(el);
   if (!map) listeners.set(el, (map = new Map()));
   const existing = map.get(name);
   if (existing) el.removeEventListener(name, existing); // replace, don't stack
   const handler: EventListener = (event) =>
-    interpret(action, { event, currentTarget: el });
+    interpret(action, { event, currentTarget: el, store }); // store lets an action's `field` expr read state
   el.addEventListener(name, handler);
   map.set(name, handler);
 }
@@ -265,7 +270,7 @@ function build(node: Node, store?: Store): Element {
     }
   }
   for (const [name, action] of Object.entries(node.events ?? {})) {
-    bindEvent(el, name, action); // actions ride the wire as the core's DSL form (plain JSON)
+    bindEvent(el, name, action, store); // actions ride the wire as the core's DSL form (plain JSON)
   }
   if (store) {
     for (const [prop, spec] of Object.entries(node.bindings ?? {})) {
@@ -357,7 +362,7 @@ function applyOp(root: Element, op: Op, store?: Store): Element {
     removeProp(resolve(root, op.RemoveProp.path), op.RemoveProp.name);
   } else if ("SetEvent" in op) {
     const { path, name, action } = op.SetEvent;
-    bindEvent(resolve(root, path), name, action);
+    bindEvent(resolve(root, path), name, action, store);
   } else if ("RemoveEvent" in op) {
     const { path, name } = op.RemoveEvent;
     unbindEvent(resolve(root, path), name);

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -316,6 +316,47 @@ test("CallEndpoint composes a JSON body from live control values via an obj expr
   expect(JSON.parse(seen[0])).toEqual({ symbol: "AAPL", qty: 10 }); // obj read the live input value
 });
 
+test("CallEndpoint composes a body from the signal store via field exprs", async ({
+  page,
+}) => {
+  // the csp-gateway pattern: a form's two-way-bound state is POSTed via obj({field}) — an action's
+  // `field` expr reads the store the tree was mounted with (no DOM ids, no handler)
+  const seen = [];
+  await page.route("**/api/order", (route) => {
+    seen.push(route.request().postData());
+    return route.fulfill({ status: 200, body: "ok" });
+  });
+  await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ symbol: "AAPL", qty: 100 });
+    const btn = mount(
+      document.body,
+      {
+        tag: "button",
+        events: {
+          click: {
+            kind: "call",
+            method: "POST",
+            url: "/api/order",
+            body: {
+              expr: "obj",
+              fields: {
+                symbol: { expr: "field", name: "symbol" },
+                qty: { expr: "field", name: "qty" },
+              },
+            },
+          },
+        },
+      },
+      store,
+    );
+    store.set("qty", 250); // the live store value, read at click time
+    btn.click();
+  });
+  await page.waitForTimeout(150);
+  expect(JSON.parse(seen[0])).toEqual({ symbol: "AAPL", qty: 250 });
+});
+
 test("NamedJs invokes a pre-registered handler (the no-eval escape hatch)", async ({
   page,
 }) => {

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -9,7 +9,8 @@
 //! The wire form (matched by `spaday.actions` in Python and the runtime in JS):
 //! - `Ref`:  `{"ref":"this"}` · `{"ref":"id","id":"panel"}`
 //! - `Expr`: `{"expr":"lit","value":<json>}` · `{"expr":"event"}` · `{"expr":"not","of":<Expr>}` ·
-//!   `{"expr":"prop","target":<Ref>,"name":"checked"}` · `{"expr":"obj","fields":{<name>:<Expr>}}`
+//!   `{"expr":"prop","target":<Ref>,"name":"checked"}` · `{"expr":"field","name":"qty"}` ·
+//!   `{"expr":"obj","fields":{<name>:<Expr>}}`
 //! - `Action`: `{"kind":"set",target,prop,value}` · `{"kind":"toggle",target,prop}` ·
 //!   `{"kind":"seq","actions":[..]}` · `{"kind":"emit","event","detail":<Expr>|null}` ·
 //!   `{"kind":"patch","model","field","value":<Expr>}` ·
@@ -46,6 +47,9 @@ pub enum Expr {
     Not { of: Box<Expr> },
     /// The current value of a `name` prop on `target` (reads live element state).
     Prop { target: Ref, name: String },
+    /// The current value of a reactive state `field` from the signal store the tree was mounted with —
+    /// e.g. compose `CallEndpoint`'s body from a form's two-way-bound fields. (Also a binding expr.)
+    Field { name: String },
     /// Compose a JSON object from named sub-expressions — e.g. a whole model as a `CallEndpoint` body:
     /// `{"expr":"obj","fields":{"symbol":{"expr":"prop","target":{"ref":"id","id":"sym"},"name":"value"}}}`.
     Obj {
@@ -323,6 +327,30 @@ mod tests {
                 "body": {"expr": "obj", "fields": {
                     "qty": {"expr": "lit", "value": 10},
                     "symbol": {"expr": "prop", "target": {"ref": "id", "id": "sym"}, "name": "value"},
+                }},
+            }),
+        );
+    }
+
+    #[test]
+    fn obj_body_from_store_fields() {
+        // the csp-gateway pattern: POST a whole model composed from the form's two-way-bound store fields
+        let mut fields = std::collections::BTreeMap::new();
+        fields.insert("qty".to_string(), Expr::Field { name: "qty".into() });
+        fields.insert("symbol".to_string(), Expr::Field { name: "symbol".into() });
+        round(
+            &Action::CallEndpoint {
+                method: "POST".into(),
+                url: "/api/order".into(),
+                body: Some(Expr::Obj { fields }),
+            },
+            json!({
+                "kind": "call",
+                "method": "POST",
+                "url": "/api/order",
+                "body": {"expr": "obj", "fields": {
+                    "qty": {"expr": "field", "name": "qty"},
+                    "symbol": {"expr": "field", "name": "symbol"},
                 }},
             }),
         );

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -337,7 +337,12 @@ mod tests {
         // the csp-gateway pattern: POST a whole model composed from the form's two-way-bound store fields
         let mut fields = std::collections::BTreeMap::new();
         fields.insert("qty".to_string(), Expr::Field { name: "qty".into() });
-        fields.insert("symbol".to_string(), Expr::Field { name: "symbol".into() });
+        fields.insert(
+            "symbol".to_string(),
+            Expr::Field {
+                name: "symbol".into(),
+            },
+        );
         round(
             &Action::CallEndpoint {
                 method: "POST".into(),

--- a/spaday/examples/gateway.html
+++ b/spaday/examples/gateway.html
@@ -47,7 +47,7 @@
       await init({ module_or_path: "/js/dist/pkg/spaday_bg.wasm" }); // the action interpreter (CallEndpoint / NamedJs)
 
       const node = await (await fetch("/tree.json")).json();
-      // the form's controls two-way bind to this store; the Send handler reads it to POST the order
+      // the form's controls two-way bind to this store; the Send action's `field` exprs read it for the POST
       const store = new Store({
         symbol: "AAPL",
         side: "buy",
@@ -57,24 +57,8 @@
       mount(document.body, node, store);
       const byId = (id) => document.getElementById(id);
 
-      // "Send order" — the one bit of glue: compose the form's fields and POST them to the channel. This is
-      // what `CallEndpoint(body=form.value)` will make declarative once the DSL can compose an object.
-      registerHandler("send-order", async () => {
-        const order = {
-          symbol: store.get("symbol"),
-          side: store.get("side"),
-          qty: store.get("qty"),
-          price: store.get("price"),
-        };
-        const res = await fetch("/api/send/orders", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(order),
-        });
-        byId("status").textContent = res.ok
-          ? `sent #${(await res.json()).id}`
-          : "rejected (invalid)";
-      });
+      // "Send order" is fully declarative now (a CallEndpoint(obj({field…})) in the tree): the action
+      // interpreter composes the form's two-way-bound store fields into the POST body — no handler here.
 
       // "Clear" — POST the channel clear, then force each viewer to repaint: a Perspective datagrid does
       // not repaint when its view is emptied (the rows are gone from the data, but linger on screen).

--- a/spaday/examples/gateway.py
+++ b/spaday/examples/gateway.py
@@ -15,10 +15,10 @@ data path is REST + Perspective's own websocket (Mode B), exactly as a real gate
 It is laid out like a gateway dashboard — a header (title + dark/light + view), a full-bleed Perspective
 workspace, a right control gutter, a footer.
 
-The glue (in ``gateway.html``): both buttons use ``NamedJs`` handlers — "Send" composes the form's fields
-into the POST body (the action DSL can't compose an object yet — the roadmap's
-``CallEndpoint(body=form.value)``), and "Clear" POSTs then forces the viewer to repaint (a Perspective
-datagrid doesn't repaint when its view is emptied). The rest of the behavior is declarative.
+"Send" is fully declarative: ``CallEndpoint("POST", …, obj({f: field(f) …}))`` composes the form's
+two-way-bound store fields into the POST body — no handler. The only remaining glue (in ``gateway.html``)
+is "Clear": a ``NamedJs`` handler that POSTs the clear, then forces each viewer to repaint (a Perspective
+datagrid doesn't repaint when its view is emptied).
 
 Run: ``python -m spaday.examples.gateway`` then open http://127.0.0.1:8006/.
 """
@@ -38,7 +38,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.websockets import WebSocket
 
 from spaday import element
-from spaday.actions import NamedJs
+from spaday.actions import CallEndpoint, NamedJs, field, obj
 from spaday.components.form import form
 from spaday.components.perspective import PerspectivePanel
 from spaday.components.shell import App, Body, Footer, Gutter, Main, Nav, Row, Stack
@@ -122,7 +122,15 @@ def controls() -> object:
             .style(margin="0 0 .25rem")
         )
         .child(form(Order))
-        .child(WaButton(variant="brand").prop("id", "send").prop("style", "width:100%").text("Send order").on("click", NamedJs("send-order")))
+        # Send is fully declarative now: compose the form's two-way-bound store fields into the POST body
+        # (obj + field), no hand-written handler. The blotter streaming the new row back is the feedback.
+        .child(
+            WaButton(variant="brand")
+            .prop("id", "send")
+            .prop("style", "width:100%")
+            .text("Send order")
+            .on("click", CallEndpoint("POST", "/api/send/orders", obj({name: field(name) for name in Order.model_fields})))
+        )
         .child(
             Row()
             .child(WaButton(appearance="outlined").prop("id", "clear").text("Clear").on("click", NamedJs("clear-blotter")))

--- a/spaday/tests/test_actions.py
+++ b/spaday/tests/test_actions.py
@@ -85,6 +85,15 @@ def test_obj_composes_an_object_body_for_call_endpoint():
     assert json.loads(apply(node, diff(node, node))) == json.loads(node)
 
 
+def test_field_composes_an_action_body_from_store_state():
+    # `field` now also works in an action expr (read the mounted signal store) — the csp-gateway pattern:
+    # POST a form's two-way-bound state without a hand-written handler
+    action = CallEndpoint("POST", "/api/order", obj({"symbol": field("symbol"), "qty": field("qty")}))
+    assert action.to_dict()["body"]["fields"]["qty"] == {"expr": "field", "name": "qty"}
+    node = element("button").on("click", action).to_json()
+    assert json.loads(apply(node, diff(node, node))) == json.loads(node)  # the core accepts field in an action
+
+
 def test_setprop_coerces_a_plain_value_to_a_literal():
     # a bare Python value is wrapped as a literal expression — no need to write lit(...) explicitly
     assert SetProp(this(), "label", "Go").to_dict()["value"] == {"expr": "lit", "value": "Go"}

--- a/spaday/tests/test_gateway.py
+++ b/spaday/tests/test_gateway.py
@@ -13,7 +13,9 @@ def test_page_has_the_form_and_the_blotter():
     s = json.dumps(gateway.page())
     assert "wa-select" in s  # the Side enum → a select (the form is generated from the schema)
     assert "perspective-panel" in s  # the live blotter
-    assert "send-order" in s  # the Send button's NamedJs handler
+    # Send is declarative now: a CallEndpoint composing the form's two-way-bound store fields (obj + field)
+    assert "/api/send/orders" in s and '"expr": "field"' in s
+    assert "clear-blotter" in s  # Clear still uses a NamedJs handler (the Perspective repaint)
 
 
 def test_send_validates_appends_and_clears():


### PR DESCRIPTION
Closes the csp-gateway capstone's last DSL gap: a form's submit is now **fully declarative**, no `NamedJs`.

## `field` works in actions (not just bindings)
`field` was a binding-only expr (JS `signals.ts`); now the **action interpreter** reads the signal store too:
- `Expr::Field { name }` in the Rust core (`action.rs`) + eval in the wasm crate (`lib.rs`), via a new host `getField`.
- The runtime threads the **mounted store** into each event handler's context (`bindEvent` → `ActionContext.store`), so an action's `field` expr resolves against the same store the bindings use.

This unifies `field` across binding + action contexts and makes "POST the reactive form state" expressible.

## Gateway: declarative form → REST
The gateway's **Send** is now:
```python
CallEndpoint("POST", "/api/send/orders", obj({name: field(name) for name in Order.model_fields}))
```
composing the form's two-way-bound store fields into the POST body. The `NamedJs("send-order")` handler is **deleted** from `gateway.html` (only the Perspective clear+repaint handler remains).

**Verified end-to-end in a browser:** clicking Send POSTs `{symbol,side,qty,price}` read live from the store; no page errors.

## Layer note (re: "consider moving to transports")
The action interpreter reads spaday's **signal store** (reactive UI state), so this stays at the spaday layer — transports remains the lower-level wire; nothing moved down.

## Tests
- Rust: `obj` of `field` exprs round-trips in a `CallEndpoint` body.
- Python: `field` in an action body round-trips the core; gateway page asserts the declarative send.
- JS: `CallEndpoint(obj({field}))` reads the mounted store → correct POST body.
- 118 py + 59 js pass; ruff + prettier clean (wasm + pyo3 rebuilt).

Remaining for full `gateway.html` removal (4.6): the Perspective clear+repaint, config/view push, and native theme.