### PR TITLE
examples: drive omnibus data generation with superstore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ form = ["pydantic>=2"]  # schema-generated forms: spaday.components.form turns a
 widget = ["anywidget"]
 examples = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets"]  # pydantic: the example models + form()
 cluster = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
-perspective = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6"]  # the omnibus Perspective panel (Mode B: a perspective.Server over its own ws)
+perspective = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6", "superstore>=0.3.1"]  # the omnibus Perspective panel (Mode B: a perspective.Server over its own ws); superstore generates the orders + chart series
 aiohttp = ["aiohttp"]  # the aiohttp backend (spaday.backends.aiohttp)
 flask = ["flask"]  # the Flask backend (spaday.backends.flask)
 tornado = ["tornado"]  # the Tornado backend (spaday.backends.tornado)
@@ -63,6 +63,7 @@ develop = [
     "pytest-cov",
     "ruff",
     "starlette",  # the Starlette backend — covered by test_backend_starlette (import spaday stays starlette-free)
+    "superstore>=0.3.1",  # the omnibus example's data generator (orders + chart series)
     "tornado",  # the Tornado backend — covered by test_backend_tornado
     "twine",
     "ty",

--- a/spaday/examples/__main__.py
+++ b/spaday/examples/__main__.py
@@ -43,7 +43,7 @@ from perspective.handlers.starlette import PerspectiveStarletteHandler
 from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse
 from starlette.routing import Route, WebSocketRoute
-from starlette.websockets import WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocket
 from superstore import RandomWalk, superstore
 
 from spaday import Wire, element
@@ -91,39 +91,46 @@ class Chart(BaseModel):
     data: dict = Field(default_factory=dict)
 
 
-class ChartSource:
-    """A `Chart` model plus the running superstore `RandomWalk` that windows points into it. Each instance
-    has its own walk, so the global and per-session charts diverge naturally."""
+class LiveChart:
+    """A `Chart` model whose live series is a superstore `RandomWalk`, windowed to `WINDOW` points. Each
+    instance owns its walk, so the global and per-session charts diverge naturally. :meth:`tick` slides one
+    point in: because the series is a time-keyed map, the Session diffs that to Set(newest) + Remove(oldest)
+    — a per-point delta — so the snapshot every new client downloads stays bounded (not an ever-growing
+    list)."""
 
     def __init__(self, type: str = "area") -> None:
-        self._walk, self._day = RandomWalk(sigma=1.4, start=100.0), date(2023, 1, 1)
-        self.model = Chart(type=type, data=dict(self._point(v) for v in self._walk.sample(WINDOW)))
+        self._walk = RandomWalk(sigma=1.4, start=100.0)
+        self._day = date(2023, 1, 1)
+        self.model = Chart(type=type, data=dict(self._next() for _ in range(WINDOW)))
 
-    def _point(self, value: float) -> tuple[str, float]:
+    def _next(self) -> tuple[str, float]:
+        """Advance the walk one day and return the ``(iso-date, value)`` point."""
         t = self._day.isoformat()
         self._day += timedelta(days=1)
-        return t, round(value, 2)
+        return t, round(self._walk.sample(1)[0], 2)
 
     def tick(self) -> None:
-        if self.model.live:
-            # add the newest point and drop the oldest, keeping the series to WINDOW entries. Because it's
-            # a time-keyed map, the Session diffs this to Set(newest) + Remove(oldest) — a 2-op per-point
-            # delta — and the snapshot every new client downloads stays bounded (not an ever-growing list).
-            data = dict(self.model.data)
-            t, v = self._point(self._walk.sample(1)[0])
-            data[t] = v
-            while len(data) > WINDOW:
-                del data[next(iter(data))]
-            self.model.data = data
+        if not self.model.live:
+            return
+        t, v = self._next()
+        data = {**self.model.data, t: v}
+        while len(data) > WINDOW:
+            del data[next(iter(data))]
+        self.model.data = data
 
 
-global_src = ChartSource(type="area")
-global_session = transports.Session()
-global_session.host(global_src.model)
-global_server = transports.Server(global_session)
+def host(model: BaseModel) -> transports.Server:
+    """Host one model in a fresh transports Session + Server — the boilerplate for a single live model."""
+    session = transports.Session()
+    session.host(model)
+    return transports.Server(session)
+
+
+global_chart = LiveChart(type="area")
+global_server = host(global_chart.model)
 
 session_hub = transports.Hub(key=lambda ws: ws.query_params.get("session", "anon"))
-session_srcs: dict = {}
+session_charts: dict = {}
 
 
 class Mode(str, enum.Enum):
@@ -147,27 +154,15 @@ class Device(BaseModel):
     schedule: Schedule = Schedule()  # nested model → an expand/collapse wa-details section
 
 
-form_session = transports.Session()
-form_session.host(Device())
-form_server = transports.Server(form_session)
+form_server = host(Device())
 
 
-# Perspective (Mode B): the table DATA rides Perspective's own websocket (served at /perspective below);
-# spaday/transports carry only a small CONFIG (which server, which tables, and the workspace layout +
-# per-viewer views) that the server can PUSH at any time. A live Superstore orders blotter (a ring buffer);
-# the schema is inferred from the seed batch, so there is no hand-written column list to keep in sync.
-psp_server = PerspectiveServer()
-psp_client = psp_server.new_local_client()
-psp_table = psp_client.table(superstore(count=500, output="dict"), limit=5000, name="orders")  # ring buffer
-
-
-def psp_tick() -> None:
-    """Append a fresh batch of Superstore orders; they stream to every browser over Perspective's own socket."""
-    psp_table.update(superstore(count=8, output="dict"))
-
-
-def _psp_layout(viewer: dict) -> dict:
-    """A single-viewer perspective-workspace layout (the shape <perspective-workspace>.restore wants)."""
+# Perspective (Mode B): the table DATA rides Perspective's own websocket while spaday/transports carry only
+# a small CONFIG (which server, which tables, and the workspace layout + per-viewer views) that the server
+# can PUSH at any time. Two pushable presets — a flat live blotter and a by-category rollup — flip
+# server-side, and every connected workspace re-restores ("push a new view at any time").
+def _layout(viewer: dict) -> dict:
+    """A single-viewer perspective-workspace layout (the shape ``<perspective-workspace>.restore`` wants)."""
     return {
         "sizes": [1],
         "detail": {"main": {"type": "tab-area", "widgets": ["view"], "currentIndex": 0}},
@@ -177,10 +172,8 @@ def _psp_layout(viewer: dict) -> dict:
     }
 
 
-# Two pushable presets: a flat live blotter and a by-category rollup. The button below flips between them
-# server-side; every connected workspace re-restores — the "push a new view at any time" demo.
-PSP_BLOTTER = _psp_layout({"title": "Orders (live)", "sort": [["Order Date", "desc"]]})
-PSP_BY_CATEGORY = _psp_layout(
+BLOTTER_VIEW = _layout({"title": "Orders (live)", "sort": [["Order Date", "desc"]]})
+BY_CATEGORY_VIEW = _layout(
     {
         "title": "By category",
         "group_by": ["Category", "Sub-Category"],
@@ -193,13 +186,38 @@ PSP_BY_CATEGORY = _psp_layout(
 class PerspectiveConfig(BaseModel):
     ws_url: str = "/perspective"  # the Perspective data websocket (this app serves it)
     tables: list = Field(default_factory=lambda: ["orders"])  # informational; discovered over the socket
-    layout: dict = Field(default_factory=lambda: dict(PSP_BLOTTER))  # the pushable workspace layout + views
+    layout: dict = Field(default_factory=lambda: dict(BLOTTER_VIEW))  # the pushable workspace layout + views
 
 
-psp_config = PerspectiveConfig()
-psp_config_session = transports.Session()
-psp_config_session.host(psp_config)
-psp_config_server = transports.Server(psp_config_session)
+class Blotter:
+    """A live Superstore orders blotter over Perspective (Mode B). It owns the Perspective server + a
+    ring-buffer ``orders`` table whose schema is inferred from the seed batch (no hand-written column list);
+    its small :class:`PerspectiveConfig` is hosted over transports so :meth:`relayout` can push a new view
+    to every connected tab."""
+
+    def __init__(self) -> None:
+        self.server = PerspectiveServer()
+        self.table = self.server.new_local_client().table(superstore(count=500, output="dict"), limit=5000, name="orders")
+        self.config = PerspectiveConfig()
+        self.config_server = host(self.config)
+
+    def tick(self) -> None:
+        """Append a fresh batch of orders; they stream to every browser over Perspective's own websocket."""
+        self.table.update(superstore(count=8, output="dict"))
+
+    async def data_endpoint(self, ws: WebSocket) -> None:
+        """Perspective's own data websocket — the bulk table data, bridged to the Perspective server."""
+        await PerspectiveStarletteHandler(perspective_server=self.server, websocket=ws).run()
+
+    async def relayout(self, request) -> JSONResponse:
+        """Flip the shared layout between the flat blotter and the by-category rollup; transports fans the
+        change so every connected workspace re-restores."""
+        grouped = self.config.layout.get("viewers", {}).get("view", {}).get("group_by")
+        self.config.layout = dict(BLOTTER_VIEW) if grouped else dict(BY_CATEGORY_VIEW)
+        return JSONResponse({"view": self.config.layout["viewers"]["view"]["title"]})
+
+
+blotter = Blotter()
 
 
 def callout(id: str, text: str, *, hidden: bool = False) -> object:
@@ -417,63 +435,28 @@ def page() -> object:
     )
 
 
-async def psp_data_endpoint(ws: WebSocket) -> None:
-    """Perspective's own data websocket — the bulk table data, not transports. The handler accepts the
-    socket and bridges it to the Perspective server (table updates fan to every connected browser)."""
-    handler = PerspectiveStarletteHandler(perspective_server=psp_server, websocket=ws)
-    await handler.run()
-
-
-async def psp_relayout(request):
-    """Push a different workspace layout/view to EVERY connected browser by mutating the shared config
-    model — transports fans the change and each perspective-panel re-restores. Flips between two presets."""
-    grouped = psp_config.layout.get("viewers", {}).get("view", {}).get("group_by")
-    psp_config.layout = dict(PSP_BLOTTER) if grouped else dict(PSP_BY_CATEGORY)
-    return JSONResponse({"view": psp_config.layout["viewers"]["view"]["title"]})
-
-
-async def _send(ws: WebSocket, msg) -> None:
-    await (ws.send_bytes(msg) if isinstance(msg, (bytes, bytearray)) else ws.send_text(msg))
+_session_ws = transports.ws_endpoint(session_hub)
 
 
 async def session_endpoint(ws: WebSocket) -> None:
-    """Like transports' built-in Hub endpoint, but hosts a private chart for a tenant on first connect."""
+    """The Hub's websocket endpoint, but with a private chart hosted for the tenant on first connect. The
+    per-tenant Session is created lazily by the Hub; we seed it with a chart, then delegate the accept/sync
+    loop to transports' own ``ws_endpoint``."""
     key = ws.query_params.get("session", "anon")
-    sess = session_hub.tenant(key)
-    if key not in session_srcs:
-        src = ChartSource(type="area")
-        sess.host(src.model)
-        session_srcs[key] = src
-    await ws.accept()
-    for msg in session_hub.open(ws):
-        await _send(ws, msg)
-    try:
-        while True:
-            frame = await ws.receive()
-            if frame.get("type") == "websocket.disconnect":
-                break
-            data = frame.get("text")
-            if data is None:
-                data = frame.get("bytes")
-            if data is None:
-                continue
-            for conn, msgs in session_hub.recv(ws, data).items():
-                for m in msgs:
-                    await _send(conn, m)
-    except WebSocketDisconnect:
-        pass
-    finally:
-        session_hub.close(ws)
-        session_srcs.pop(key, None)  # stop ticking a gone tenant (its dormant Session is left behind)
+    if key not in session_charts:
+        chart = LiveChart(type="area")
+        session_hub.tenant(key).host(chart.model)
+        session_charts[key] = chart
+    await _session_ws(ws)
 
 
 async def ticker() -> None:
     while True:
         await asyncio.sleep(1.0)
-        global_src.tick()
-        for src in list(session_srcs.values()):
-            src.tick()
-        psp_tick()  # stream new orders into the Perspective table (over its own websocket)
+        global_chart.tick()
+        for chart in list(session_charts.values()):
+            chart.tick()
+        blotter.tick()  # stream new orders into the Perspective table (over its own websocket)
 
 
 # serve() generates the whole page (bootstrap, the four namespaced transports wires + the spaday:patch
@@ -494,16 +477,16 @@ app = serve(
         transports.autosync(global_server),
         transports.autosync(session_hub),
         transports.autosync(form_server),
-        transports.autosync(psp_config_server),
+        transports.autosync(blotter.config_server),
         ticker(),
     ],
     routes=[
         WebSocketRoute("/ws", transports.ws_endpoint(global_server)),
         WebSocketRoute("/ws/session", session_endpoint),
         WebSocketRoute("/ws/form", transports.ws_endpoint(form_server)),
-        WebSocketRoute("/ws/perspective-config", transports.ws_endpoint(psp_config_server)),
-        WebSocketRoute("/perspective", psp_data_endpoint),  # Perspective's own data socket (Mode B)
-        Route("/perspective/relayout", psp_relayout, methods=["POST"]),
+        WebSocketRoute("/ws/perspective-config", transports.ws_endpoint(blotter.config_server)),
+        WebSocketRoute("/perspective", blotter.data_endpoint),  # Perspective's own data socket (Mode B)
+        Route("/perspective/relayout", blotter.relayout, methods=["POST"]),
     ],
     bundles=["webawesome", "lightweight-charts", "perspective"],
     head=TYPOGRAPHY_CSS,

--- a/spaday/examples/__main__.py
+++ b/spaday/examples/__main__.py
@@ -33,7 +33,6 @@ signal store, and the ``spaday:patch`` sink — and mounts the Python-authored t
 
 import asyncio
 import enum
-import random
 from datetime import date, timedelta
 from typing import Annotated
 
@@ -45,6 +44,7 @@ from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse
 from starlette.routing import Route, WebSocketRoute
 from starlette.websockets import WebSocket, WebSocketDisconnect
+from superstore import RandomWalk, superstore
 
 from spaday import Wire, element
 from spaday.actions import CallEndpoint, SendPatch, Sequence, SetProp, Toggle, bind, by_id, cond, field, lit, not_, obj
@@ -76,14 +76,11 @@ TYPES = ["line", "area", "histogram"]
 WINDOW = 120
 
 
-def random_walk(n: int, *, seed: int = 7, start: float = 100.0) -> list:
-    """A deterministic daily-value series, e.g. ``[{"time": "2023-01-01", "value": 99.54}, ...]``."""
-    rng = random.Random(seed)
-    value, day, points = start, date(2023, 1, 1), []
-    for i in range(n):
-        value += rng.uniform(-1.4, 1.5)
-        points.append({"time": (day + timedelta(days=i)).isoformat(), "value": round(value, 2)})
-    return points
+def daily_walk(n: int = WINDOW) -> list:
+    """A random-walk price series ``[{"time": "2023-01-01", "value": 99.54}, ...]`` for the client-only
+    charts, generated with superstore's ``RandomWalk``."""
+    day = date(2023, 1, 1)
+    return [{"time": (day + timedelta(days=i)).isoformat(), "value": round(v, 2)} for i, v in enumerate(RandomWalk(sigma=1.4, start=100.0).sample(n))]
 
 
 class Chart(BaseModel):
@@ -95,18 +92,17 @@ class Chart(BaseModel):
 
 
 class ChartSource:
-    """A `Chart` model plus the running state that windows points into it."""
+    """A `Chart` model plus the running superstore `RandomWalk` that windows points into it. Each instance
+    has its own walk, so the global and per-session charts diverge naturally."""
 
-    def __init__(self, type: str = "area", seed: int = 0) -> None:
-        self._rng = random.Random(seed)
-        self._value, self._day = 100.0, date(2023, 1, 1)
-        self.model = Chart(type=type, data=dict(self._point() for _ in range(WINDOW)))
+    def __init__(self, type: str = "area") -> None:
+        self._walk, self._day = RandomWalk(sigma=1.4, start=100.0), date(2023, 1, 1)
+        self.model = Chart(type=type, data=dict(self._point(v) for v in self._walk.sample(WINDOW)))
 
-    def _point(self) -> tuple[str, float]:
-        self._value += self._rng.uniform(-1.4, 1.5)
+    def _point(self, value: float) -> tuple[str, float]:
         t = self._day.isoformat()
         self._day += timedelta(days=1)
-        return t, round(self._value, 2)
+        return t, round(value, 2)
 
     def tick(self) -> None:
         if self.model.live:
@@ -114,14 +110,14 @@ class ChartSource:
             # a time-keyed map, the Session diffs this to Set(newest) + Remove(oldest) — a 2-op per-point
             # delta — and the snapshot every new client downloads stays bounded (not an ever-growing list).
             data = dict(self.model.data)
-            t, v = self._point()
+            t, v = self._point(self._walk.sample(1)[0])
             data[t] = v
             while len(data) > WINDOW:
                 del data[next(iter(data))]
             self.model.data = data
 
 
-global_src = ChartSource(type="area", seed=7)
+global_src = ChartSource(type="area")
 global_session = transports.Session()
 global_session.host(global_src.model)
 global_server = transports.Server(global_session)
@@ -158,27 +154,16 @@ form_server = transports.Server(form_session)
 
 # Perspective (Mode B): the table DATA rides Perspective's own websocket (served at /perspective below);
 # spaday/transports carry only a small CONFIG (which server, which tables, and the workspace layout +
-# per-viewer views) that the server can PUSH at any time. A live trades blotter capped to a ring buffer.
+# per-viewer views) that the server can PUSH at any time. A live Superstore orders blotter (a ring buffer);
+# the schema is inferred from the seed batch, so there is no hand-written column list to keep in sync.
 psp_server = PerspectiveServer()
 psp_client = psp_server.new_local_client()
-TRADES_SCHEMA = {"id": "integer", "symbol": "string", "price": "float", "size": "integer"}
-psp_table = psp_client.table(TRADES_SCHEMA, limit=2000, name="trades")  # ring buffer (append; drop oldest)
-_PSP_SYMBOLS = ["AAPL", "MSFT", "GOOG", "AMZN", "NVDA"]
-_psp_rng = random.Random(11)
-_psp_px = {s: round(_psp_rng.uniform(80, 400), 2) for s in _PSP_SYMBOLS}
-_psp_id = 0
+psp_table = psp_client.table(superstore(count=500, output="dict"), limit=5000, name="orders")  # ring buffer
 
 
 def psp_tick() -> None:
-    """Append a few random trades; they stream to every connected browser over Perspective's own websocket."""
-    global _psp_id
-    rows = []
-    for _ in range(6):
-        _psp_id += 1
-        sym = _psp_rng.choice(_PSP_SYMBOLS)
-        _psp_px[sym] = round(max(1.0, _psp_px[sym] + _psp_rng.uniform(-2, 2)), 2)
-        rows.append({"id": _psp_id, "symbol": sym, "price": _psp_px[sym], "size": _psp_rng.randint(1, 1000)})
-    psp_table.update(rows)
+    """Append a fresh batch of Superstore orders; they stream to every browser over Perspective's own socket."""
+    psp_table.update(superstore(count=8, output="dict"))
 
 
 def _psp_layout(viewer: dict) -> dict:
@@ -188,21 +173,26 @@ def _psp_layout(viewer: dict) -> dict:
         "detail": {"main": {"type": "tab-area", "widgets": ["view"], "currentIndex": 0}},
         "master": {"sizes": [], "widgets": []},
         "mode": "globalFilters",
-        "viewers": {"view": {"table": "trades", "plugin": "Datagrid", "theme": "Pro Light", **viewer}},
+        "viewers": {"view": {"table": "orders", "plugin": "Datagrid", "theme": "Pro Light", **viewer}},
     }
 
 
-# Two pushable presets: a flat live blotter and a by-symbol aggregation. The button below flips between
-# them server-side; every connected workspace re-restores — the "push a new view at any time" demo.
-PSP_BLOTTER = _psp_layout({"title": "Trades (live)", "sort": [["id", "desc"]]})
-PSP_BY_SYMBOL = _psp_layout(
-    {"title": "By symbol", "group_by": ["symbol"], "columns": ["price", "size"], "aggregates": {"price": "avg", "size": "sum"}}
+# Two pushable presets: a flat live blotter and a by-category rollup. The button below flips between them
+# server-side; every connected workspace re-restores — the "push a new view at any time" demo.
+PSP_BLOTTER = _psp_layout({"title": "Orders (live)", "sort": [["Order Date", "desc"]]})
+PSP_BY_CATEGORY = _psp_layout(
+    {
+        "title": "By category",
+        "group_by": ["Category", "Sub-Category"],
+        "columns": ["Sales", "Quantity", "Profit"],
+        "aggregates": {"Sales": "sum", "Quantity": "sum", "Profit": "sum"},
+    }
 )
 
 
 class PerspectiveConfig(BaseModel):
     ws_url: str = "/perspective"  # the Perspective data websocket (this app serves it)
-    tables: list = Field(default_factory=lambda: ["trades"])  # informational; discovered over the socket
+    tables: list = Field(default_factory=lambda: ["orders"])  # informational; discovered over the socket
     layout: dict = Field(default_factory=lambda: dict(PSP_BLOTTER))  # the pushable workspace layout + views
 
 
@@ -254,7 +244,7 @@ def dsl_card() -> object:
         .child(
             Stack()
             .child(Toolbar().child(type_button("Line", "line")).child(type_button("Area", "area")).child(type_button("Histogram", "histogram")))
-            .child(LightweightChart(type="area", data=random_walk(120)).prop("id", "dsl-chart").compute("theme", DARK_THEME))
+            .child(LightweightChart(type="area", data=daily_walk()).prop("id", "dsl-chart").compute("theme", DARK_THEME))
         )
     )
 
@@ -279,7 +269,7 @@ def structure_card() -> object:
         .child(WaSwitch().prop("id", "chart-toggle").bind("checked", "show_chart", mode="two-way").text("Show chart"))
         .child(
             Show(field="show_chart").child(
-                LightweightChart(type="area", data=random_walk(120)).prop("style", "height:260px;display:block").compute("theme", DARK_THEME)
+                LightweightChart(type="area", data=daily_walk()).prop("style", "height:260px;display:block").compute("theme", DARK_THEME)
             )
         )
     )
@@ -438,7 +428,7 @@ async def psp_relayout(request):
     """Push a different workspace layout/view to EVERY connected browser by mutating the shared config
     model — transports fans the change and each perspective-panel re-restores. Flips between two presets."""
     grouped = psp_config.layout.get("viewers", {}).get("view", {}).get("group_by")
-    psp_config.layout = dict(PSP_BLOTTER) if grouped else dict(PSP_BY_SYMBOL)
+    psp_config.layout = dict(PSP_BLOTTER) if grouped else dict(PSP_BY_CATEGORY)
     return JSONResponse({"view": psp_config.layout["viewers"]["view"]["title"]})
 
 
@@ -451,7 +441,7 @@ async def session_endpoint(ws: WebSocket) -> None:
     key = ws.query_params.get("session", "anon")
     sess = session_hub.tenant(key)
     if key not in session_srcs:
-        src = ChartSource(type="area", seed=hash(key) & 0xFFFF)
+        src = ChartSource(type="area")
         sess.host(src.model)
         session_srcs[key] = src
     await ws.accept()
@@ -483,7 +473,7 @@ async def ticker() -> None:
         global_src.tick()
         for src in list(session_srcs.values()):
             src.tick()
-        psp_tick()  # stream new trades into the Perspective table (over its own websocket)
+        psp_tick()  # stream new orders into the Perspective table (over its own websocket)
 
 
 # serve() generates the whole page (bootstrap, the four namespaced transports wires + the spaday:patch


### PR DESCRIPTION
Cleans up the omnibus example's data generation by delegating it to the
[superstore](https://pypi.org/project/superstore/) package (added as a
`[perspective]` + `[develop]` dependency), so the example stops hand-rolling
random data.

## Charts
A superstore `RandomWalk` now backs both the static client-only series
(`daily_walk`) and the live windowed `ChartSource`, replacing the manual
`rng.uniform` walk. Each `ChartSource` owns its own walk, so the global and
per-session charts diverge naturally — no more `seed=hash(key)` juggling.

## Perspective blotter
A live **Superstore orders** table replaces the synthetic random trades. The
schema is inferred from the seed batch (no hand-written `TRADES_SCHEMA` column
list to keep in sync), and the two pushable presets become a flat orders
blotter and a **by-category rollup** (`Sales`/`Quantity`/`Profit` summed,
grouped by `Category`/`Sub-Category`).

Net removal of `_PSP_SYMBOLS`/`_psp_px`/`_psp_id` trade state, `TRADES_SCHEMA`,
and the manual walk math (39 insertions, 48 deletions).

## Verification
- `pytest spaday/tests/test_examples.py` — all pass (incl. the omnibus serve test).
- `make lint` — ruff/prettier/clippy/mdformat/codespell all green.
- Browser smoke: charts render, no console errors, the Perspective viewer is
  bound to the `orders` table (columns `Sales`/`Quantity`/`Profit`, grouped by
  `Category`/`Sub-Category`), and the push-view button flips
  `Orders (live)` ↔ `By category`.
