### PR TITLE
Add external component package registry

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -88,6 +88,14 @@ Generate a page and deliver it on any backend; see [Serve and embed](serving.md)
 .. autofunction:: spaday.bootstrap.bundles_dir
 ```
 
+### External component packages
+
+```{eval-rst}
+.. autoclass:: spaday.ComponentPackage
+.. autofunction:: spaday.resolve_component_packages
+.. autofunction:: spaday.discover_component_packages
+```
+
 ## Server-side rendering
 
 ```{eval-rst}

--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -20,6 +20,8 @@ Every attribute is a typed keyword (`variant: Optional[Literal["brand", "neutral
 **don't** pass is omitted, so the element keeps its own default and update patches stay minimal.
 
 To use a component library other than WebAwesome, [generate its classes from a manifest](cem.md).
+An independently distributed integration can also register its browser assets through the
+[`ComponentPackage` serving contract](serving.md#install-an-external-component-package).
 
 ## Nest children into slots
 

--- a/docs/src/serving.md
+++ b/docs/src/serving.md
@@ -7,12 +7,12 @@ takes the same generation options. (For keeping the UI in sync with a server-sid
 
 There is **no hand-written HTML**: spaday generates the bootstrap page from your Python description.
 
-| Rung | spaday owns | Seam |
-| ---- | ----------- | ---- |
-| No HTML | the whole app | `serve(page, …)` |
-| Some HTML | a sub-path of your app | `mount(app, page, prefix=…)` |
-| Full custom HTML | one node in your page | `bootstrap(fragment=True, target=…)` + `tree_json(page)` |
-| Notebook | a cell's widget | `Widget(component)` |
+| Rung             | spaday owns            | Seam                                                     |
+| ---------------- | ---------------------- | -------------------------------------------------------- |
+| No HTML          | the whole app          | `serve(page, …)`                                         |
+| Some HTML        | a sub-path of your app | `mount(app, page, prefix=…)`                             |
+| Full custom HTML | one node in your page  | `bootstrap(fragment=True, target=…)` + `tree_json(page)` |
+| Notebook         | a cell's widget        | `Widget(component)`                                      |
 
 `page` is a built component **or a zero-arg callable returning one** — a callable is re-rendered per
 request, so the tree can reflect current state.
@@ -44,6 +44,46 @@ one-line happy path — it is just `mount` onto a fresh app, so drop to `mount` 
 In a source checkout it serves built assets from `js/`; from a wheel it automatically serves packaged
 `spaday/extension` assets. Use `layout="source"` or `layout="installed"` only to override detection, such
 as when supplying a matching custom `js=` directory.
+
+## Install an external component package
+
+External integrations use one `ComponentPackage` descriptor for both `<head>` tags and static routes.
+An application can pass the descriptor directly or select it by Python path:
+
+```python
+from spaday_trees import package as trees
+
+app = serve(page, packages=[trees])
+app = serve(page, packages=["spaday_trees:package"])
+```
+
+An integration package defines that descriptor beside its built assets:
+
+```python
+from pathlib import Path
+
+from spaday import ComponentPackage
+
+package = ComponentPackage(
+    name="trees",
+    assets_dir=Path(__file__).parent / "extension",
+    assets=(("css", "trees.css"), ("js", "trees.js")),
+)
+```
+
+To make the short form `packages=["trees"]` available, publish the same object as a Python packaging
+entry point:
+
+```toml
+[project.entry-points."spaday.component_packages"]
+trees = "spaday_trees:package"
+```
+
+Entry-point packages are opt-in: spaday loads only names selected by the application, never every
+installed integration. All four backends serve each selected descriptor's `assets_dir` at
+`{prefix}/components/{name}/`; `bootstrap` emits its CSS and module-script URLs from the same `assets`
+list. This registration is host-side only: component tags and props already cross the generic spaday
+tree, so an integration needs no Rust plugin.
 
 ## Embed in an existing app
 
@@ -127,10 +167,10 @@ app = serve(
 Whatever rung you pick, the generated page expects the host to serve these paths (`{base}` is the
 `prefix`, empty by default) — `serve`/`mount` wire them for you:
 
-| Path | Serves |
-| ---- | ------ |
-| `GET {base}/` | the bootstrap HTML (`bootstrap(...)`) |
-| `GET {base}/tree.json` | the authored tree (`tree_json(page)`) |
-| `GET {base}/js/*` | the bundles under `bundles_dir()` |
-| `WS {base}/ws` | a transports endpoint (only when wired) |
-```
+| Path                             | Serves                                      |
+| -------------------------------- | ------------------------------------------- |
+| `GET {base}/`                    | the bootstrap HTML (`bootstrap(...)`)       |
+| `GET {base}/tree.json`           | the authored tree (`tree_json(page)`)       |
+| `GET {base}/js/*`                | the bundles under `bundles_dir()`           |
+| `GET {base}/components/{name}/*` | assets for each selected `ComponentPackage` |
+| `WS {base}/ws`                   | a transports endpoint (only when wired)     |

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -28,6 +28,7 @@ from .actions import (
 from .bootstrap import Wire
 from .cem import classes, generate
 from .component import Component, Paragraph, Strong, Text, element
+from .packages import ComponentPackage, discover_component_packages, resolve_component_packages
 from .render import render_html
 from .spaday import apply, decode_frame, diff, encode_frame, parse_cem  # compiled Rust extension (rust/python)
 from .theme import SHELL_TOKENS
@@ -56,6 +57,10 @@ __all__ = [
     "render_html",
     # a typed transports wire spec for a multi-model page (serve/bootstrap wire=[…])
     "Wire",
+    # external component-package assets (direct descriptor, Python path, or entry point)
+    "ComponentPackage",
+    "resolve_component_packages",
+    "discover_component_packages",
     # theming token reference (css custom properties are set via Component.css)
     "SHELL_TOKENS",
     # build-time validation

--- a/spaday/backends/aiohttp.py
+++ b/spaday/backends/aiohttp.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Optional, Sequence, Union
 
 from ..bootstrap import AssetLayout, Page, bootstrap, bundles_dir, tree_frame, tree_json
+from ..packages import PackageRef, package_url_prefix, resolve_component_packages
 
 if TYPE_CHECKING:  # annotations only — aiohttp is imported inside the functions (not a spaday dependency)
     from aiohttp import web
@@ -32,6 +33,7 @@ def mount(
     layout: Optional[AssetLayout] = None,
     title: str = "spaday",
     bundles: Sequence[str] = (),
+    packages: Union[PackageRef, Sequence[PackageRef]] = (),
     wire: Optional[str] = None,
     ws: str = "/ws",
     tree: str = "json",
@@ -45,9 +47,11 @@ def mount(
     from aiohttp import web
 
     asset_layout = layout or ("source" if js is not None else None)
+    component_packages = resolve_component_packages(packages)
     body = bootstrap(
         base=prefix,
         bundles=bundles,
+        packages=component_packages,
         wire=wire,
         ws=ws,
         tree=tree,
@@ -76,6 +80,8 @@ def mount(
         tree_route = web.get(f"{prefix}/tree.json", tree_handler)
 
     app.add_routes([web.get(f"{prefix}/", homepage), tree_route, *routes])
+    for package in component_packages:
+        app.router.add_static(package_url_prefix(package, prefix), str(package.assets_dir))
     app.router.add_static(f"{prefix}/js", js_dir)
     return app
 

--- a/spaday/backends/flask.py
+++ b/spaday/backends/flask.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 from ..bootstrap import AssetLayout, Page, bootstrap, bundles_dir, tree_frame, tree_json
+from ..packages import PackageRef, package_url_prefix, resolve_component_packages
 
 if TYPE_CHECKING:  # annotations only — flask is imported inside the functions (not a spaday dependency)
     from flask import Flask
@@ -30,6 +31,7 @@ def mount(
     layout: Optional[AssetLayout] = None,
     title: str = "spaday",
     bundles: Sequence[str] = (),
+    packages: Union[PackageRef, Sequence[PackageRef]] = (),
     wire: Optional[str] = None,
     ws: str = "/ws",
     tree: str = "json",
@@ -43,9 +45,11 @@ def mount(
     from flask import Response, send_from_directory
 
     asset_layout = layout or ("source" if js is not None else None)
+    component_packages = resolve_component_packages(packages)
     body = bootstrap(
         base=prefix,
         bundles=bundles,
+        packages=component_packages,
         wire=wire,
         ws=ws,
         tree=tree,
@@ -64,6 +68,14 @@ def mount(
     else:
         app.add_url_rule(f"{prefix}/tree.json", f"spaday_tree_{key}", lambda: Response(tree_json(page), mimetype="application/json"))
     app.add_url_rule(f"{prefix}/js/<path:path>", f"spaday_js_{key}", lambda path: send_from_directory(js_dir, path))
+    for package in component_packages:
+        package_dir = package.assets_dir
+        package_key = package.name.replace("-", "_").replace(".", "_")
+        app.add_url_rule(
+            f"{package_url_prefix(package, prefix)}/<path:path>",
+            f"spaday_component_{key}_{package_key}",
+            lambda path, directory=package_dir: send_from_directory(directory, path),
+        )
     for rule in routes:
         app.add_url_rule(*rule)
     return app

--- a/spaday/backends/starlette.py
+++ b/spaday/backends/starlette.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Callable, Optional, Sequence, Union
 
 from ..bootstrap import AssetLayout, Page, Wire, bootstrap, bundles_dir, tree_frame, tree_json
+from ..packages import PackageRef, package_url_prefix, resolve_component_packages
 
 if TYPE_CHECKING:  # annotations only — starlette is imported inside the functions (optional extra)
     from starlette.applications import Starlette
@@ -53,6 +54,7 @@ def mount(
     layout: Optional[AssetLayout] = None,
     title: str = "spaday",
     bundles: Sequence[str] = (),
+    packages: Union[PackageRef, Sequence[PackageRef]] = (),
     wire: Optional[Union[str, Sequence[Union[dict, Wire]]]] = None,
     ws: str = "/ws",
     tree: str = "json",
@@ -75,9 +77,11 @@ def mount(
     from starlette.staticfiles import StaticFiles
 
     asset_layout = layout or ("source" if js is not None else None)
+    component_packages = resolve_component_packages(packages)
     body = bootstrap(
         base=prefix,
         bundles=bundles,
+        packages=component_packages,
         wire=wire,
         ws=ws,
         tree=tree,
@@ -101,14 +105,23 @@ def mount(
         return Response(tree_frame(page), media_type="application/octet-stream")
 
     tree_route = Route(f"{prefix}/tree", tree_route_frame) if tree == "frame" else Route(f"{prefix}/tree.json", tree_route_json)
-    app.routes.extend([Route(f"{prefix}/", homepage), tree_route, *_prefixed(routes, prefix), Mount(f"{prefix}/js", StaticFiles(directory=js_dir))])
+    package_mounts = [Mount(package_url_prefix(package, prefix), StaticFiles(directory=package.assets_dir)) for package in component_packages]
+    app.routes.extend(
+        [
+            Route(f"{prefix}/", homepage),
+            tree_route,
+            *_prefixed(routes, prefix),
+            *package_mounts,
+            Mount(f"{prefix}/js", StaticFiles(directory=js_dir)),
+        ]
+    )
     return app
 
 
 def serve(page: Page, *, background: Sequence[Awaitable] = (), lifespan: Optional[Callable] = None, **opts) -> Starlette:
     """Create a Starlette app and :func:`mount` ``page`` onto it. ``background`` coroutines run for the
     app's lifetime (or pass a custom ``lifespan`` for ordered startup, e.g. a clustering relay); all other
-    keyword options are :func:`mount`'s (``prefix``/``routes``/``html``/``js``/``title``/``bundles``/
+    keyword options are :func:`mount`'s (``prefix``/``routes``/``html``/``js``/``title``/``bundles``/``packages``/
     ``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``/``store``/``nonce``)."""
     from starlette.applications import Starlette
 

--- a/spaday/backends/tornado.py
+++ b/spaday/backends/tornado.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Optional, Sequence, Union
 
 from ..bootstrap import AssetLayout, Page, bootstrap, bundles_dir, tree_frame, tree_json
+from ..packages import PackageRef, package_url_prefix, resolve_component_packages
 
 if TYPE_CHECKING:  # annotations only — tornado is imported inside the functions (not a spaday dependency)
     from tornado.web import Application
@@ -33,6 +34,7 @@ def mount(
     layout: Optional[AssetLayout] = None,
     title: str = "spaday",
     bundles: Sequence[str] = (),
+    packages: Union[PackageRef, Sequence[PackageRef]] = (),
     wire: Optional[str] = None,
     ws: str = "/ws",
     tree: str = "json",
@@ -46,9 +48,11 @@ def mount(
     from tornado.web import RequestHandler, StaticFileHandler
 
     asset_layout = layout or ("source" if js is not None else None)
+    component_packages = resolve_component_packages(packages)
     body = bootstrap(
         base=prefix,
         bundles=bundles,
+        packages=component_packages,
         wire=wire,
         ws=ws,
         tree=tree,
@@ -83,7 +87,15 @@ def mount(
 
         tree_rule = (rf"{pre}/tree\.json", _Tree)
 
-    handlers = [(rf"{pre}/", _Index), tree_rule, *routes, (rf"{pre}/js/(.*)", StaticFileHandler, {"path": js_dir})]
+    package_handlers = [
+        (
+            rf"{re.escape(package_url_prefix(package, prefix))}/(.*)",
+            StaticFileHandler,
+            {"path": str(package.assets_dir)},
+        )
+        for package in component_packages
+    ]
+    handlers = [(rf"{pre}/", _Index), tree_rule, *routes, *package_handlers, (rf"{pre}/js/(.*)", StaticFileHandler, {"path": js_dir})]
     app.add_handlers(r".*", handlers)
     return app
 

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -6,6 +6,8 @@ What an app would otherwise hand-write in HTML is declared in Python:
 
 - ``bundles=["webawesome", …]`` — pull a component library's styles + catalog bundle into ``<head>``
   (see :data:`BUNDLES`), instead of copy-pasting its ``<link>``/``<script>`` tags.
+- ``packages=["trees", …]`` — do the same for external component packages selected by descriptor,
+  ``module:attribute`` Python path, or installed entry-point name.
 - ``wire="transports"`` — generate the transports ``Client`` + ``connectStore`` + websocket bootstrap
   (what every transports example's HTML repeats); without it the page just mounts a static tree.
 - ``tree="frame"`` — fetch the tree as a transports Snapshot frame at ``…/tree`` (UI tree + model data on
@@ -24,6 +26,7 @@ What an app would otherwise hand-write in HTML is declared in Python:
     GET {base}/            -> bootstrap(...)        # this HTML
     GET {base}/tree.json   -> tree_json(page)       # or GET {base}/tree -> tree_frame(page) when tree="frame"
     GET {base}/js/*        -> the files under bundles_dir()
+    GET {base}/components/{package}/* -> a selected component package's assets
     WS  {base}/ws          -> a transports endpoint # only when wire="transports" (the backend/transports owns it)
 """
 
@@ -35,6 +38,7 @@ from pathlib import Path
 from typing import Literal, Optional, Sequence, Union
 
 from .component import Component
+from .packages import ComponentPackage, PackageRef, package_url_prefix, resolve_component_packages
 from .spaday import encode_frame  # compiled core (always available); used by tree_frame
 
 #: A page is a built :class:`~spaday.component.Component`, or a zero-arg callable returning one (called
@@ -160,6 +164,17 @@ def _bundle_head(bundles: Sequence[str], base: str, nonce: Optional[str] = None,
             raise ValueError(f"unknown bundle {name!r}; known: {', '.join(sorted(available))}")
         for kind, path in available[name]:
             url = f"{_js(base)}{path}"
+            tags.append(f'<link rel="stylesheet"{n} href="{url}" />' if kind == "css" else f'<script type="module"{n} src="{url}"></script>')
+    return "\n    ".join(tags)
+
+
+def _package_head(packages: Sequence[ComponentPackage], base: str, nonce: Optional[str] = None) -> str:
+    n = f' nonce="{nonce}"' if nonce else ""
+    tags = []
+    for package in packages:
+        prefix = package_url_prefix(package, base)
+        for kind, path in package.assets:
+            url = f"{prefix}/{path}"
             tags.append(f'<link rel="stylesheet"{n} href="{url}" />' if kind == "css" else f'<script type="module"{n} src="{url}"></script>')
     return "\n    ".join(tags)
 
@@ -297,6 +312,7 @@ def bootstrap(
     *,
     base: str = "",
     bundles: Sequence[str] = (),
+    packages: Union[PackageRef, Sequence[PackageRef]] = (),
     wire: Optional[Union[str, Sequence[Union[dict, Wire]]]] = None,
     ws: str = "/ws",
     tree: str = "json",
@@ -324,10 +340,12 @@ def bootstrap(
     specific element (e.g. ``"#widget"``) instead of ``document.body``; the host provides that element.
     ``nonce`` stamps the generated ``<script>``/``<link>`` tags with a CSP nonce, so a host with a strict
     ``script-src``/``style-src`` policy can allow the snippet. See the module docstring for the rest of the
-    options and the route contract. ``layout`` selects source-checkout or installed-wheel asset URLs;
-    by default it follows :func:`bundles_dir`."""
+    options and the route contract. ``packages`` selects external :class:`~spaday.packages.ComponentPackage`
+    descriptors directly, by ``module:attribute`` path, or by installed entry-point name. ``layout``
+    selects source-checkout or installed-wheel asset URLs; by default it follows :func:`bundles_dir`."""
     n = f' nonce="{nonce}"' if nonce else ""
-    head_markup = "\n    ".join(p for p in (_bundle_head(bundles, base, nonce, layout), head) if p)
+    component_packages = resolve_component_packages(packages)
+    head_markup = "\n    ".join(p for p in (_bundle_head(bundles, base, nonce, layout), _package_head(component_packages, base, nonce), head) if p)
     script = _script(base, wire, scripts, ws, tree, reconnect, store, target, layout)
     if fragment:
         head_block = f"{head_markup}\n" if head_markup else ""

--- a/spaday/packages.py
+++ b/spaday/packages.py
@@ -1,0 +1,103 @@
+"""Component-package descriptors and installed entry-point discovery."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from importlib import import_module
+from importlib.metadata import entry_points
+from pathlib import Path, PurePosixPath
+from typing import Sequence, Union
+
+ENTRY_POINT_GROUP = "spaday.component_packages"
+_PACKAGE_NAME = re.compile(r"[a-z0-9][a-z0-9._-]*\Z")
+
+
+@dataclass(frozen=True)
+class ComponentPackage:
+    """Assets that register one external component library in the browser.
+
+    ``assets`` contains ``("css" | "js", relative_path)`` pairs under
+    ``assets_dir``. Backends serve that directory at
+    ``{prefix}/components/{name}``; :func:`spaday.bootstrap.bootstrap` emits
+    the matching tags.
+    """
+
+    name: str
+    assets_dir: Path
+    assets: Sequence[tuple[str, str]]
+
+    def __post_init__(self) -> None:
+        if not _PACKAGE_NAME.fullmatch(self.name):
+            raise ValueError("component package name must contain only lowercase letters, digits, '.', '_', or '-'")
+        normalized = []
+        for kind, path in self.assets:
+            if kind not in ("css", "js"):
+                raise ValueError("component package asset kind must be 'css' or 'js'")
+            asset_path = PurePosixPath(path)
+            if asset_path.is_absolute() or not path or ".." in asset_path.parts:
+                raise ValueError("component package asset paths must be relative and cannot contain '..'")
+            normalized.append((kind, asset_path.as_posix()))
+        object.__setattr__(self, "assets_dir", Path(self.assets_dir))
+        object.__setattr__(self, "assets", tuple(normalized))
+
+
+PackageRef = Union[ComponentPackage, str]
+
+
+def package_url_prefix(package: ComponentPackage, base: str = "") -> str:
+    """URL prefix where a backend serves ``package.assets_dir``."""
+    return f"{base}/components/{package.name}"
+
+
+def _require_package(value: object, source: str) -> ComponentPackage:
+    if not isinstance(value, ComponentPackage):
+        raise TypeError(f"{source} must expose a ComponentPackage, got {type(value).__name__}")
+    return value
+
+
+def _from_python_path(spec: str) -> ComponentPackage:
+    module_name, separator, attribute = spec.partition(":")
+    if not separator or not module_name or not attribute:
+        raise ValueError(f"invalid component package Python path {spec!r}; expected 'module:attribute'")
+    value = getattr(import_module(module_name), attribute)
+    return _require_package(value, f"component package Python path {spec!r}")
+
+
+def _installed_entry_points():
+    return tuple(entry_points(group=ENTRY_POINT_GROUP))
+
+
+def _from_entry_point(name: str) -> ComponentPackage:
+    matches = [candidate for candidate in _installed_entry_points() if candidate.name == name]
+    if not matches:
+        raise ValueError(f"unknown component package {name!r}; no {ENTRY_POINT_GROUP!r} entry point is installed")
+    if len(matches) > 1:
+        raise ValueError(f"multiple {ENTRY_POINT_GROUP!r} entry points are named {name!r}")
+    return _require_package(matches[0].load(), f"component package entry point {name!r}")
+
+
+def resolve_component_packages(packages: Union[PackageRef, Sequence[PackageRef]] = ()) -> tuple[ComponentPackage, ...]:
+    """Resolve descriptors, ``module:attribute`` paths, or installed entry-point names.
+
+    Entry points are loaded only when explicitly named; installing an integration
+    never injects assets into unrelated applications.
+    """
+    refs = (packages,) if isinstance(packages, (str, ComponentPackage)) else packages
+    resolved = tuple(
+        package if isinstance(package, ComponentPackage) else (_from_python_path(package) if ":" in package else _from_entry_point(package))
+        for package in refs
+    )
+    names = [package.name for package in resolved]
+    duplicate = next((name for name in names if names.count(name) > 1), None)
+    if duplicate is not None:
+        raise ValueError(f"component package {duplicate!r} was selected more than once")
+    return resolved
+
+
+def discover_component_packages() -> tuple[ComponentPackage, ...]:
+    """Load every installed component-package entry point, sorted by entry-point name."""
+    return tuple(
+        _require_package(candidate.load(), f"component package entry point {candidate.name!r}")
+        for candidate in sorted(_installed_entry_points(), key=lambda candidate: candidate.name)
+    )

--- a/spaday/tests/fixtures/component_package/fixture.css
+++ b/spaday/tests/fixtures/component_package/fixture.css
@@ -1,0 +1,1 @@
+fixture-element { display: block; }

--- a/spaday/tests/fixtures/component_package/fixture.js
+++ b/spaday/tests/fixtures/component_package/fixture.js
@@ -1,0 +1,1 @@
+customElements.define("fixture-element", class extends HTMLElement {});

--- a/spaday/tests/package_fixture.py
+++ b/spaday/tests/package_fixture.py
@@ -1,9 +1,0 @@
-from pathlib import Path
-
-from spaday.packages import ComponentPackage
-
-package = ComponentPackage(
-    name="fixture",
-    assets_dir=Path(__file__).parent / "fixtures" / "component_package",
-    assets=(("css", "fixture.css"), ("js", "fixture.js")),
-)

--- a/spaday/tests/package_fixture.py
+++ b/spaday/tests/package_fixture.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from spaday.packages import ComponentPackage
+
+package = ComponentPackage(
+    name="fixture",
+    assets_dir=Path(__file__).parent / "fixtures" / "component_package",
+    assets=(("css", "fixture.css"), ("js", "fixture.js")),
+)

--- a/spaday/tests/test_backend_aiohttp.py
+++ b/spaday/tests/test_backend_aiohttp.py
@@ -8,6 +8,7 @@ from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
 
 from spaday.backends.aiohttp import serve  # noqa: E402
 from spaday.components.shell import Main  # noqa: E402
+from spaday.packages import ComponentPackage  # noqa: E402
 
 
 def test_serve_hosts_page_and_tree(tmp_path):
@@ -20,5 +21,16 @@ def test_serve_hosts_page_and_tree(tmp_path):
             assert "connectStore" in home and "webawesome.css" in home  # the generated bootstrap + bundle
             tree = await (await client.get("/tree.json")).json()
             assert tree == page.to_node()  # tree served as JSON
+
+    asyncio.run(check())
+
+
+def test_serve_hosts_component_package_assets(tmp_path):
+    (tmp_path / "index.js").write_text("export {};", encoding="utf-8")
+
+    async def check():
+        package = ComponentPackage("fixture", tmp_path, (("js", "index.js"),))
+        async with TestClient(TestServer(serve(Main("hi"), packages=[package]))) as client:
+            assert (await client.get("/components/fixture/index.js")).status == 200
 
     asyncio.run(check())

--- a/spaday/tests/test_backend_flask.py
+++ b/spaday/tests/test_backend_flask.py
@@ -4,6 +4,7 @@ pytest.importorskip("flask")  # the Flask (WSGI) backend — flask is not a spad
 
 from spaday.backends.flask import serve  # noqa: E402
 from spaday.components.shell import Main  # noqa: E402
+from spaday.packages import ComponentPackage  # noqa: E402
 
 
 def test_serve_hosts_page_and_tree(tmp_path):
@@ -12,3 +13,10 @@ def test_serve_hosts_page_and_tree(tmp_path):
     home = client.get("/").get_data(as_text=True)
     assert "connectStore" in home and "webawesome.css" in home  # the generated bootstrap + bundle
     assert client.get("/tree.json").get_json() == page.to_node()  # tree served as JSON
+
+
+def test_serve_hosts_component_package_assets(tmp_path):
+    (tmp_path / "index.js").write_text("export {};", encoding="utf-8")
+    package = ComponentPackage("fixture", tmp_path, (("js", "index.js"),))
+    client = serve(Main("hi"), packages=[package]).test_client()
+    assert client.get("/components/fixture/index.js").status_code == 200

--- a/spaday/tests/test_backend_starlette.py
+++ b/spaday/tests/test_backend_starlette.py
@@ -9,9 +9,21 @@ from starlette.responses import PlainTextResponse  # noqa: E402
 from starlette.routing import Route  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
+import spaday.packages as package_registry  # noqa: E402
 from spaday import decode_frame  # noqa: E402
 from spaday.backends.starlette import mount, serve  # noqa: E402
 from spaday.components.shell import Main  # noqa: E402
+from spaday.packages import ComponentPackage  # noqa: E402
+
+
+class _EntryPoint:
+    name = "fixture"
+
+    def __init__(self, package):
+        self.package = package
+
+    def load(self):
+        return self.package
 
 
 def test_serve_hosts_page_tree_bundle_and_routes(tmp_path):
@@ -22,6 +34,18 @@ def test_serve_hosts_page_tree_bundle_and_routes(tmp_path):
     assert client.get("/tree.json").json() == page.to_node()  # tree served as JSON
     assert client.get("/js/dist/esm/index.js") is not None  # /js mount present (dir is tmp here)
     assert client.get("/api/ping").text == "pong"  # spliced route
+
+
+def test_entry_point_package_adds_tags_and_serves_assets(monkeypatch, tmp_path):
+    (tmp_path / "index.js").write_text("export const loaded = true;", encoding="utf-8")
+    package = ComponentPackage("fixture", tmp_path, (("js", "index.js"),))
+    monkeypatch.setattr(package_registry, "entry_points", lambda **_kwargs: [_EntryPoint(package)])
+
+    client = TestClient(serve(Main("hi"), packages=["fixture"], prefix="/dash"))
+    assert 'src="/dash/components/fixture/index.js"' in client.get("/dash/").text
+    asset = client.get("/dash/components/fixture/index.js")
+    assert asset.status_code == 200
+    assert asset.text == "export const loaded = true;"
 
 
 def test_serve_frame_route_returns_a_decodable_frame(tmp_path):

--- a/spaday/tests/test_backend_tornado.py
+++ b/spaday/tests/test_backend_tornado.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -8,6 +9,7 @@ from tornado.testing import AsyncHTTPTestCase  # noqa: E402
 
 from spaday.backends.tornado import serve  # noqa: E402
 from spaday.components.shell import Main  # noqa: E402
+from spaday.packages import ComponentPackage  # noqa: E402
 
 
 class TestTornadoBackend(AsyncHTTPTestCase):
@@ -19,3 +21,13 @@ class TestTornadoBackend(AsyncHTTPTestCase):
         home = self.fetch("/").body.decode()
         assert "connectStore" in home and "webawesome.css" in home  # the generated bootstrap + bundle
         assert json.loads(self.fetch("/tree.json").body) == Main("hi").to_node()  # tree served as JSON
+
+
+class TestTornadoComponentPackage(AsyncHTTPTestCase):
+    def get_app(self):
+        assets = Path(__file__).parent / "fixtures" / "component_package"
+        package = ComponentPackage("fixture", assets, (("js", "fixture.js"),))
+        return serve(Main("hi"), packages=[package])
+
+    def test_serves_package_asset(self):
+        assert self.fetch("/components/fixture/fixture.js").code == 200

--- a/spaday/tests/test_packages.py
+++ b/spaday/tests/test_packages.py
@@ -1,0 +1,56 @@
+import pytest
+
+import spaday.packages as package_registry
+from spaday.bootstrap import bootstrap
+from spaday.packages import ComponentPackage, discover_component_packages, resolve_component_packages
+
+
+class EntryPoint:
+    def __init__(self, name, package):
+        self.name = name
+        self.package = package
+
+    def load(self):
+        return self.package
+
+
+def test_resolves_a_descriptor_and_python_path():
+    direct = ComponentPackage("direct", ".", (("js", "index.js"),))
+    assert resolve_component_packages(direct) == (direct,)
+    assert resolve_component_packages("spaday.tests.package_fixture:package")[0].name == "fixture"
+
+
+def test_resolves_and_discovers_installed_entry_points(monkeypatch):
+    first = ComponentPackage("first", ".", (("js", "first.js"),))
+    second = ComponentPackage("second", ".", (("css", "second.css"),))
+    candidates = [EntryPoint("z-second", second), EntryPoint("a-first", first)]
+    monkeypatch.setattr(package_registry, "entry_points", lambda **_kwargs: candidates)
+
+    assert resolve_component_packages("z-second") == (second,)
+    assert discover_component_packages() == (first, second)
+
+
+def test_bootstrap_uses_the_same_descriptor_for_package_asset_urls():
+    html = bootstrap(
+        base="/dash",
+        packages="spaday.tests.package_fixture:package",
+        nonce="abc123",
+    )
+    assert '<link rel="stylesheet" nonce="abc123" href="/dash/components/fixture/fixture.css" />' in html
+    assert '<script type="module" nonce="abc123" src="/dash/components/fixture/fixture.js"></script>' in html
+
+
+def test_rejects_unsafe_descriptors_and_duplicate_selection():
+    with pytest.raises(ValueError, match="name"):
+        ComponentPackage("Not Safe", ".", (("js", "index.js"),))
+    with pytest.raises(ValueError, match="relative"):
+        ComponentPackage("safe", ".", (("js", "../index.js"),))
+    package = ComponentPackage("same", ".", (("js", "index.js"),))
+    with pytest.raises(ValueError, match="more than once"):
+        resolve_component_packages((package, package))
+
+
+def test_unknown_entry_point_has_a_useful_error(monkeypatch):
+    monkeypatch.setattr(package_registry, "entry_points", lambda **_kwargs: ())
+    with pytest.raises(ValueError, match="spaday.component_packages"):
+        resolve_component_packages("missing")

--- a/spaday/tests/test_packages.py
+++ b/spaday/tests/test_packages.py
@@ -1,3 +1,6 @@
+import sys
+from types import ModuleType
+
 import pytest
 
 import spaday.packages as package_registry
@@ -14,10 +17,19 @@ class EntryPoint:
         return self.package
 
 
-def test_resolves_a_descriptor_and_python_path():
+@pytest.fixture
+def python_path_package(monkeypatch):
+    package = ComponentPackage("fixture", ".", (("css", "fixture.css"), ("js", "fixture.js")))
+    module = ModuleType("spaday_package_fixture")
+    module.package = package
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    return package
+
+
+def test_resolves_a_descriptor_and_python_path(python_path_package):
     direct = ComponentPackage("direct", ".", (("js", "index.js"),))
     assert resolve_component_packages(direct) == (direct,)
-    assert resolve_component_packages("spaday.tests.package_fixture:package")[0].name == "fixture"
+    assert resolve_component_packages("spaday_package_fixture:package") == (python_path_package,)
 
 
 def test_resolves_and_discovers_installed_entry_points(monkeypatch):
@@ -30,10 +42,10 @@ def test_resolves_and_discovers_installed_entry_points(monkeypatch):
     assert discover_component_packages() == (first, second)
 
 
-def test_bootstrap_uses_the_same_descriptor_for_package_asset_urls():
+def test_bootstrap_uses_the_same_descriptor_for_package_asset_urls(python_path_package):
     html = bootstrap(
         base="/dash",
-        packages="spaday.tests.package_fixture:package",
+        packages="spaday_package_fixture:package",
         nonce="abc123",
     )
     assert '<link rel="stylesheet" nonce="abc123" href="/dash/components/fixture/fixture.css" />' in html


### PR DESCRIPTION
## Description

Add one `ComponentPackage` descriptor shared by bootstrap markup and backend static mounts. Packages can be selected directly, through a `module:attribute` Python path, or by an explicitly named `spaday.component_packages` entry point. Installing a package remains opt-in and requires no Rust registration layer.

All four backends serve selected package assets under `{prefix}/components/{name}/`. Documentation covers application and package-author flows.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [x] Changelog / version bump (not applicable; release managed separately)