### PR TITLE
deps: declare pydantic for form() + add form/backend extras (core stays dep-free)

### DIFF
--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -79,8 +79,9 @@ class Settings(BaseModel):
 form(Settings)   # a Stack of bound controls — none authored by hand
 ```
 
-The controls bind to fields named `name` / `enabled` / `size`, so back them with a seeded
-[`store=`](serving.md) or a hosted model over [transports](transports.md). Relabel a field with
+`form` needs pydantic — install it with the `form` extra (`pip install "spaday[form]"`); it's also pulled
+in by `spaday[examples]`. The controls bind to fields named `name` / `enabled` / `size`, so back them with
+a seeded [`store=`](serving.md) or a hosted model over [transports](transports.md). Relabel a field with
 `FormField` (as `Annotated[int, FormField(label="…")]` metadata or via `overrides=`), and drop fields with
 `exclude=`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "spaday"
 authors = [
     {name = "1kbgz", email = "dev@1kbgz.com"},
 ]
-description = ""
+description = "Build reactive web-component UIs configured in Python, executed in the browser"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 version = "0.1.0"
@@ -35,10 +35,14 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
+form = ["pydantic>=2"]  # schema-generated forms: spaday.components.form turns a pydantic model into bound wa-* controls
 widget = ["anywidget"]
-examples = ["transports", "starlette", "uvicorn", "websockets"]
-cluster = ["transports", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
-perspective = ["transports", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6"]  # the omnibus Perspective panel (Mode B: a perspective.Server over its own ws)
+examples = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets"]  # pydantic: the example models + form()
+cluster = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
+perspective = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6"]  # the omnibus Perspective panel (Mode B: a perspective.Server over its own ws)
+aiohttp = ["aiohttp"]  # the aiohttp backend (spaday.backends.aiohttp)
+flask = ["flask"]  # the Flask backend (spaday.backends.flask)
+tornado = ["tornado"]  # the Tornado backend (spaday.backends.tornado)
 develop = [
     "aiohttp",  # the aiohttp backend — covered by test_backend_aiohttp
     "anywidget",
@@ -54,6 +58,7 @@ develop = [
     "httpx",  # starlette TestClient backend (for test_backend_starlette)
     "mdformat",
     "mdformat-tables>=1",
+    "pydantic>=2",  # form() + the example/test models (was only present transitively, via bump-my-version)
     "pytest",
     "pytest-cov",
     "ruff",


### PR DESCRIPTION
## The question

Is `dependencies = []` accurate? **Yes for the core** — `import spaday` pulls in **zero** third-party modules (verified); the Rust core is compiled into the wheel and everything `__init__` loads is stdlib + the bundled extension. A bare `pip install spaday` genuinely needs nothing.

## The gap this fixes

`spaday/components/form.py` imports `pydantic` (and `annotated_types`) **at module level**, but pydantic was declared in **no extra**:

- `pip install spaday` → `from spaday.components.form import form` → `ModuleNotFoundError: pydantic`.
- `spaday[examples]` / `[perspective]` don't list pydantic — yet `examples/form.py`, `reactive.py`, `gateway.py`, and the omnibus all define pydantic models and call `form()`.
- `test_form.py` imports pydantic unconditionally; CI passed only because `bump-my-version` happens to pull pydantic transitively into `[develop]` — fragile.

## Fix

- New **`form = ["pydantic>=2"]`** extra (pydantic v2 pulls `annotated_types` transitively); documented in the form how-to (`pip install "spaday[form]"`).
- Add `pydantic>=2` to **`examples`**, **`cluster`**, **`perspective`** (they define models + use `form`) and to **`develop`** (so form/example tests don't depend on a transitive dep).
- New user-facing **`aiohttp`** / **`flask`** / **`tornado`** extras for the non-Starlette backends (previously only in `[develop]`, so undiscoverable).

**Core `dependencies` stays `[]`** — schema-forms remain opt-in rather than dragging pydantic into every install.

## Verification
- `pyproject.toml` parses; the extras resolve as expected (pydantic present in form/examples/cluster/perspective/develop; backend extras map to their frameworks); `from spaday.components.form import form` imports.
- No code changed beyond packaging metadata + a one-line docs note.
