### PR TITLE
examples: address branch review — prefix mount routes, CSP nonce, wired embed, lifespan in tests

### DIFF
--- a/spaday/backends/starlette.py
+++ b/spaday/backends/starlette.py
@@ -23,6 +23,25 @@ if TYPE_CHECKING:  # annotations only — starlette is imported inside the funct
     from starlette.applications import Starlette
 
 
+def _prefixed(routes: Sequence, prefix: str) -> list:
+    """Prefix each supplied ``Route``/``WebSocketRoute`` path with ``prefix`` so it lines up with the wire
+    URLs :func:`bootstrap` generates under the same prefix (a ``wire`` ws at ``{prefix}/ws`` must match its
+    ``WebSocketRoute``). Other route types (``Mount``/``Host``) pass through — prefix those yourself."""
+    if not prefix:
+        return list(routes)
+    from starlette.routing import Route, WebSocketRoute
+
+    out = []
+    for r in routes:
+        if isinstance(r, WebSocketRoute):
+            out.append(WebSocketRoute(f"{prefix}{r.path}", r.endpoint, name=r.name))
+        elif isinstance(r, Route):
+            out.append(Route(f"{prefix}{r.path}", r.endpoint, methods=r.methods, name=r.name))
+        else:
+            out.append(r)
+    return out
+
+
 def mount(
     app: Starlette,
     page: Page,
@@ -40,17 +59,32 @@ def mount(
     scripts: Sequence[str] = (),
     head: str = "",
     store: Optional[dict] = None,
+    nonce: Optional[str] = None,
 ) -> Starlette:
     """Add spaday's routes (page, tree, ``/js``, plus ``routes``) to an existing Starlette ``app`` under
-    ``prefix``. Generation options are passed to :func:`spaday.bootstrap.bootstrap` (incl. ``store``, a
-    local signal-store seed); ``html`` serves a hand-authored bootstrap instead; ``js`` overrides the
-    bundle dir. Returns ``app`` for chaining."""
+    ``prefix``. The supplied ``routes`` are **prefixed too** (a ``Route``/``WebSocketRoute`` at ``/ws``
+    becomes ``{prefix}/ws``), so a wired panel's generated ws URL and its endpoint line up — pass the
+    *unprefixed* path (``WebSocketRoute("/ws", …)``) and let ``mount`` add the prefix. Generation options
+    pass to :func:`spaday.bootstrap.bootstrap` (incl. ``store`` and ``nonce``, a CSP nonce for the
+    generated scripts); ``html`` serves a hand-authored bootstrap instead; ``js`` overrides the bundle dir.
+    ``mount`` only adds routes — **the host owns the app's lifespan**, so run any ``transports.autosync``
+    in your own lifespan (see ``examples/embed.py``). Returns ``app`` for chaining."""
     from starlette.responses import FileResponse, HTMLResponse, Response
     from starlette.routing import Mount, Route
     from starlette.staticfiles import StaticFiles
 
     body = bootstrap(
-        base=prefix, bundles=bundles, wire=wire, ws=ws, tree=tree, reconnect=reconnect, scripts=scripts, head=head, title=title, store=store
+        base=prefix,
+        bundles=bundles,
+        wire=wire,
+        ws=ws,
+        tree=tree,
+        reconnect=reconnect,
+        scripts=scripts,
+        head=head,
+        title=title,
+        store=store,
+        nonce=nonce,
     )
     js_dir = Path(js) if js is not None else bundles_dir()
 
@@ -64,7 +98,7 @@ def mount(
         return Response(tree_frame(page), media_type="application/octet-stream")
 
     tree_route = Route(f"{prefix}/tree", tree_route_frame) if tree == "frame" else Route(f"{prefix}/tree.json", tree_route_json)
-    app.routes.extend([Route(f"{prefix}/", homepage), tree_route, *routes, Mount(f"{prefix}/js", StaticFiles(directory=js_dir))])
+    app.routes.extend([Route(f"{prefix}/", homepage), tree_route, *_prefixed(routes, prefix), Mount(f"{prefix}/js", StaticFiles(directory=js_dir))])
     return app
 
 
@@ -72,7 +106,7 @@ def serve(page: Page, *, background: Sequence[Awaitable] = (), lifespan: Optiona
     """Create a Starlette app and :func:`mount` ``page`` onto it. ``background`` coroutines run for the
     app's lifetime (or pass a custom ``lifespan`` for ordered startup, e.g. a clustering relay); all other
     keyword options are :func:`mount`'s (``prefix``/``routes``/``html``/``js``/``title``/``bundles``/
-    ``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``)."""
+    ``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``/``store``/``nonce``)."""
     from starlette.applications import Starlette
 
     @asynccontextmanager

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -114,14 +114,15 @@ def tree_frame(page: Page, *, id: str = "spa-tree") -> bytes:
     return encode_frame(json.dumps(_resolve(page).to_node()), id, "snapshot", 0, "application/json")
 
 
-def _bundle_head(bundles: Sequence[str], base: str) -> str:
+def _bundle_head(bundles: Sequence[str], base: str, nonce: Optional[str] = None) -> str:
+    n = f' nonce="{nonce}"' if nonce else ""  # CSP nonce on the generated script/style tags
     tags = []
     for name in bundles:
         if name not in BUNDLES:
             raise ValueError(f"unknown bundle {name!r}; known: {', '.join(sorted(BUNDLES))}")
         for kind, path in BUNDLES[name]:
             url = f"{_js(base)}{path}"
-            tags.append(f'<link rel="stylesheet" href="{url}" />' if kind == "css" else f'<script type="module" src="{url}"></script>')
+            tags.append(f'<link rel="stylesheet"{n} href="{url}" />' if kind == "css" else f'<script type="module"{n} src="{url}"></script>')
     return "\n    ".join(tags)
 
 
@@ -266,6 +267,7 @@ def bootstrap(
     store: Optional[dict] = None,
     fragment: bool = False,
     target: Optional[str] = None,
+    nonce: Optional[str] = None,
 ) -> str:
     """The bootstrap markup (init the wasm core, fetch the tree, mount it). ``base`` prefixes the tree /
     ``/js`` / ws URLs so the page can be mounted under a sub-path. ``store`` seeds a local signal ``Store``
@@ -279,12 +281,15 @@ def bootstrap(
     module ``<script>`` — a snippet to **drop into a host page's template** (Jinja/Django/…), so spaday is
     one component among many rather than the whole page. Pass ``target`` (a CSS selector) to mount into a
     specific element (e.g. ``"#widget"``) instead of ``document.body``; the host provides that element.
-    See the module docstring for the rest of the options and the route contract."""
-    head_markup = "\n    ".join(p for p in (_bundle_head(bundles, base), head) if p)
+    ``nonce`` stamps the generated ``<script>``/``<link>`` tags with a CSP nonce, so a host with a strict
+    ``script-src``/``style-src`` policy can allow the snippet. See the module docstring for the rest of the
+    options and the route contract."""
+    n = f' nonce="{nonce}"' if nonce else ""
+    head_markup = "\n    ".join(p for p in (_bundle_head(bundles, base, nonce), head) if p)
     script = _script(base, wire, scripts, ws, tree, reconnect, store, target)
     if fragment:
         head_block = f"{head_markup}\n" if head_markup else ""
-        return f'{head_block}<script type="module">\n  {script}\n</script>\n'
+        return f'{head_block}<script type="module"{n}>\n  {script}\n</script>\n'
     return f"""<!doctype html>
 <html lang="en">
   <head>
@@ -294,7 +299,7 @@ def bootstrap(
     {head_markup}
   </head>
   <body>
-    <script type="module">
+    <script type="module"{n}>
       {script}
     </script>
   </body>

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -74,7 +74,7 @@ is one node on a page you own". Each rung is fully customizable — start at the
 | ---- | ---------------- | ---- | -------- |
 | **No HTML** | the whole app (its routes, assets, bootstrap) | `serve(page, …)` | `form.py`, `reactive.py`, `cluster.py`, `gateway.py`, `__main__.py` |
 | **Some HTML** | a sub-path of *your* app | `mount(app, page, prefix=…)` | `embed.py` |
-| **Full custom HTML** | one node in *your* page (you own markup + assets) | `bootstrap(page, fragment=True, target=…)` | `fragment.py`; `ssr.py` (server-render + hydrate) |
+| **Full custom HTML** | one node in *your* page (you own markup + assets) | `bootstrap(fragment=True, target=…)` + `tree_json(page)` | `fragment.py`; `ssr.py` (server-render + hydrate) |
 | **Notebook** | a cell's widget (no server) | `Widget(component)` | `widget.py`, `devices.py` |
 
 `serve` is just `mount` onto a fresh app, and `mount` is just route-wiring around `bootstrap` — the same

--- a/spaday/examples/embed.py
+++ b/spaday/examples/embed.py
@@ -1,49 +1,70 @@
-"""Embed spaday in an EXISTING app — the "some HTML" tier.
+"""Embed spaday in an EXISTING app — the "some HTML" tier, the *wired* case.
 
-The host owns the Starlette app, its routes, and its own pages (hand-written HTML); spaday attaches at a
-sub-path with ``mount(app, page, prefix=…)``, contributing only its bootstrap + tree + ``/js`` under that
-prefix. This is the seam for "I already have a complicated app and want to add a spaday component to it" —
-spaday adds *nothing* at the root, just ``/spaday/``, ``/spaday/tree.json``, ``/spaday/js`` here.
+The host owns the Starlette app, its routes, its own pages (hand-written HTML), **and the app lifespan**.
+spaday attaches at a sub-path with ``mount(app, page, prefix="/spaday", …)``, contributing its bootstrap +
+tree + ``/js`` *and its websocket route* under that prefix. This is the seam for "I already have a
+complicated app and want to add a live spaday panel to it."
 
-``serve(page, …)`` is just ``mount()`` onto a fresh app; drop to ``mount()`` when the app is already yours.
-The spaday panel is client-side reactive (a seeded signal ``store`` + a ``Show``), so it needs no wire — but
-``mount`` takes the same ``wire=``/``routes=``/``background=`` options as ``serve`` when it does.
+Three things the simple case glosses over, shown here:
 
-Run: ``python -m spaday.examples.embed`` then open http://127.0.0.1:8007/ (the host page links to /spaday/).
+- **Route prefixing.** ``mount(prefix="/spaday")`` prefixes the supplied ``routes`` too, so the wire URL
+  spaday generates (``/spaday/ws``) lines up with the ``WebSocketRoute`` — pass the *unprefixed* ``/ws``.
+- **Lifespan composition.** ``mount`` only adds routes; the **host owns the lifespan**, so the host runs
+  ``transports.autosync`` in its own lifespan (``mount`` has no ``background`` — that's ``serve``'s).
+- **A real wire.** the panel two-way binds to a model hosted over transports, so an edit fans to every tab.
+
+Run: ``python -m spaday.examples.embed`` then open http://127.0.0.1:8007/ (the host page links to /spaday/;
+open it in two tabs to see edits fan).
 """
 
+import asyncio
+from contextlib import asynccontextmanager
+
+import transports
 import uvicorn
+from pydantic import BaseModel
 from starlette.applications import Starlette
 from starlette.responses import HTMLResponse
-from starlette.routing import Route
+from starlette.routing import Route, WebSocketRoute
 
 from spaday import element
 from spaday.backends.starlette import mount
-from spaday.components.shell import App, Body, Main, Nav, Show, Stack
-from spaday.components.webawesome import WaCallout, WaSwitch
+from spaday.components.shell import App, Body, Main, Nav, Row, Stack
+
+HOST = "127.0.0.1"
+
+
+class Shared(BaseModel):
+    message: str = "edit me — it fans to every tab"
+
+
+session = transports.Session()
+shared = Shared()
+session.host(shared)
+server = transports.Server(session)
 
 
 def panel() -> object:
-    """A small self-contained spaday UI to mount into the host app — reactive client-side, no server wire."""
+    """A live spaday panel, two-way bound to the hosted ``Shared`` model over transports."""
     return (
         App()
-        .child(Nav().child(element("strong").text("spaday panel — mounted at /spaday")))
+        .child(Nav().child(element("strong").text("spaday panel — mounted at /spaday, wired over transports")))
         .child(
             Body().child(
                 Main().child(
                     Stack()
                     .child(
                         element("p").text(
-                            "This panel was attached to an existing Starlette app with mount(prefix='/spaday'). "
-                            "The host owns / and its own routes; spaday only added this sub-path."
+                            "Attached to an existing Starlette app with mount(prefix='/spaday'). The host owns / "
+                            "and the app lifespan (it runs autosync); mount() prefixed the wire route to /spaday/ws."
                         )
                     )
-                    .child(WaSwitch().prop("id", "toggle").bind("checked", "show", mode="two-way").text("Show detail"))
                     .child(
-                        Show(field="show").child(
-                            WaCallout(variant="brand").text("Revealed client-side from a seeded signal store — no round-trip, no wire.")
-                        )
+                        Row()
+                        .child(element("label").text("Shared message"))
+                        .child(element("input", id="msg", type="text").bind("value", "message", mode="two-way"))
                     )
+                    .child(Row().child(element("span").text("Echo: ")).child(element("strong").bind("textContent", "message")))
                 )
             )
         )
@@ -56,15 +77,32 @@ async def host_home(_request):
         "<!doctype html><html lang=en><head><meta charset=utf-8><title>My app</title>"
         "<style>body{font-family:system-ui,sans-serif;margin:3rem;max-width:40rem}a{color:#6366f1}</style>"
         "</head><body><h1>My existing app</h1>"
-        "<p>This page is the host's own HTML. spaday is embedded as one piece, mounted at "
-        "<a href='/spaday/'>/spaday/</a> — it added nothing at the root.</p></body></html>"
+        "<p>This page is the host's own HTML. A live spaday panel is embedded at "
+        "<a href='/spaday/'>/spaday/</a> — open it in two tabs and watch edits fan over transports.</p></body></html>"
     )
 
 
-# The host app — its own routes; spaday is mounted under a prefix, coexisting with everything else.
-app = Starlette(routes=[Route("/", host_home)])
-mount(app, panel, prefix="/spaday", bundles=["webawesome"], store={"show": False}, title="spaday panel")
+@asynccontextmanager
+async def lifespan(_app):
+    # the HOST owns the lifespan — mount() only adds routes, so run the model's autosync here
+    task = asyncio.create_task(transports.autosync(server))
+    try:
+        yield
+    finally:
+        task.cancel()
+
+
+# The host app — its own routes + its own lifespan; spaday is mounted under a prefix, wire route and all.
+app = Starlette(routes=[Route("/", host_home)], lifespan=lifespan)
+mount(
+    app,
+    panel,
+    prefix="/spaday",
+    wire="transports",
+    routes=[WebSocketRoute("/ws", transports.ws_endpoint(server))],  # mount prefixes this to /spaday/ws
+    title="spaday panel",
+)
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="127.0.0.1", port=8007)
+    uvicorn.run(app, host=HOST, port=8007)

--- a/spaday/examples/fragment.py
+++ b/spaday/examples/fragment.py
@@ -1,17 +1,20 @@
 """Drop spaday into a host-owned HTML page — the "full custom HTML" tier.
 
-The host writes the WHOLE page (its own doctype, head, layout, assets) and embeds spaday as a *fragment*:
-``bootstrap(fragment=True, target="#spaday-root")`` returns just the bundle tags + the mounting
-``<script>`` (not a document), which the host splices into a node it provides. spaday touches only that
-node; the host owns everything else — markup, CSS, CSP, its own bundler. The host serves spaday's tree and
-``/js`` itself (host-managed assets), so spaday isn't running the app at all — it just emits a component
-tree and the code to mount it.
+The host writes the WHOLE page (its own doctype, head, layout, markup, CSS) and embeds spaday as a
+*fragment*: ``bootstrap(fragment=True, target="#spaday-root")`` returns the bundle tags + an **inline**
+module ``<script>`` (not a document) that imports the spaday runtime/wasm from the served ``/js`` tree and
+mounts into a node the host provides. spaday touches only that node; the host owns the rest of the page and
+serves spaday's tree + ``/js`` itself (host-managed assets) — spaday isn't running the app, just emitting a
+tree and the code to mount it. (The script is inline, so a host with a strict ``script-src`` CSP passes
+``bootstrap(…, nonce=<per-request-nonce>)`` to stamp the generated tags — demonstrated below.)
 
 This is the bottom of the ladder: ``serve`` (whole app) → ``mount`` (existing app) → ``fragment`` (existing
 page). Each step hands more control to the host.
 
 Run: ``python -m spaday.examples.fragment`` then open http://127.0.0.1:8008/.
 """
+
+import secrets
 
 import uvicorn
 from starlette.applications import Starlette
@@ -64,9 +67,13 @@ HOST_PAGE = """<!doctype html>
 
 
 async def home(_request):
-    # just the bundle tags + the module <script> that fetches the tree and mounts into the host's node
-    fragment = bootstrap(fragment=True, target="#spaday-root", bundles=["webawesome"])
-    return HTMLResponse(HOST_PAGE.format(fragment=fragment))
+    # A strict-CSP host: a fresh per-request nonce stamps the generated tags (bootstrap(nonce=…)) and goes
+    # in the host's CSP header, so the inline module script is allowed without 'unsafe-inline'. ('self'
+    # covers the imported /js modules; 'wasm-unsafe-eval' lets spaday compile its wasm core.)
+    nonce = secrets.token_urlsafe(16)
+    fragment = bootstrap(fragment=True, target="#spaday-root", bundles=["webawesome"], nonce=nonce)
+    csp = f"script-src 'self' 'nonce-{nonce}' 'wasm-unsafe-eval'"
+    return HTMLResponse(HOST_PAGE.format(fragment=fragment), headers={"Content-Security-Policy": csp})
 
 
 async def tree(_request):

--- a/spaday/tests/test_backend_starlette.py
+++ b/spaday/tests/test_backend_starlette.py
@@ -44,16 +44,24 @@ def test_mount_adds_routes_to_an_existing_app_under_a_prefix(tmp_path):
 
 def test_mount_prefixes_supplied_routes_to_match_the_generated_wire(tmp_path):
     from starlette.applications import Starlette
-    from starlette.routing import WebSocketRoute
+    from starlette.routing import Mount, WebSocketRoute
+    from starlette.staticfiles import StaticFiles
 
     async def ws_ep(websocket):  # a stand-in wire endpoint
         await websocket.accept()
         await websocket.close()
 
     app = Starlette()
-    mount(app, Main("hi"), prefix="/dash", wire="transports", routes=[WebSocketRoute("/ws", ws_ep)], js=tmp_path)
-    # the supplied /ws is prefixed to /dash/ws, so it lines up with the wire URL bootstrap generated
-    assert any(getattr(r, "path", None) == "/dash/ws" for r in app.routes)
+    supplied = [
+        WebSocketRoute("/ws", ws_ep),  # the wire — prefixed to match the generated URL
+        Route("/api/ping", lambda _r: PlainTextResponse("pong")),  # a REST route — prefixed too
+        Mount("/static", StaticFiles(directory=tmp_path)),  # a Mount — passes through (prefix it yourself)
+    ]
+    mount(app, Main("hi"), prefix="/dash", wire="transports", routes=supplied, js=tmp_path)
+    paths = [getattr(r, "path", None) for r in app.routes]
+    assert "/dash/ws" in paths  # WebSocketRoute prefixed → lines up with the generated wire URL
+    assert "/dash/api/ping" in paths  # Route prefixed
+    assert "/static" in paths  # Mount passes through unchanged
     assert "ws://${location.host}/dash/ws" in TestClient(app).get("/dash/").text
 
 

--- a/spaday/tests/test_backend_starlette.py
+++ b/spaday/tests/test_backend_starlette.py
@@ -42,6 +42,31 @@ def test_mount_adds_routes_to_an_existing_app_under_a_prefix(tmp_path):
     assert client.get("/dash/tree.json").json() == Main("hi").to_node()
 
 
+def test_mount_prefixes_supplied_routes_to_match_the_generated_wire(tmp_path):
+    from starlette.applications import Starlette
+    from starlette.routing import WebSocketRoute
+
+    async def ws_ep(websocket):  # a stand-in wire endpoint
+        await websocket.accept()
+        await websocket.close()
+
+    app = Starlette()
+    mount(app, Main("hi"), prefix="/dash", wire="transports", routes=[WebSocketRoute("/ws", ws_ep)], js=tmp_path)
+    # the supplied /ws is prefixed to /dash/ws, so it lines up with the wire URL bootstrap generated
+    assert any(getattr(r, "path", None) == "/dash/ws" for r in app.routes)
+    assert "ws://${location.host}/dash/ws" in TestClient(app).get("/dash/").text
+
+
+def test_mount_stamps_a_csp_nonce_on_generated_tags(tmp_path):
+    from starlette.applications import Starlette
+
+    app = Starlette()
+    mount(app, Main("hi"), prefix="/dash", bundles=["webawesome"], js=tmp_path, nonce="abc123")
+    page = TestClient(app).get("/dash/").text
+    assert '<script type="module" nonce="abc123">' in page  # the inline mount script
+    assert 'nonce="abc123"' in page and "webawesome.css" in page  # ...and the bundle tags
+
+
 def test_serve_custom_html_and_background(tmp_path):
     html_file = tmp_path / "page.html"
     html_file.write_text("<!doctype html><title>custom</title>", encoding="utf-8")

--- a/spaday/tests/test_examples.py
+++ b/spaday/tests/test_examples.py
@@ -1,7 +1,11 @@
 """Every example, smoke-tested across the integration ladder — no-HTML ``serve()``, some-HTML ``mount()``
 into an existing app, full-custom-HTML ``bootstrap(fragment=…)`` / SSR, and the notebook widgets. Each
 test skips if its optional extra is missing (``starlette`` / ``transports`` / ``perspective`` /
-``anywidget``). ``cluster`` and ``gateway`` have their own dedicated tests (test_cluster / test_gateway)."""
+``anywidget``). ``cluster`` and ``gateway`` have their own dedicated tests (test_cluster / test_gateway).
+
+The serve/mount examples carry background work (``autosync``/``ticker``); use ``with TestClient(app)`` so
+the lifespan actually starts and stops them — exercising startup/shutdown, not just route handlers (and not
+leaving unawaited-coroutine warnings)."""
 
 import json
 
@@ -13,7 +17,7 @@ pytest.importorskip("starlette", reason="examples need the [examples] extra (sta
 def _client(app):
     from starlette.testclient import TestClient
 
-    return TestClient(app)  # no context manager → the background lifespan stays inert (we only GET)
+    return TestClient(app)  # used as `with _client(app) as client:` so the lifespan runs
 
 
 # ── No HTML: serve() owns the whole app ──────────────────────────────────────────────────────────
@@ -21,53 +25,61 @@ def _client(app):
 
 def test_serve_form_generates_a_bootstrap_page():
     form = pytest.importorskip("spaday.examples.form", reason="needs transports + starlette")
-    page = _client(form.app).get("/")
-    assert page.status_code == 200
-    assert "connectStore(" in page.text and "mount(document.body, node, store)" in page.text  # serve() generated it
-    assert _client(form.app).get("/tree.json").status_code == 200  # the tree is hosted, not hand-built
+    with _client(form.app) as client:  # runs the background lifespan (autosync)
+        page = client.get("/")
+        assert page.status_code == 200
+        assert "connectStore(" in page.text and "mount(document.body, node, store)" in page.text
+        assert client.get("/tree.json").status_code == 200  # the tree is hosted, not hand-built
 
 
 def test_serve_reactive_generates_a_bootstrap_page():
     reactive = pytest.importorskip("spaday.examples.reactive", reason="needs transports + starlette")
-    page = _client(reactive.app).get("/")
-    assert page.status_code == 200 and "mount(document.body, node, store)" in page.text
+    with _client(reactive.app) as client:
+        page = client.get("/")
+        assert page.status_code == 200 and "mount(document.body, node, store)" in page.text
 
 
-# ── Some HTML: mount() into an existing app ───────────────────────────────────────────────────────
+# ── Some HTML: mount() a wired panel into an existing app ─────────────────────────────────────────
 
 
-def test_mount_embeds_into_an_existing_app_at_a_prefix():
-    embed = pytest.importorskip("spaday.examples.embed", reason="needs starlette")
-    client = _client(embed.app)
-    home = client.get("/")
-    assert home.status_code == 200 and "My existing app" in home.text  # the host's OWN homepage HTML
-    assert "/spaday/" in home.text  # which links to the mounted spaday panel
-    spa = client.get("/spaday/")  # spaday lives only under the prefix
-    assert spa.status_code == 200 and "mount(document.body, node, store)" in spa.text
-    assert client.get("/spaday/tree.json").status_code == 200
+def test_mount_embeds_a_wired_panel_into_an_existing_app():
+    embed = pytest.importorskip("spaday.examples.embed", reason="needs transports + starlette")
+    with _client(embed.app) as client:  # the host owns the lifespan (autosync) — run it
+        home = client.get("/")
+        assert home.status_code == 200 and "My existing app" in home.text  # the host's OWN homepage HTML
+        assert "/spaday/" in home.text  # which links to the mounted spaday panel
+        spa = client.get("/spaday/")  # spaday lives only under the prefix
+        assert spa.status_code == 200
+        assert "ws://${location.host}/spaday/ws" in spa.text  # the wire URL is prefixed to match the route
+        assert client.get("/spaday/tree.json").status_code == 200
+    assert any(getattr(r, "path", None) == "/spaday/ws" for r in embed.app.routes)  # supplied route, prefixed
 
 
 # ── Full custom HTML: the host owns the page; spaday is a fragment / SSR island ────────────────────
 
 
-def test_fragment_drops_into_a_host_owned_page():
+def test_fragment_drops_into_a_host_owned_page_with_a_csp_nonce():
     fragment = pytest.importorskip("spaday.examples.fragment", reason="needs starlette")
-    client = _client(fragment.app)
-    home = client.get("/")
-    assert home.status_code == 200
-    assert "The host owns this page" in home.text  # the host's own full HTML
-    assert '<div id="spaday-root"></div>' in home.text  # the host-provided mount node
-    assert 'mount(document.querySelector("#spaday-root"), node)' in home.text  # the fragment mounts into it
-    assert home.text.count("<!doctype html>") == 1  # ONE document — the host's, not a spaday-generated one
-    assert client.get("/tree.json").status_code == 200  # the host serves spaday's tree itself
+    with _client(fragment.app) as client:
+        home = client.get("/")
+        assert home.status_code == 200
+        assert "The host owns this page" in home.text  # the host's own full HTML
+        assert '<div id="spaday-root"></div>' in home.text  # the host-provided mount node
+        assert 'mount(document.querySelector("#spaday-root"), node)' in home.text  # the fragment mounts into it
+        assert home.text.count("<!doctype html>") == 1  # ONE document — the host's, not a spaday-generated one
+        # the strict-CSP seam: the per-request nonce stamps the script and is allowed by the CSP header
+        nonce = home.headers["content-security-policy"].split("'nonce-")[1].split("'")[0]
+        assert f'<script type="module" nonce="{nonce}">' in home.text
+        assert client.get("/tree.json").status_code == 200  # the host serves spaday's tree itself
 
 
 def test_ssr_ships_server_rendered_markup_to_hydrate():
     ssr = pytest.importorskip("spaday.examples.ssr", reason="needs starlette")
-    home = _client(ssr.app).get("/")
-    assert home.status_code == 200
-    assert "spaday SSR" in home.text  # the server-rendered content is in the body (view-source paints it)
-    assert "hydrate(" in home.text and 'id="tree"' in home.text  # + the tree the browser hydrates onto
+    with _client(ssr.app) as client:
+        home = client.get("/")
+        assert home.status_code == 200
+        assert "spaday SSR" in home.text  # the server-rendered content is in the body (view-source paints it)
+        assert "hydrate(" in home.text and 'id="tree"' in home.text  # + the tree the browser hydrates onto
 
 
 # ── Notebook / anywidget: a reusable component builder + a demo wrapper ────────────────────────────
@@ -93,7 +105,8 @@ def test_omnibus_serves_the_namespaced_multi_wire_page():
 
     tree = tree_json(main.page)
     assert '"root-class:wa-dark"' in tree and "global.data" in tree  # namespaced declarative tree
-    page = _client(main.app).get("/")
-    assert page.status_code == 200
-    assert "connectStore(store, client0" in page.text and '"global"' in page.text  # several namespaced wires
-    assert _client(main.app).get("/tree.json").status_code == 200
+    with _client(main.app) as client:  # runs the 4 autosync loops + the ticker
+        page = client.get("/")
+        assert page.status_code == 200
+        assert "connectStore(store, client0" in page.text and '"global"' in page.text  # several namespaced wires
+        assert client.get("/tree.json").status_code == 200


### PR DESCRIPTION
Addresses every finding in the branch review (`REVIEW.md`) of the now-merged examples-ladder work (#92).

## High — `mount(prefix=…)` now prefixes the supplied routes
`mount()` prefixed the page/tree/js + generated wire URLs, but appended `routes` unchanged — so a prefixed wired panel connected to `/spaday/ws` while the route lived at `/ws`. Now `mount()` prefixes each supplied `Route`/`WebSocketRoute` (`/ws` → `{prefix}/ws`), so the generated wire URL and the endpoint line up. Pass the *unprefixed* path; `mount` adds the prefix. (`_prefixed()` in `backends/starlette.py`; `Mount`/`Host` pass through.) Tested directly + end-to-end via the new wired `embed.py`.

## Medium — CSP: the fragment overstated host ownership
`bootstrap(fragment=True)` emits an **inline** module script, which a strict `script-src` CSP blocks. Added `nonce=` to `bootstrap`/`mount` — it stamps the generated `<script>`/`<link>` tags. `fragment.py` now **demonstrates** it (a per-request `secrets.token_urlsafe` nonce + a `Content-Security-Policy` header), and its wording no longer claims more host CSP/bundler ownership than is true.

## Medium — `embed.py` is now the *wired* embedded case
It was local-store only. Now it's the hard case the review asked for: a host app that owns `/` **and the lifespan** (runs `transports.autosync`), mounting a transports-bound panel under `/spaday` with a `WebSocketRoute` — exercising route-prefix + lifespan composition + a real wire together.

## Medium — example smoke tests exercise the lifespan
`test_examples.py` avoided the `TestClient` context manager, so the background coroutines were created at import but never awaited (the `RuntimeWarning`s). Now each uses `with TestClient(app) as client:` — startup/shutdown actually run; warnings gone.

## Low — copy-paste traps
- README ladder seam `bootstrap(page, fragment=True, …)` → `bootstrap(fragment=True, target=…)` + `tree_json(page)` (`bootstrap` has no `page` param).
- `embed.py` no longer claims `mount` takes `background` (only `serve` does — the host owns the lifespan).

## Verification
- `pytest spaday/tests` — **140 passed**, no unawaited-coroutine warnings (added: `test_mount_prefixes_supplied_routes_to_match_the_generated_wire`, `test_mount_stamps_a_csp_nonce_on_generated_tags`; updated example smokes).
- `make lint` clean (ruff, prettier, clippy, fmt, mdformat, codespell).
- Browser smoke (ad-hoc, removed): **embed** — the panel at `/spaday/` connects to the prefixed `/spaday/ws` and an edit fans across two tabs; **fragment** — mounts into `#spaday-root` under a strict `script-src` CSP via the nonce, **zero CSP violations**, the action runs.
