### PR TITLE
components(4.4): lightweight reactive Table (spa-table)

### DIFF
--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -105,6 +105,22 @@ a seeded [`store=`](serving.md) or a hosted model over [transports](transports.m
 `FormField` (as `Annotated[int, FormField(label="…")]` metadata or via `overrides=`), and drop fields with
 `exclude=`.
 
+## Show data in a table
+
+`Table` renders a lightweight data grid — a `spa-table` that lays out `rows` (a list of dicts) under
+`columns`. Both are reactive, so binding or computing `rows` re-renders the table live:
+
+```python
+from spaday import field
+from spaday.components.shell import Table
+
+Table(columns=["symbol", "qty", "price"]).compute("rows", field("orders"))
+```
+
+`columns` may be plain keys (`["symbol"]` — the label is the key) or `{"key": …, "label": …}` dicts; omit
+it to infer the columns from the first row. Pass `rows=[…]` for a static table. Cells are text; for virtual
+scrolling or very large datasets, wrap a grid library (regular-table) via the [wrapper recipe](wrappers.md).
+
 ## Reach for a raw element
 
 For text or a structural tag a typed class doesn't cover, use `element`:

--- a/js/src/ts/shell.ts
+++ b/js/src/ts/shell.ts
@@ -91,3 +91,90 @@ if (typeof customElements !== "undefined") {
     );
   }
 }
+
+// A lightweight data table (`spa-table`): renders `rows` (a list of objects) under `columns`, both set as
+// JS properties — so a bound / computed `rows` re-renders reactively. Cells are text (built with
+// createElement, never innerHTML). Not a virtual-scroll grid (that's regular-table); a themed `<table>`
+// for modest data.
+const TABLE_CSS = `:host{display:block;overflow:auto}
+table{border-collapse:collapse;width:100%;font-size:.9rem;color:inherit}
+th,td{text-align:left;padding:.4rem .65rem;border-bottom:1px solid ${BORDER};white-space:nowrap}
+thead th{background:${SURFACE_2};font-weight:600;position:sticky;top:0}
+tbody tr:hover td{background:${SURFACE_2}}`;
+
+type TableCol = { key: string; label: string };
+function tableColumns(
+  cols: unknown,
+  rows: Record<string, unknown>[],
+): TableCol[] {
+  const raw =
+    Array.isArray(cols) && cols.length
+      ? cols
+      : rows[0]
+        ? Object.keys(rows[0])
+        : []; // infer from the first row
+  return raw.map((c) =>
+    typeof c === "string"
+      ? { key: c, label: c }
+      : {
+          key: String((c as Record<string, unknown>).key),
+          label: String(
+            (c as Record<string, unknown>).label ??
+              (c as Record<string, unknown>).key,
+          ),
+        },
+  );
+}
+
+if (typeof customElements !== "undefined" && !customElements.get("spa-table")) {
+  customElements.define(
+    "spa-table",
+    class extends HTMLElement {
+      private cols: unknown = null;
+      private data: Record<string, unknown>[] = [];
+      private root: ShadowRoot;
+      constructor() {
+        super();
+        this.root = this.attachShadow({ mode: "open" });
+        const style = document.createElement("style");
+        style.textContent = TABLE_CSS;
+        this.root.append(style);
+        this.render();
+      }
+      set columns(v: unknown) {
+        this.cols = v;
+        this.render();
+      }
+      get columns(): unknown {
+        return this.cols;
+      }
+      set rows(v: unknown) {
+        this.data = Array.isArray(v) ? (v as Record<string, unknown>[]) : [];
+        this.render();
+      }
+      get rows(): unknown {
+        return this.data;
+      }
+      private render(): void {
+        const cols = tableColumns(this.cols, this.data);
+        const table = document.createElement("table");
+        const hr = table.createTHead().insertRow();
+        for (const c of cols) {
+          const th = document.createElement("th");
+          th.textContent = c.label;
+          hr.append(th);
+        }
+        const tbody = table.createTBody();
+        for (const row of this.data) {
+          const tr = tbody.insertRow();
+          for (const c of cols)
+            tr.insertCell().textContent =
+              row[c.key] == null ? "" : String(row[c.key]);
+        }
+        const old = this.root.querySelector("table");
+        if (old) old.replaceWith(table);
+        else this.root.append(table);
+      }
+    },
+  );
+}

--- a/js/tests/shell.spec.js
+++ b/js/tests/shell.spec.js
@@ -68,3 +68,45 @@ test("shell containers carry the slotted wa-button display fix", async ({
   });
   expect(hasFix).toBe(true);
 });
+
+test("spa-table renders rows under columns and re-renders when the bound field changes", async ({
+  page,
+}) => {
+  const r = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ orders: [{ symbol: "AAPL", qty: 10 }] });
+    // columns are static; rows are computed from a store field (the reactive case)
+    const el = mount(
+      document.body,
+      {
+        tag: "spa-table",
+        props: { columns: { List: [{ Str: "symbol" }, { Str: "qty" }] } },
+        bindings: {
+          rows: { compute: { expr: "field", name: "orders" }, mode: "one-way" },
+        },
+      },
+      store,
+    );
+    const read = () => {
+      const t = el.shadowRoot.querySelector("table");
+      return {
+        headers: [...t.tHead.rows[0].cells].map((c) => c.textContent),
+        cells: [...t.tBodies[0].rows].map((row) =>
+          [...row.cells].map((c) => c.textContent),
+        ),
+      };
+    };
+    const before = read();
+    store.set("orders", [
+      { symbol: "MSFT", qty: 5 },
+      { symbol: "GOOG", qty: 7 },
+    ]); // a field change re-renders the table
+    return { before, after: read() };
+  });
+  expect(r.before.headers).toEqual(["symbol", "qty"]); // columns → header cells
+  expect(r.before.cells).toEqual([["AAPL", "10"]]); // seeded row
+  expect(r.after.cells).toEqual([
+    ["MSFT", "5"],
+    ["GOOG", "7"],
+  ]); // reactively re-rendered from the changed field
+});

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -21,7 +21,7 @@ from typing import Any, Optional
 from ..component import Child, Component
 from .webawesome import WaTab, WaTabPanel
 
-__all__ = ["App", "Nav", "Body", "Gutter", "Main", "Footer", "Column", "Stack", "Row", "Toolbar", "Show", "Tabs"]
+__all__ = ["App", "Nav", "Body", "Gutter", "Main", "Footer", "Column", "Stack", "Row", "Toolbar", "Show", "Tabs", "Table"]
 
 
 class App(Component):
@@ -172,3 +172,20 @@ class Tabs(Component):
         self.child_in("nav", WaTab(panel=name).text(label))  # tab headers live in the group's "nav" slot
         self.child(WaTabPanel(name=name).child(*content))  # panels in the default slot
         return self
+
+
+class Table(Component):
+    """A lightweight data table — a ``spa-table`` that renders ``rows`` (a list of dicts) under
+    ``columns``. Both are reactive: bind or compute ``rows`` to a state field and the table re-renders::
+
+        Table(columns=["symbol", "qty", "price"]).compute("rows", field("orders"))
+
+    ``columns`` may be plain keys (``["symbol"]`` — the label is the key) or ``{"key": …, "label": …}``
+    dicts; omit it to infer the columns from the first row. Pass ``rows`` for a static table. (For virtual
+    scrolling / very large datasets, wrap regular-table — Phase 7.)
+    """
+
+    tag = "spa-table"
+
+    def __init__(self, *, columns: Optional[list] = None, rows: Optional[list] = None, key: Optional[str] = None, **props: Any) -> None:
+        super().__init__(key=key, props={"columns": columns, "rows": rows}, **props)

--- a/spaday/tests/test_shell.py
+++ b/spaday/tests/test_shell.py
@@ -4,7 +4,7 @@ import pytest
 
 from spaday import apply, diff, element
 from spaday.actions import field, not_
-from spaday.components.shell import App, Body, Column, Footer, Gutter, Main, Nav, Row, Show, Stack, Tabs, Toolbar
+from spaday.components.shell import App, Body, Column, Footer, Gutter, Main, Nav, Row, Show, Stack, Table, Tabs, Toolbar
 
 
 def test_shell_classes_emit_spa_tags():
@@ -104,3 +104,16 @@ def test_tabs_active_binds_for_routing():
     assert node["bindings"]["active"] == {"field": "view", "mode": "two-way"}  # state <-> active tab
     # an explicit name overrides the slug (bind against a stable value)
     assert Tabs().tab("A B", name="tab1").to_node()["slots"]["nav"][0]["props"]["panel"] == {"Str": "tab1"}
+
+
+def test_table_authors_a_spa_table():
+    node = Table(columns=["symbol", "qty"], rows=[{"symbol": "AAPL", "qty": 10}]).to_node()
+    assert node["tag"] == "spa-table"
+    assert node["props"]["columns"] == {"List": [{"Str": "symbol"}, {"Str": "qty"}]}
+    assert node["props"]["rows"] == {"List": [{"Map": {"symbol": {"Str": "AAPL"}, "qty": {"Int": 10}}}]}
+
+
+def test_table_rows_are_reactive():
+    node = Table(columns=["a"]).compute("rows", field("orders")).to_node()
+    assert node["bindings"]["rows"] == {"compute": {"expr": "field", "name": "orders"}, "mode": "one-way"}
+    assert "rows" not in node.get("props", {})  # computed, not a static prop


### PR DESCRIPTION
Phase 4.4 — a lightweight data component (the non-Perspective case). There is no `wa-table`, so this adds a small `spa-table` shell element.

## `Table` / `<spa-table>`
A `<spa-table>` custom element (in `js/src/ts/shell.ts`) renders `rows` (a list of objects) under `columns` — both set as **JS properties**, so a bound or computed `rows` re-renders reactively. Cells are built with `createElement` (never `innerHTML`) and themed via the `--spa-*` tokens. It's a themed `<table>` for modest data — not a virtual-scroll grid (that's regular-table / Phase 7).

```python
from spaday import field
from spaday.components.shell import Table

Table(columns=["symbol", "qty", "price"]).compute("rows", field("orders"))   # reactive
Table(columns=["symbol"], rows=[{"symbol": "AAPL"}])                          # static
```

`columns` may be plain keys (`["symbol"]` — label is the key) or `{"key": …, "label": …}` dicts; omit it to infer from the first row.

## Verification
- `pytest spaday/tests` — 144 passed (new `Table` tests in `test_shell.py`: tagged `columns`/`rows` props + the reactive `rows` binding).
- `shell.spec.js` — a **real-browser** test: `columns` → header cells, `rows` → body cells, and a bound store-field change re-renders the table.
- `make lint` clean. Documented in `components.md`.

Second of three Phase 4 PRs (after #97 nav). Next: Grid/Dashboard + gutters (4.1).
