### PR TITLE
bootstrap: make the session-wire id work over plain http (insecure context)

### DIFF
--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -71,6 +71,11 @@ _WASM = "/dist/pkg/spaday_bg.wasm"
 _TRANSPORTS = "/node_modules/@1kbgz/transports/dist/cdn/index.js"
 _TRANSPORTS_WASM = "/node_modules/@1kbgz/transports/dist/pkg/transports_bg.wasm"
 
+# A fresh per-page-load id for a ``session=True`` wire's tenant key. ``crypto.randomUUID()`` is
+# secure-context-only (https / localhost), so it's undefined over plain http from another host — fall back
+# to a non-crypto id so the page still loads. It's only a transports ``Hub`` key, not a secret.
+_SESSION_ID = "globalThis.crypto?.randomUUID?.() ?? (Date.now().toString(36) + Math.random().toString(36).slice(2))"
+
 #: Named component-library bundles a page can pull into ``<head>`` via ``bundles=[…]``. Each entry is a
 #: ``(kind, path)`` pair — ``kind`` is ``"css"`` or ``"js"``, ``path`` is under the served ``/js`` mount —
 #: the markup (styles + the catalog/wrapper script that registers the elements) an example would otherwise
@@ -143,7 +148,7 @@ def _wire_block(spec: dict, base: str, idx: int) -> list:
         extra = f", {json.dumps(ns)}" if ns else ""
     else:
         extra = f", {json.dumps(ns) if ns else 'undefined'}, false"
-    session = "?session=${crypto.randomUUID()}" if spec.get("session") else ""  # a fresh tenant per page load
+    session = "?session=${" + _SESSION_ID + "}" if spec.get("session") else ""  # a fresh tenant per page load
     lines = [
         f"const {client} = new Client();",
         f"const {sock} = new WebSocket(`ws://${{location.host}}{base}{url}{session}`);",

--- a/spaday/tests/test_bootstrap.py
+++ b/spaday/tests/test_bootstrap.py
@@ -120,9 +120,12 @@ def test_wire_list_shares_one_store_with_namespaced_connectstores():
     assert html.count("mount(document.body, node, store)") == 1  # one mount of the shared store
 
 
-def test_wire_list_session_appends_a_uuid():
+def test_wire_list_session_appends_a_per_load_id():
     html = bootstrap(wire=[{"url": "/ws/s", "namespace": "s", "session": True}])
-    assert "new WebSocket(`ws://${location.host}/ws/s?session=${crypto.randomUUID()}`)" in html  # fresh tenant
+    # a fresh per-load tenant id appended to the ws url; crypto.randomUUID is secure-context-only, so it
+    # must degrade gracefully (plain http from another host has no secure context)
+    assert "/ws/s?session=${globalThis.crypto?.randomUUID?.() ?? " in html
+    assert "Math.random()" in html  # the insecure-context (http) fallback
 
 
 def test_wire_list_namespaced_wire_sets_a_connected_flag_bare_wire_does_not():


### PR DESCRIPTION
## Problem

Opening a `session=True` wire (e.g. the omnibus' per-tab chart) from **another machine over plain http** threw — the generated wire URL used `?session=${crypto.randomUUID()}`, and `crypto.randomUUID()` is **secure-context-only** (https / localhost). Over `http://<host>:<port>` from a non-localhost origin there is no secure context, so `crypto.randomUUID` is `undefined` and the page errored on load.

## Fix

Generate the per-load tenant id as `globalThis.crypto?.randomUUID?.() ?? (Date.now().toString(36) + Math.random().toString(36).slice(2))` (a new `_SESSION_ID` constant in `spaday/bootstrap.py`):

- **Secure context** (https / localhost) → still a real `crypto.randomUUID()` (unchanged).
- **Insecure context** (plain http, another host) → degrades to a non-crypto per-load id instead of throwing.

It's only a transports `Hub` tenant key (partitions per-load sessions), not a secret, so the non-crypto fallback is fine.

## Verification
- `pytest spaday/tests` — 140 passed (`test_wire_list_session_appends_a_per_load_id` updated to assert the secure-context-safe form + the http fallback).
- Browser check: evaluated the expression with `crypto.randomUUID` stubbed out (simulating an insecure context) — it returns a valid id with **no throw**; with it present, a real UUID. The existing omnibus smoke already exercises the secure-context (localhost) path.
- `ruff` clean.
