### PR TITLE
docs: refresh for serving + reactivity, modernize transports, fill API gaps (Diátaxis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ pip install "spaday[widget]"  # + the Jupyter / anywidget host
 - **[Tutorial](docs/src/tutorial.md)** — build your first interactive UI, step by step (in a notebook).
 - **How-to guides** — [author a component tree](docs/src/components.md),
   [add behavior and reactivity](docs/src/behavior.md),
+  [serve and embed an app](docs/src/serving.md),
   [use it in a notebook](docs/src/notebook.md),
   [sync to a server over transports](docs/src/transports.md),
   [wrap an imperative JS library](docs/src/wrappers.md),

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -42,6 +42,8 @@ Behavior attached to a component with `Component.on`; see [Add behavior and reac
 .. autofunction:: spaday.eq
 .. autofunction:: spaday.all_
 .. autofunction:: spaday.any_
+.. autofunction:: spaday.cond
+.. autofunction:: spaday.obj
 .. autofunction:: spaday.this
 .. autofunction:: spaday.by_id
 ```
@@ -70,6 +72,28 @@ state bindings prefer `Component.bind` / `Component.compute` (above).
 .. autofunction:: spaday.classes
 ```
 
+## Serving
+
+Generate a page and deliver it on any backend; see [Serve and embed](serving.md) and
+[Sync over transports](transports.md). The generator is framework-agnostic (`spaday.bootstrap`); a backend
+(`spaday.backends.<name>` — `starlette`, `aiohttp`, `flask`, `tornado`) wires it into routes.
+
+```{eval-rst}
+.. autofunction:: spaday.backends.starlette.serve
+.. autofunction:: spaday.backends.starlette.mount
+.. autofunction:: spaday.bootstrap.bootstrap
+.. autoclass:: spaday.Wire
+.. autofunction:: spaday.bootstrap.tree_json
+.. autofunction:: spaday.bootstrap.tree_frame
+.. autofunction:: spaday.bootstrap.bundles_dir
+```
+
+## Server-side rendering
+
+```{eval-rst}
+.. autofunction:: spaday.render_html
+```
+
 ## Notebook host
 
 ```{eval-rst}
@@ -80,8 +104,21 @@ state bindings prefer `Component.bind` / `Component.compute` (above).
 ## Core diff / apply
 
 The low-level component-tree engine (JSON wire form), shared byte-for-byte with the browser runtime.
+`encode_frame` / `decode_frame` wrap a tree (or patch) in a transports `Frame` so the UI rides the same
+envelope as model state (used by `tree="frame"`).
 
 ```{eval-rst}
 .. autofunction:: spaday.diff
 .. autofunction:: spaday.apply
+.. autofunction:: spaday.encode_frame
+.. autofunction:: spaday.decode_frame
 ```
+
+## Theming
+
+The `spa-*` shell components are re-themed by setting their `--spa-*` CSS custom properties via
+`Component.css` (e.g. `App().css(spa_surface="#111", spa_border="#333")`, which cascades to the whole
+shell). `spaday.SHELL_TOKENS` maps each `css()` keyword to the CSS custom property it drives and what it
+controls — `spa_surface`, `spa_surface_2`, `spa_border`, `spa_muted`, `spa_gap`, `spa_align`,
+`spa_justify`, `spa_gutter_width` — each falling back to a WebAwesome `--wa-color-*` token so the shell
+follows the active theme unless overridden.

--- a/docs/src/behavior.md
+++ b/docs/src/behavior.md
@@ -79,7 +79,8 @@ WaButton().compute("disabled", not_(all_(field("a"), field("b"))))
 ```
 
 The field-expression helpers: `field(name)`, `lit(value)`, `not_(e)`, `eq(a, b)`, `all_(*es)` (AND),
-`any_(*es)` (OR). They compose.
+`any_(*es)` (OR), `cond(test, then, else)` (a ternary — `compute("theme", cond(field("dark"), "dark",
+"light"))`), and `obj({name: expr})` (compose an object from sub-expressions). They compose.
 
 ## Send a model edit or call an endpoint
 
@@ -96,9 +97,19 @@ WaSelect().on("change", SendPatch("chart", "type", event_value()))
 WaButton().text("Save").on("click", CallEndpoint("POST", "/save", body=event_value()))
 ```
 
+The body can be any expression — use `obj({name: field(name)})` to compose a whole request from state
+fields, so a generated [`form`](components.md) POSTs declaratively with no handler:
+
+```python
+from spaday import CallEndpoint, field, obj
+
+WaButton().text("Send").on("click", CallEndpoint("POST", "/api/order", obj({"symbol": field("symbol"), "qty": field("qty")})))
+```
+
 `SendPatch` is usually unnecessary once you use a two-way binding (above) — the binding carries the
 control→model edit declaratively. Reach for `SendPatch` for an imperative edit that
-isn't a simple control value.
+isn't a simple control value. When several models share a page, a `SendPatch("ns", field, value)` is
+routed into the `ns`-namespaced store (see [transports](transports.md)).
 
 ## The escape hatch
 

--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -55,6 +55,35 @@ App().child(Nav().child(...)).child(Body().child(Gutter().child(...)).child(Main
 `Stack` stacks children vertically, `Row` lays them horizontally, `Toolbar` is a control strip; `App` /
 `Nav` / `Body` / `Gutter` / `Main` / `Footer` are the page shell.
 
+## Generate a form from a model
+
+`form(Model)` turns a pydantic model into a `Stack` of labelled `wa-*` controls — one per field, typed
+from the schema and each **two-way bound** to a field of the same name. An `Enum` field becomes a
+`wa-select` of its members; a nested sub-model becomes an expand/collapse `wa-details` whose controls bind
+to dotted `parent.child` paths:
+
+```python
+import enum
+from pydantic import BaseModel
+from spaday.components.form import FormField, form
+
+class Size(str, enum.Enum):
+    small = "small"
+    large = "large"
+
+class Settings(BaseModel):
+    name: str = "lamp"
+    enabled: bool = True
+    size: Size = Size.small
+
+form(Settings)   # a Stack of bound controls — none authored by hand
+```
+
+The controls bind to fields named `name` / `enabled` / `size`, so back them with a seeded
+[`store=`](serving.md) or a hosted model over [transports](transports.md). Relabel a field with
+`FormField` (as `Annotated[int, FormField(label="…")]` metadata or via `overrides=`), and drop fields with
+`exclude=`.
+
 ## Reach for a raw element
 
 For text or a structural tag a typed class doesn't cover, use `element`:

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -83,6 +83,20 @@ sends edits) and knows nothing about UI. A single small adapter marries them —
 through a four-method interface. So you can back the same reactive store with a transports session on a
 webserver, or with the synced state of a Jupyter widget, and the UI code is identical.
 
+## The page generates itself
+
+A spaday web page is not hand-written — it is a **function of the Python description**. `serve(page, …)`
+(and the lower-level `bootstrap`) generate the bootstrap HTML: the `<head>` bundles, the wasm init, the
+fetch of the tree, the websocket wiring, and the mount. Because the page is generated rather than authored,
+there is a single **integration ladder** — `serve` (spaday runs the whole app) → `mount` (spaday under a
+sub-path of your app) → a `fragment` (spaday in one node of a page you own) → an anywidget (a notebook
+cell). It is the same generated bootstrap handing progressively more of the page to a host; nothing is
+re-implemented per rung. (See [Serve and embed](serving.md).)
+
+And because the wire is just data, **several models can share one page**: each is mirrored into the signal
+store under its own *namespace*, so a page can compose a global model, a per-tenant model, and a form
+without their fields colliding — the multi-model dashboard, still with no hand-written glue.
+
 ## Two hosts, one UI
 
 Because spaday is *a web-component runtime driven by a serialized model over a connection*, it slots into

--- a/docs/src/serving.md
+++ b/docs/src/serving.md
@@ -1,0 +1,133 @@
+# Serve and embed a spaday app
+
+This guide shows you how to deliver a spaday UI to a browser — from "spaday runs the whole app" down to
+"spaday is one node on a page you already own." Each rung hands more control to the host, and every rung
+takes the same generation options. (For keeping the UI in sync with a server-side model, see
+[Sync over transports](transports.md); for a notebook, see [Use in a notebook](notebook.md).)
+
+There is **no hand-written HTML**: spaday generates the bootstrap page from your Python description.
+
+| Rung | spaday owns | Seam |
+| ---- | ----------- | ---- |
+| No HTML | the whole app | `serve(page, …)` |
+| Some HTML | a sub-path of your app | `mount(app, page, prefix=…)` |
+| Full custom HTML | one node in your page | `bootstrap(fragment=True, target=…)` + `tree_json(page)` |
+| Notebook | a cell's widget | `Widget(component)` |
+
+`page` is a built component **or a zero-arg callable returning one** — a callable is re-rendered per
+request, so the tree can reflect current state.
+
+## Serve a whole app
+
+`serve` creates a Starlette app and mounts your page on it: it generates the bootstrap HTML, hosts the
+tree at `/tree.json`, and serves the JS bundles at `/js`. Pull a component library into `<head>` with
+`bundles=`, add your own routes with `routes=`, and run lifetime coroutines with `background=`:
+
+```python
+import uvicorn
+from spaday.backends.starlette import serve
+from spaday.components.webawesome import WaButton
+
+app = serve(
+    lambda: WaButton(variant="brand").text("Hi"),
+    bundles=["webawesome"],          # pull WebAwesome's styles + catalog into <head>
+    head="<style>body{margin:2rem}</style>",
+    title="my app",
+)
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8000)
+```
+
+The built-in bundles are `"webawesome"`, `"lightweight-charts"`, and `"perspective"`. `serve` is the
+one-line happy path — it is just `mount` onto a fresh app, so drop to `mount` when the app is yours.
+
+## Embed in an existing app
+
+`mount` adds spaday's routes to an app **you** already have, under a `prefix` — it touches nothing else.
+The page, tree, `/js`, **and your supplied `routes`** are all prefixed, so a wired panel's generated
+websocket URL lines up with its endpoint (pass the *unprefixed* path; `mount` adds the prefix). `mount`
+only adds routes — **the host owns the app's lifespan**, so run any background work in your own lifespan:
+
+```python
+from starlette.applications import Starlette
+from starlette.routing import Route
+from spaday.backends.starlette import mount
+
+app = Starlette(routes=[Route("/", my_own_homepage)])   # your app, your routes
+mount(app, page, prefix="/panel", bundles=["webawesome"])   # spaday lives only under /panel
+```
+
+Backends ship for **Starlette/FastAPI**, **aiohttp**, **Flask**, and **Tornado** — import `serve`/`mount`
+from `spaday.backends.<name>`. They are thin glue over the framework-agnostic generator.
+
+## Drop into a host page
+
+When the host owns the entire HTML page (its own markup, CSS, bundler), emit spaday as a *fragment* —
+just the bundle tags + the mounting `<script>`, with no document — and splice it into a node the host
+provides. The host serves the tree and `/js` itself:
+
+```python
+from starlette.responses import HTMLResponse, Response
+from starlette.routing import Mount, Route
+from starlette.staticfiles import StaticFiles
+from spaday.bootstrap import bootstrap, bundles_dir, tree_json
+
+async def home(_request):
+    fragment = bootstrap(fragment=True, target="#spaday-root", bundles=["webawesome"])
+    return HTMLResponse(f"<!doctype html>… <div id='spaday-root'></div> {fragment} …")
+
+routes = [
+    Route("/", home),
+    Route("/tree.json", lambda _r: Response(tree_json(page), media_type="application/json")),
+    Mount("/js", StaticFiles(directory=bundles_dir())),
+]
+```
+
+The mounting script is inline, so a host with a strict `script-src` Content-Security-Policy passes a
+per-request **`nonce`** — it stamps the generated `<script>`/`<link>` tags so the policy can allow them:
+
+```python
+fragment = bootstrap(fragment=True, target="#spaday-root", bundles=["webawesome"], nonce=request_nonce)
+# ...and set `Content-Security-Policy: script-src 'self' 'nonce-<request_nonce>' 'wasm-unsafe-eval'`
+```
+
+## Seed reactive state without a server
+
+For client-side reactive UI (two-way bindings, `field` actions) that needs no server model, seed a local
+signal store with `store=` — the page mounts with that state, no wire required:
+
+```python
+app = serve(page, store={"dark": False, "view": "list"})   # the tree's bindings read/write these fields
+```
+
+## Connect a live model
+
+To keep the UI in sync with a server-side model, add a wire: `wire="transports"` for one model, or a list
+of [`Wire`](transports.md) specs for several. The generated page opens the websocket(s) and binds them to
+the store; you supply the websocket route and run `autosync`. See [Sync over transports](transports.md).
+
+```python
+import transports
+from starlette.routing import WebSocketRoute
+
+app = serve(
+    page,
+    wire="transports",
+    routes=[WebSocketRoute("/ws", transports.ws_endpoint(server))],
+    background=[transports.autosync(server)],
+)
+```
+
+## The route contract
+
+Whatever rung you pick, the generated page expects the host to serve these paths (`{base}` is the
+`prefix`, empty by default) — `serve`/`mount` wire them for you:
+
+| Path | Serves |
+| ---- | ------ |
+| `GET {base}/` | the bootstrap HTML (`bootstrap(...)`) |
+| `GET {base}/tree.json` | the authored tree (`tree_json(page)`) |
+| `GET {base}/js/*` | the bundles under `bundles_dir()` |
+| `WS {base}/ws` | a transports endpoint (only when wired) |
+```

--- a/docs/src/transports.md
+++ b/docs/src/transports.md
@@ -1,36 +1,31 @@
 # Sync a UI to a server over transports
 
-This guide shows you how to serve a spaday UI from a webserver and keep it in sync with a server-side
-state model using [transports](https://github.com/1kbgz/transports) — so a two-way control's change is
-applied on the server and fanned to every connected browser. This is the multi-tenant, no-notebook path;
-for the zero-setup version see the [notebook guide](notebook.md).
+This guide shows you how to keep a served spaday UI in sync with a server-side state model using
+[transports](https://github.com/1kbgz/transports) — so a two-way control's change is applied on the
+server and fanned to every connected browser. For delivering the page itself (the integration ladder),
+see [Serve and embed](serving.md); for the zero-server version, the [notebook guide](notebook.md).
 
 The split to keep in mind: **spaday** owns the UI (the tree and its reactive `Store`); **transports**
-owns the wire (a `Client` that mirrors a model and sends edits); a single adapter, `connectStore`, is
-the only place they meet.
-
-Install both:
+owns the wire (a `Client` that mirrors a model and sends edits); a single adapter, `connectStore`, is the
+only place they meet — and `serve(wire="transports", …)` **generates that adapter for you**, so there is
+no hand-written browser glue.
 
 ```bash
-pip install spaday transports uvicorn
-cd js && pnpm install && pnpm build   # builds the runtime + bundles served to the browser
+pip install "spaday[examples]"   # spaday + transports + starlette + uvicorn
 ```
 
-## Host a model and author the UI (Python)
+## Host a model and wire the page
 
-Host a model in a transports `Session`, author a tree whose controls are **two-way bound** to its
-fields, and serve the page, the tree, and a WebSocket:
+Host a model in a transports `Session`, author a tree whose controls **two-way bind** to its fields, and
+serve it with `wire="transports"` — supply the websocket route and run `autosync` as a background task:
 
 ```python
-import asyncio
-
-import transports
+import transports, uvicorn
 from pydantic import BaseModel
+from starlette.routing import WebSocketRoute
 from spaday import element
+from spaday.backends.starlette import serve
 from spaday.components.webawesome import WaInput, WaSwitch
-from starlette.applications import Starlette
-from starlette.responses import FileResponse, JSONResponse
-from starlette.routing import Route, WebSocketRoute
 
 class Controls(BaseModel):
     label: str = "hello"
@@ -40,63 +35,84 @@ session = transports.Session()
 session.host(Controls())
 server = transports.Server(session)
 
-def tree() -> dict:
+def page():
     return (
         element("div")
         .child(WaInput().bind("value", "label", mode="two-way"))
         .child(WaSwitch().bind("checked", "on", mode="two-way"))
-        .to_node()
     )
 
-async def startup():
-    asyncio.create_task(transports.autosync(server))  # broadcast host-side changes to all clients
-
-app = Starlette(
-    routes=[
-        Route("/", lambda r: FileResponse("index.html")),
-        Route("/tree.json", lambda r: JSONResponse(tree())),
-        WebSocketRoute("/ws", transports.ws_endpoint(server)),
-    ],
-    on_startup=[startup],
+app = serve(
+    page,
+    bundles=["webawesome"],
+    wire="transports",
+    routes=[WebSocketRoute("/ws", transports.ws_endpoint(server))],
+    background=[transports.autosync(server)],   # fan host-side changes to every client
 )
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8000)
 ```
 
 There are **no event handlers** in the tree — the two-way bindings carry every control→model edit.
-
-## Wire the store to the client (browser)
-
-In the page, create a spaday `Store`, a transports `Client`, and link them with `connectStore`. Then
-mount the tree with that store:
-
-```ts
-import { mount, init, Store, connectStore } from "spaday";
-import { Client, fromValue, toValue, wasm } from "@1kbgz/transports";
-
-await init();                 // spaday wasm (action interpreter)
-await wasm.default();         // transports wasm
-
-const store = new Store();
-const client = new Client();
-const ws = new WebSocket(`ws://${location.host}/ws`);
-ws.binaryType = "arraybuffer";
-
-// the seam: model fields <-> store fields; a two-way control's change becomes a server edit
-const link = connectStore(store, client, (frame) => ws.send(frame), { fromValue, toValue });
-ws.addEventListener("message", (e) =>
-  link.receive(typeof e.data === "string" ? e.data : new Uint8Array(e.data)),
-);
-
-mount(document.body, await (await fetch("/tree.json")).json(), store);
-```
-
 Inbound model patches flow `model → store → bound props`; a two-way control's change becomes a
-server-authoritative `client.edit`. Edits take effect when the server echoes them back, so **two browser
-tabs stay in sync**.
-
-A complete, runnable version of this is `spaday/examples/reactive.py` in the repository.
+server-authoritative `client.edit`, which takes effect when the server echoes it back, so **two browser
+tabs stay in sync**. A complete, runnable version is `spaday/examples/reactive.py`.
 
 ## Go multi-tenant
 
-Swap the `Session` for a [`Hub`](https://github.com/1kbgz/transports), which routes each connection to
-its own tenant session (and can share models across tenants). The UI code is unchanged — `connectStore`
-and the bindings don't know or care whether the model is private or shared.
+Swap the `Session` for a [`Hub`](https://github.com/1kbgz/transports), which routes each connection to its
+own tenant session (and can share models across tenants). The UI code is unchanged — `connectStore` and
+the bindings don't know whether the model is private or shared.
+
+## Several models on one page
+
+Pass a **list** of `Wire` specs to mirror several models into one store at once, each under its own
+**namespace** so their fields don't collide (two `Chart` models would both have `data`/`type`):
+
+```python
+from spaday import Wire, field
+from spaday.backends.starlette import serve
+
+app = serve(
+    page,
+    wire=[
+        Wire("/ws", namespace="global"),                      # a shared model
+        Wire("/ws/session", namespace="session", session=True),  # a fresh per-tab tenant (a Hub)
+        Wire("/ws/cfg", namespace="cfg", flatten=False),      # an opaque map/dict field, mirrored whole
+    ],
+    routes=[...],        # one WebSocketRoute per wire
+    background=[...],    # one autosync per Server/Hub
+)
+```
+
+The tree then binds against namespaced fields — `bind("value", "global.type")`,
+`compute("data", field("global.data"))`. A `Wire`:
+
+- **`namespace`** — mirror the model's fields under `<namespace>.` (omit for bare fields, e.g. a form).
+- **`session`** — append `?session=<uuid>`, making the model a fresh per-page-load tenant.
+- **`flatten`** — recurse nested sub-models into dotted `parent.child` fields (the default, what a form
+  binds); set `False` for an **opaque map/dict** field (a chart's time-keyed `data`, a Perspective
+  layout) so it's mirrored whole instead of one store field per key.
+
+A raw `{"url": …, "namespace": …}` dict works anywhere a `Wire` does. The omnibus
+(`python -m spaday.examples`) wires four models this way.
+
+## Perspective (Mode B)
+
+A live Perspective table streams its **data** over Perspective's own websocket; spaday/transports sync
+only a small **config** model (server, tables, layout). Mirror the config with `flatten=False` and feed it
+to the panel with a computed `config` prop, so a server push re-restores the workspace for every tab:
+
+```python
+from spaday import field, obj
+from spaday.components.perspective import PerspectivePanel
+
+PerspectivePanel().compute("config", obj({
+    "ws_url": field("cfg.ws_url"), "tables": field("cfg.tables"), "layout": field("cfg.layout"),
+}))
+```
+
+See `spaday/examples/gateway.py` (no transports — REST + Perspective's own ws) and the omnibus for the
+full pattern.
+```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -134,5 +134,7 @@ interactions run in the browser *and* report back to Python.
 - [How spaday works](concepts.md) — why behavior is data and how one Rust core drives both Python and the browser.
 - [Add behavior and reactivity](behavior.md) — the full action DSL and binding kinds (including
   *computed* props derived from state).
-- [Author a component tree](components.md) — props, slots, keys, and the shell components in depth.
+- [Author a component tree](components.md) — props, slots, keys, generated forms, and the shell components.
+- [Serve and embed a spaday app](serving.md) — put this panel on a webserver, from a whole app down to a
+  fragment in a page you already own.
 - [Sync a UI to a server over transports](transports.md) — the same panel, multi-tenant, on a webserver.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,7 @@ pages = [
     "docs/src/concepts.md",
     "docs/src/behavior.md",
     "docs/src/components.md",
+    "docs/src/serving.md",
     "docs/src/transports.md",
     "docs/src/notebook.md",
     "docs/src/wrappers.md",


### PR DESCRIPTION
Brings the docs current with the action DSL + reactive engine + the `serve()`/`mount()`/`bootstrap()` integration ladder (Phases 2–4.6), keeping each page single-mode per **Diátaxis** (tutorial / how-to / reference / explanation).

## What changed

**New — `serving.md` (how-to)** — the biggest gap. The integration ladder, end to end:
- `serve` (whole app) → `mount` (a sub-path of your app, routes prefixed, host owns the lifespan) → `bootstrap(fragment=True, target=…)` + `tree_json` (a node in a page you own) → notebook.
- `store=` seed (client reactive state, no wire), `wire="transports"` / `Wire` list, `bundles`/`head`/`scripts`, the CSP **`nonce`**, the four backends, and the route contract.

**Modernized — `transports.md` (how-to)** — was the most stale page: it taught the hand-rolled Starlette + `index.html` + browser `connectStore` glue that `serve()` now generates. Rewritten to `serve(wire="transports", routes=[ws], background=[autosync])`, plus namespaced multi-model `Wire` specs (`namespace`/`session`/`flatten`) and the Mode-B Perspective config.

**Filled — `api.md` (reference)** — adds `cond`/`obj`; a **Serving** section (`serve`/`mount`/`bootstrap`/`Wire`/`tree_json`/`tree_frame`/`bundles_dir`); `render_html` (SSR); `encode_frame`/`decode_frame`; a theming note (`SHELL_TOKENS`).

**Refreshed:**
- `concepts.md` (explanation) — "the page generates itself": why `serve()`/the ladder exist, and how several models share one store under namespaces.
- `components.md` — documents `form(Model)` (generated, two-way-bound controls).
- `behavior.md` — `cond`/`obj` helpers, `obj()` request bodies, multi-model `SendPatch` routing.
- `tutorial.md` + `README.md` — link the serving guide.

## Verification
- `yardang build` — **build succeeded**; the new `serving.md` + all new autodoc targets (`serve`/`mount`/`bootstrap`/`Wire`/`cond`/`obj`/`render_html`/frame codecs) resolve. The only remaining warnings are the pre-existing yardang-template ones (autodoc_pydantic config + one toctree caption); the docs introduce no new errors.
- `mdformat --check README.md` + `codespell` (README + all new/changed pages) pass.
- No code changed — docs/pyproject only.
