### PR TITLE
Fragment/embed mode: bootstrap(fragment=True, target=)

### DIFF
--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -14,6 +14,9 @@ What an app would otherwise hand-write in HTML is declared in Python:
 - ``scripts=[…]`` — extra ES-module URLs to load (e.g. ``NamedJs`` handlers).
 - ``base="/dashboard"`` — mount the app under a path prefix, so it coexists with the host's other routes
   (the tree / ``/js`` / ws URLs are all prefixed). Default ``""`` = served at the root.
+- ``fragment=True`` + ``target="#widget"`` — return just the bundle tags + the module ``<script>`` (not a
+  whole document), mounting into ``target`` — a snippet to drop into a host page's template, so spaday is
+  one component among many (several roots can share a page).
 
 **The contract a backend must satisfy** — the generated HTML expects the host to serve, at these paths
 (``{base}`` is the prefix, default empty)::
@@ -97,10 +100,12 @@ def _bundle_head(bundles: Sequence[str], base: str) -> str:
     return "\n    ".join(tags)
 
 
-def _script(base: str, wire: Optional[str], scripts: Sequence[str], ws: str, tree: str, reconnect: bool) -> str:
+def _script(base: str, wire: Optional[str], scripts: Sequence[str], ws: str, tree: str, reconnect: bool, target: Optional[str] = None) -> str:
     """The page's module script: imports, wasm init(s), fetch the tree, then mount — statically, or wired
-    to a transports model (Store + Client + connectStore) when ``wire="transports"``."""
+    to a transports model (Store + Client + connectStore) when ``wire="transports"``. Mounts into
+    ``target`` (a CSS selector) when given, else ``document.body``."""
     js = _js(base)
+    into = f'document.querySelector("{target}")' if target else "document.body"
     transports = wire == "transports"
     frame = tree == "frame"
     runtime_names = ["mount", "init"] + (["Store", "connectStore"] if transports else []) + (["decodeFrame"] if frame else [])
@@ -132,7 +137,7 @@ def _script(base: str, wire: Optional[str], scripts: Sequence[str], ws: str, tre
                 "  socket.addEventListener('close', () => setTimeout(connect, 1000));",
                 "}",
                 "connect();",
-                "mount(document.body, node, store);",
+                f"mount({into}, node, store);",
             ]
         )
     elif transports:
@@ -146,11 +151,11 @@ def _script(base: str, wire: Optional[str], scripts: Sequence[str], ws: str, tre
                 'ws.addEventListener("message", (event) =>',
                 '  link.receive(typeof event.data === "string" ? event.data : new Uint8Array(event.data)),',
                 ");",
-                "mount(document.body, node, store);",
+                f"mount({into}, node, store);",
             ]
         )
     else:
-        lines.append("mount(document.body, node);")
+        lines.append(f"mount({into}, node);")
     return "\n      ".join(lines)
 
 
@@ -165,12 +170,22 @@ def bootstrap(
     scripts: Sequence[str] = (),
     head: str = "",
     title: str = "spaday",
+    fragment: bool = False,
+    target: Optional[str] = None,
 ) -> str:
-    """The bootstrap page HTML (init the wasm core, fetch the tree, mount it). ``base`` prefixes the tree /
-    ``/js`` / ws URLs so the page can be mounted under a sub-path. See the module docstring for the options
-    and the route contract a backend must satisfy."""
+    """The bootstrap markup (init the wasm core, fetch the tree, mount it). ``base`` prefixes the tree /
+    ``/js`` / ws URLs so the page can be mounted under a sub-path.
+
+    By default returns a whole HTML document. With ``fragment=True`` it returns just the bundle tags + the
+    module ``<script>`` — a snippet to **drop into a host page's template** (Jinja/Django/…), so spaday is
+    one component among many rather than the whole page. Pass ``target`` (a CSS selector) to mount into a
+    specific element (e.g. ``"#widget"``) instead of ``document.body``; the host provides that element.
+    See the module docstring for the rest of the options and the route contract."""
     head_markup = "\n    ".join(p for p in (_bundle_head(bundles, base), head) if p)
-    script = _script(base, wire, scripts, ws, tree, reconnect)
+    script = _script(base, wire, scripts, ws, tree, reconnect, target)
+    if fragment:
+        head_block = f"{head_markup}\n" if head_markup else ""
+        return f'{head_block}<script type="module">\n  {script}\n</script>\n'
     return f"""<!doctype html>
 <html lang="en">
   <head>

--- a/spaday/tests/test_bootstrap.py
+++ b/spaday/tests/test_bootstrap.py
@@ -78,3 +78,15 @@ def test_base_prefixes_the_tree_js_and_ws_urls():
     assert "/dash/js/node_modules/@awesome.me" in html  # bundle
     assert "${location.host}/dash/ws" in html  # websocket
     assert 'fetch("/tree.json")' in bootstrap()  # default base="" is unprefixed (served at root)
+
+
+def test_fragment_emits_a_snippet_not_a_document():
+    f = bootstrap(fragment=True, target="#widget", wire="transports", bundles=["webawesome"])
+    assert "<!doctype html>" not in f and "<html" not in f  # a snippet to drop into a host template
+    assert '<script type="module">' in f and "webawesome.css" in f  # bundle tags + the module script
+    assert 'mount(document.querySelector("#widget"), node, store)' in f  # mounts into the target element
+
+
+def test_target_selects_the_mount_point():
+    assert 'mount(document.querySelector("#app"), node)' in bootstrap(target="#app")
+    assert "mount(document.body, node)" in bootstrap()  # default mounts the body


### PR DESCRIPTION
The last granular-integration seam (ROADMAP 4.6) — embed a spaday app inside a bigger app's page.

`bootstrap()` can now emit **just the bundle tags + the module `<script>`** (not a whole document), to drop into a host template (Jinja/Django/…):

```python
bootstrap(fragment=True, target="#widget", bundles=["webawesome"], wire="transports")
```

- `fragment=True` → a snippet, not a full `<html>` document.
- `target="#widget"` → mounts into `document.querySelector("#widget")` instead of `document.body` (the host provides the element; several spaday roots can share one page). `target` works in full-document mode too.
- Default (whole document, `document.body`) is unchanged.

With `mount()`/`base` (already shipped), this completes the embedding story: add spaday routes to an existing app (`mount`), under a sub-path (`base`), and render it as a component within a host page (`fragment`/`target`).

Tests: fragment emits a snippet (no `<html>`) with bundle tags + a `querySelector` mount; `target` selects the mount point; the default stays a full document into the body. 13 bootstrap tests pass (the generic layer needs no webserver dep); ruff clean. Independent of the other open PRs.