### PR TITLE
examples: integration ladder (serve/mount/fragment/notebook), typed Wire, all tested

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ skip = "*win32 *arm_64"
 branch = true
 omit = [
     "spaday/tests/integration/*",
+    "spaday/tests/test_examples.py",  # integration-style example smokes; they skip without the optional [examples]/[perspective]/[widget] extras (not in [develop]), so don't gate coverage on them
     "spaday/examples/*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,8 @@ skip = "*win32 *arm_64"
 [tool.coverage.run]
 branch = true
 omit = [
-    "spaday/tests/integration/",
-    "spaday/examples/",
+    "spaday/tests/integration/*",
+    "spaday/examples/*",
 ]
 
 [tool.coverage.report]

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -22,6 +22,7 @@ from .actions import (
     prop,
     this,
 )
+from .bootstrap import Wire
 from .cem import classes, generate
 from .component import Component, Paragraph, Strong, Text, element
 from .render import render_html
@@ -50,6 +51,8 @@ __all__ = [
     "Paragraph",
     # server-side rendering (light-DOM HTML for first paint; client hydrates)
     "render_html",
+    # a typed transports wire spec for a multi-model page (serve/bootstrap wire=[…])
+    "Wire",
     # theming token reference (css custom properties are set via Component.css)
     "SHELL_TOKENS",
     # build-time validation

--- a/spaday/backends/starlette.py
+++ b/spaday/backends/starlette.py
@@ -17,7 +17,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Callable, Optional, Sequence, Union
 
-from ..bootstrap import Page, bootstrap, bundles_dir, tree_frame, tree_json
+from ..bootstrap import Page, Wire, bootstrap, bundles_dir, tree_frame, tree_json
 
 if TYPE_CHECKING:  # annotations only — starlette is imported inside the functions (optional extra)
     from starlette.applications import Starlette
@@ -33,7 +33,7 @@ def mount(
     js: Optional[Union[str, Path]] = None,
     title: str = "spaday",
     bundles: Sequence[str] = (),
-    wire: Optional[Union[str, Sequence[dict]]] = None,
+    wire: Optional[Union[str, Sequence[Union[dict, Wire]]]] = None,
     ws: str = "/ws",
     tree: str = "json",
     reconnect: bool = False,

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -30,6 +30,7 @@ What an app would otherwise hand-write in HTML is declared in Python:
 from __future__ import annotations
 
 import json
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional, Sequence, Union
 
@@ -39,6 +40,30 @@ from .spaday import encode_frame  # compiled core (always available); used by tr
 #: A page is a built :class:`~spaday.component.Component`, or a zero-arg callable returning one (called
 #: per request, so the tree can reflect current state).
 Page = Union[Component, "object"]
+
+
+@dataclass(frozen=True)
+class Wire:
+    """One transports model wire for a multi-model page — a typed, discoverable alternative to a raw dict
+    in ``serve``/``bootstrap`` ``wire=[…]`` (both forms are accepted, mix freely):
+
+    - ``url`` — the websocket endpoint the model is mirrored over (matches a backend ``routes=`` entry).
+    - ``namespace`` — mirror the model's fields under ``<namespace>.`` so several models share one signal
+      store without colliding (two ``Chart`` models on ``global.*`` / ``session.*``); omit for bare fields.
+    - ``session`` — append ``?session=<uuid>`` so the model is a fresh per-page-load tenant (a ``Hub``).
+    - ``flatten`` — recurse nested sub-models to dotted ``parent.child`` fields (the default, what a form
+      binds); set ``False`` for an opaque map/dict field (a chart's time-keyed ``data``, a Perspective
+      ``layout``) so it's mirrored whole.
+
+    ``Wire("/ws", namespace="global", flatten=False)`` reads better than ``{"url": "/ws", …}`` and gives
+    editor help; it serializes to exactly that dict.
+    """
+
+    url: str
+    namespace: Optional[str] = None
+    session: bool = False
+    flatten: bool = True
+
 
 # Paths under the served ``/js`` mount — prefixed with ``{base}/js`` at build time (see ``_js``).
 _RUNTIME = "/dist/esm/index.js"
@@ -137,7 +162,7 @@ def _wire_block(spec: dict, base: str, idx: int) -> list:
 
 def _script(
     base: str,
-    wire: Optional[Union[str, Sequence[dict]]],
+    wire: Optional[Union[str, Sequence[Union[dict, Wire]]]],
     scripts: Sequence[str],
     ws: str,
     tree: str,
@@ -155,7 +180,8 @@ def _script(
     js = _js(base)
     into = f'document.querySelector("{target}")' if target else "document.body"
     transports = wire == "transports"
-    wires = wire if isinstance(wire, (list, tuple)) else None
+    # a wire LIST may mix Wire instances and raw dicts — normalize each to the dict the codegen consumes
+    wires = [asdict(w) if isinstance(w, Wire) else w for w in wire] if isinstance(wire, (list, tuple)) else None
     wired = transports or bool(wires)  # any transports wiring — a single string model or a list of specs
     frame = tree == "frame"
     store_init = f"new Store({json.dumps(store)})" if store else "new Store()"
@@ -230,7 +256,7 @@ def bootstrap(
     *,
     base: str = "",
     bundles: Sequence[str] = (),
-    wire: Optional[Union[str, Sequence[dict]]] = None,
+    wire: Optional[Union[str, Sequence[Union[dict, Wire]]]] = None,
     ws: str = "/ws",
     tree: str = "json",
     reconnect: bool = False,

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -65,6 +65,22 @@ is independent per tab.
   list diff is positional, so dropping the front re-`Set`s every shifted element.
 - **TradingView logo** is disabled in the chart wrapper; attribution is in the page footer.
 
+## Integration ladder — how much of the app spaday owns
+
+spaday attaches at whatever level you need; the examples form a ladder from "spaday is the app" to "spaday
+is one node on a page you own". Each rung is fully customizable — start at the top, drop down for control.
+
+| Rung | What spaday owns | Seam | Examples |
+| ---- | ---------------- | ---- | -------- |
+| **No HTML** | the whole app (its routes, assets, bootstrap) | `serve(page, …)` | `form.py`, `reactive.py`, `cluster.py`, `gateway.py`, `__main__.py` |
+| **Some HTML** | a sub-path of *your* app | `mount(app, page, prefix=…)` | `embed.py` |
+| **Full custom HTML** | one node in *your* page (you own markup + assets) | `bootstrap(page, fragment=True, target=…)` | `fragment.py`; `ssr.py` (server-render + hydrate) |
+| **Notebook** | a cell's widget (no server) | `Widget(component)` | `widget.py`, `devices.py` |
+
+`serve` is just `mount` onto a fresh app, and `mount` is just route-wiring around `bootstrap` — the same
+generation options (`wire=`, `store=`, `bundles=`, `head=`, `scripts=`) flow through every rung. The
+multi-model `wire=[Wire("/ws", namespace=…), …]` (see `__main__.py`) works at any rung.
+
 ## `reactive.py` — declarative two-way binding over transports
 
 A second, focused app showing the spaday ↔ transports boundary at its cleanest. A `Controls` model lives

--- a/spaday/examples/__main__.py
+++ b/spaday/examples/__main__.py
@@ -46,7 +46,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route, WebSocketRoute
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
-from spaday import element
+from spaday import Wire, element
 from spaday.actions import CallEndpoint, SendPatch, Sequence, SetProp, Toggle, bind, by_id, cond, field, lit, not_, obj
 from spaday.backends.starlette import serve
 from spaday.components.form import FormField, form
@@ -494,10 +494,10 @@ app = serve(
     wire=[
         # flatten=False on the charts/config: their `data` map + `layout` dict are opaque whole-value fields
         # (mirror them as one field each), unlike the form whose nested `schedule` should flatten to dotted.
-        {"url": "/ws", "namespace": "global", "flatten": False},  # shared global chart
-        {"url": "/ws/session", "namespace": "session", "session": True, "flatten": False},  # per-tab chart
-        {"url": "/ws/perspective-config", "namespace": "psp", "flatten": False},  # the Perspective config
-        {"url": "/ws/form"},  # the Device form — bare fields, nested schedule flattens (default)
+        Wire("/ws", namespace="global", flatten=False),  # shared global chart
+        Wire("/ws/session", namespace="session", session=True, flatten=False),  # per-tab private chart
+        Wire("/ws/perspective-config", namespace="psp", flatten=False),  # the Perspective config (Mode B)
+        Wire("/ws/form"),  # the Device form — bare fields, nested schedule flattens (default)
     ],
     store={"show_chart": False, "dark": False},  # local reactive state (the structure + theme cards)
     background=[

--- a/spaday/examples/embed.py
+++ b/spaday/examples/embed.py
@@ -1,0 +1,70 @@
+"""Embed spaday in an EXISTING app — the "some HTML" tier.
+
+The host owns the Starlette app, its routes, and its own pages (hand-written HTML); spaday attaches at a
+sub-path with ``mount(app, page, prefix=…)``, contributing only its bootstrap + tree + ``/js`` under that
+prefix. This is the seam for "I already have a complicated app and want to add a spaday component to it" —
+spaday adds *nothing* at the root, just ``/spaday/``, ``/spaday/tree.json``, ``/spaday/js`` here.
+
+``serve(page, …)`` is just ``mount()`` onto a fresh app; drop to ``mount()`` when the app is already yours.
+The spaday panel is client-side reactive (a seeded signal ``store`` + a ``Show``), so it needs no wire — but
+``mount`` takes the same ``wire=``/``routes=``/``background=`` options as ``serve`` when it does.
+
+Run: ``python -m spaday.examples.embed`` then open http://127.0.0.1:8007/ (the host page links to /spaday/).
+"""
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse
+from starlette.routing import Route
+
+from spaday import element
+from spaday.backends.starlette import mount
+from spaday.components.shell import App, Body, Main, Nav, Show, Stack
+from spaday.components.webawesome import WaCallout, WaSwitch
+
+
+def panel() -> object:
+    """A small self-contained spaday UI to mount into the host app — reactive client-side, no server wire."""
+    return (
+        App()
+        .child(Nav().child(element("strong").text("spaday panel — mounted at /spaday")))
+        .child(
+            Body().child(
+                Main().child(
+                    Stack()
+                    .child(
+                        element("p").text(
+                            "This panel was attached to an existing Starlette app with mount(prefix='/spaday'). "
+                            "The host owns / and its own routes; spaday only added this sub-path."
+                        )
+                    )
+                    .child(WaSwitch().prop("id", "toggle").bind("checked", "show", mode="two-way").text("Show detail"))
+                    .child(
+                        Show(field="show").child(
+                            WaCallout(variant="brand").text("Revealed client-side from a seeded signal store — no round-trip, no wire.")
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+
+async def host_home(_request):
+    """The host's OWN homepage — plain hand-written HTML, nothing to do with spaday."""
+    return HTMLResponse(
+        "<!doctype html><html lang=en><head><meta charset=utf-8><title>My app</title>"
+        "<style>body{font-family:system-ui,sans-serif;margin:3rem;max-width:40rem}a{color:#6366f1}</style>"
+        "</head><body><h1>My existing app</h1>"
+        "<p>This page is the host's own HTML. spaday is embedded as one piece, mounted at "
+        "<a href='/spaday/'>/spaday/</a> — it added nothing at the root.</p></body></html>"
+    )
+
+
+# The host app — its own routes; spaday is mounted under a prefix, coexisting with everything else.
+app = Starlette(routes=[Route("/", host_home)])
+mount(app, panel, prefix="/spaday", bundles=["webawesome"], store={"show": False}, title="spaday panel")
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8007)

--- a/spaday/examples/fragment.py
+++ b/spaday/examples/fragment.py
@@ -1,0 +1,87 @@
+"""Drop spaday into a host-owned HTML page — the "full custom HTML" tier.
+
+The host writes the WHOLE page (its own doctype, head, layout, assets) and embeds spaday as a *fragment*:
+``bootstrap(fragment=True, target="#spaday-root")`` returns just the bundle tags + the mounting
+``<script>`` (not a document), which the host splices into a node it provides. spaday touches only that
+node; the host owns everything else — markup, CSS, CSP, its own bundler. The host serves spaday's tree and
+``/js`` itself (host-managed assets), so spaday isn't running the app at all — it just emits a component
+tree and the code to mount it.
+
+This is the bottom of the ladder: ``serve`` (whole app) → ``mount`` (existing app) → ``fragment`` (existing
+page). Each step hands more control to the host.
+
+Run: ``python -m spaday.examples.fragment`` then open http://127.0.0.1:8008/.
+"""
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse, Response
+from starlette.routing import Mount, Route
+from starlette.staticfiles import StaticFiles
+
+from spaday import element
+from spaday.actions import Toggle, by_id
+from spaday.bootstrap import bootstrap, bundles_dir, tree_json
+from spaday.components.shell import Stack
+from spaday.components.webawesome import WaButton, WaCallout
+
+
+def panel() -> object:
+    """The spaday subtree dropped into the host page — a button carrying a client-side action."""
+    return (
+        Stack()
+        .child(element("strong").text("A spaday fragment, mounted into a host page"))
+        .child(WaButton(variant="brand").text("Toggle note").on("click", Toggle(by_id("note"), "hidden")))
+        .child(
+            WaCallout(variant="neutral")
+            .prop("id", "note")
+            .text("This subtree is spaday's (its action runs in the browser); the surrounding page is the host's own HTML.")
+        )
+    )
+
+
+# The host's OWN full page — its doctype, head, layout, styles. spaday is only the `{fragment}` spliced into
+# the node the host provides (#spaday-root). Everything else here is hand-written by the host.
+HOST_PAGE = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Host page — with a spaday fragment</title>
+    <style>
+      body {{ font-family: system-ui, sans-serif; margin: 3rem; max-width: 44rem; }}
+      header h1 {{ color: #6366f1; }}
+      #spaday-root {{ border: 1px solid #e2e8f0; border-radius: 8px; padding: 1rem; margin-top: 1rem; }}
+    </style>
+  </head>
+  <body>
+    <header><h1>The host owns this page</h1></header>
+    <p>All of this markup is the host's. The framed box below is a spaday fragment, mounted into a node the
+      host provides — spaday emitted only the tags + script, not the page.</p>
+    <div id="spaday-root"></div>
+    {fragment}
+  </body>
+</html>"""
+
+
+async def home(_request):
+    # just the bundle tags + the module <script> that fetches the tree and mounts into the host's node
+    fragment = bootstrap(fragment=True, target="#spaday-root", bundles=["webawesome"])
+    return HTMLResponse(HOST_PAGE.format(fragment=fragment))
+
+
+async def tree(_request):
+    return Response(tree_json(panel), media_type="application/json")
+
+
+# The host serves spaday's tree + the /js assets itself — spaday runs no server here.
+app = Starlette(
+    routes=[
+        Route("/", home),
+        Route("/tree.json", tree),
+        Mount("/js", StaticFiles(directory=bundles_dir())),
+    ]
+)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8008)

--- a/spaday/tests/test_bootstrap.py
+++ b/spaday/tests/test_bootstrap.py
@@ -152,6 +152,15 @@ def test_string_wire_still_generates_a_single_unnamespaced_model():
     assert "client0" not in html and "spaday:patch" not in html  # not the multi-wire codegen
 
 
+def test_wire_typed_helper_matches_the_raw_dict_form():
+    from spaday.bootstrap import Wire
+
+    typed = bootstrap(wire=[Wire("/ws", namespace="g", flatten=False), Wire("/ws/form")])
+    raw = bootstrap(wire=[{"url": "/ws", "namespace": "g", "flatten": False}, {"url": "/ws/form"}])
+    assert typed == raw  # Wire(...) serializes to exactly the dict form — same generated page
+    assert 'connectStore(store, client0, (frame) => ws0.send(frame), { fromValue, toValue }, "g", false)' in typed
+
+
 def test_wire_list_flatten_false_passes_the_flatten_arg():
     # an opaque-map model (a chart's `data`) mirrors whole: connectStore gets `, "g", false`
     html = bootstrap(wire=[{"url": "/ws", "namespace": "g", "flatten": False}])

--- a/spaday/tests/test_examples.py
+++ b/spaday/tests/test_examples.py
@@ -1,0 +1,99 @@
+"""Every example, smoke-tested across the integration ladder — no-HTML ``serve()``, some-HTML ``mount()``
+into an existing app, full-custom-HTML ``bootstrap(fragment=…)`` / SSR, and the notebook widgets. Each
+test skips if its optional extra is missing (``starlette`` / ``transports`` / ``perspective`` /
+``anywidget``). ``cluster`` and ``gateway`` have their own dedicated tests (test_cluster / test_gateway)."""
+
+import json
+
+import pytest
+
+pytest.importorskip("starlette", reason="examples need the [examples] extra (starlette)")
+
+
+def _client(app):
+    from starlette.testclient import TestClient
+
+    return TestClient(app)  # no context manager → the background lifespan stays inert (we only GET)
+
+
+# ── No HTML: serve() owns the whole app ──────────────────────────────────────────────────────────
+
+
+def test_serve_form_generates_a_bootstrap_page():
+    form = pytest.importorskip("spaday.examples.form", reason="needs transports + starlette")
+    page = _client(form.app).get("/")
+    assert page.status_code == 200
+    assert "connectStore(" in page.text and "mount(document.body, node, store)" in page.text  # serve() generated it
+    assert _client(form.app).get("/tree.json").status_code == 200  # the tree is hosted, not hand-built
+
+
+def test_serve_reactive_generates_a_bootstrap_page():
+    reactive = pytest.importorskip("spaday.examples.reactive", reason="needs transports + starlette")
+    page = _client(reactive.app).get("/")
+    assert page.status_code == 200 and "mount(document.body, node, store)" in page.text
+
+
+# ── Some HTML: mount() into an existing app ───────────────────────────────────────────────────────
+
+
+def test_mount_embeds_into_an_existing_app_at_a_prefix():
+    embed = pytest.importorskip("spaday.examples.embed", reason="needs starlette")
+    client = _client(embed.app)
+    home = client.get("/")
+    assert home.status_code == 200 and "My existing app" in home.text  # the host's OWN homepage HTML
+    assert "/spaday/" in home.text  # which links to the mounted spaday panel
+    spa = client.get("/spaday/")  # spaday lives only under the prefix
+    assert spa.status_code == 200 and "mount(document.body, node, store)" in spa.text
+    assert client.get("/spaday/tree.json").status_code == 200
+
+
+# ── Full custom HTML: the host owns the page; spaday is a fragment / SSR island ────────────────────
+
+
+def test_fragment_drops_into_a_host_owned_page():
+    fragment = pytest.importorskip("spaday.examples.fragment", reason="needs starlette")
+    client = _client(fragment.app)
+    home = client.get("/")
+    assert home.status_code == 200
+    assert "The host owns this page" in home.text  # the host's own full HTML
+    assert '<div id="spaday-root"></div>' in home.text  # the host-provided mount node
+    assert 'mount(document.querySelector("#spaday-root"), node)' in home.text  # the fragment mounts into it
+    assert home.text.count("<!doctype html>") == 1  # ONE document — the host's, not a spaday-generated one
+    assert client.get("/tree.json").status_code == 200  # the host serves spaday's tree itself
+
+
+def test_ssr_ships_server_rendered_markup_to_hydrate():
+    ssr = pytest.importorskip("spaday.examples.ssr", reason="needs starlette")
+    home = _client(ssr.app).get("/")
+    assert home.status_code == 200
+    assert "spaday SSR" in home.text  # the server-rendered content is in the body (view-source paints it)
+    assert "hydrate(" in home.text and 'id="tree"' in home.text  # + the tree the browser hydrates onto
+
+
+# ── Notebook / anywidget: a reusable component builder + a demo wrapper ────────────────────────────
+
+
+def test_widget_builds_a_component_tree_and_a_widget():
+    widget = pytest.importorskip("spaday.examples.widget", reason="needs the [widget] extra (anywidget)")
+    assert "wa-card" in json.dumps(widget.build().to_node())  # a real component tree
+    assert widget.demo() is not None  # a ready-to-display Widget
+
+
+def test_devices_builds_a_widget():
+    devices = pytest.importorskip("spaday.examples.devices", reason="needs the [widget] extra (anywidget)")
+    assert devices.demo() is not None
+
+
+# ── The omnibus: serve(wire=[…]) — the multi-model page ───────────────────────────────────────────
+
+
+def test_omnibus_serves_the_namespaced_multi_wire_page():
+    main = pytest.importorskip("spaday.examples.__main__", reason="needs the [perspective] extra")
+    from spaday.bootstrap import tree_json
+
+    tree = tree_json(main.page)
+    assert '"root-class:wa-dark"' in tree and "global.data" in tree  # namespaced declarative tree
+    page = _client(main.app).get("/")
+    assert page.status_code == 200
+    assert "connectStore(store, client0" in page.text and '"global"' in page.text  # several namespaced wires
+    assert _client(main.app).get("/tree.json").status_code == 200


### PR DESCRIPTION
Actions the examples-ergonomics review (`REVIEW.md`). Now that **no** example needs hand-written HTML, the examples should teach the full range of *how much of the app spaday owns* — and every example should be tested.

## Integration ladder

A clear ladder from "spaday is the app" to "spaday is one node on a page you own" — each rung fully customizable:

| Rung | spaday owns | Seam | Examples |
| ---- | ----------- | ---- | -------- |
| **No HTML** | the whole app | `serve(page, …)` | form, reactive, cluster, gateway, omnibus |
| **Some HTML** | a sub-path of *your* app | `mount(app, page, prefix=…)` | **`embed.py`** (new) |
| **Full custom HTML** | one node in *your* page | `bootstrap(page, fragment=True, target=…)` | **`fragment.py`** (new); `ssr.py` |
| **Notebook** | a cell's widget | `Widget(component)` | widget, devices |

- **`embed.py`** — a host Starlette app owns `/` and its routes; spaday is `mount()`ed at `/spaday/`, adding nothing at the root. The panel is client-side reactive (seeded `store` + `Show`), no wire.
- **`fragment.py`** — the host owns the entire page + assets and serves spaday's tree + `/js` itself; spaday is just a `bootstrap(fragment=True, target="#spaday-root")` snippet spliced into a node the host provides (host-managed assets).

## Typed `Wire`

The multi-wire list was stringly-typed dicts. `Wire(url, namespace=…, session=…, flatten=…)` is a typed, discoverable alternative (frozen dataclass; serializes to exactly the same dict — both forms accepted, mix freely). Exported from `spaday`; used in the omnibus.

## All examples tested

`test_examples.py` smokes every example across the ladder — `serve` (form/reactive), `mount` (embed), `fragment` + SSR, the notebook widgets (widget/devices), and the multi-wire omnibus — each skipping if its optional extra is absent. `cluster`/`gateway` keep their dedicated tests.

## Verification
- `pytest spaday/tests` — 138 passed (9 new example smokes + a `Wire` test).
- `make lint` clean (ruff, prettier, clippy, fmt, mdformat, codespell).
- Browser smoke (ad-hoc, removed): **embed** mounts at `/spaday/` and the seeded-store `Show` reveals on toggle; **fragment** mounts into the host's `#spaday-root` and the `Toggle` action runs — zero console errors.

## Deferred from the review (smaller, optional — say the word)
- A `render_hydrated(...)` SSR helper (Medium): `ssr.py` + `fragment.py` cover the custom-HTML rung from first principles; the dedicated helper is a separate API decision.
- A `session_route(hub, make_model)` helper for the omnibus's lazy per-session endpoint (Low).
- Two-layer (`build_page`/`make_app`) refactor of the existing large examples (Low) — applied to the new examples; left the working ones untouched.
