### PR TITLE
Add rich table cells

### DIFF
--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -139,8 +139,40 @@ Table(columns=["symbol", "qty", "price"]).compute("rows", field("orders"))
 ```
 
 `columns` may be plain keys (`["symbol"]` — the label is the key) or `{"key": …, "label": …}` dicts; omit
-it to infer the columns from the first row. Pass `rows=[…]` for a static table. Cells are text; for virtual
-scrolling or very large datasets, wrap a grid library (regular-table) via the [wrapper recipe](wrappers.md).
+it to infer the columns from the first row. Pass `rows=[…]` for a static table. Scalar cells render as
+text. A static cell can instead contain any spaday component, including a button with an action:
+
+```python
+from spaday import NamedJs
+from spaday.components.shell import Table
+from spaday.components.webawesome import WaButton
+
+inspect = (
+    WaButton(appearance="plain")
+    .text("Inspect")
+    .prop("data-symbol", "AAPL")
+    .on("click", NamedJs("inspect-order"))
+)
+Table(
+    columns=["symbol", {"key": "action", "label": ""}],
+    rows=[{"symbol": "AAPL", "action": inspect}],
+)
+```
+
+Register the named handler in a JavaScript module loaded through `scripts=`:
+
+```javascript
+import { registerHandler } from "/js/dist/esm/index.js";
+
+registerHandler("inspect-order", (_event, button) => {
+  window.inspectOrder(button.getAttribute("data-symbol"));
+});
+```
+
+Rich cells are normal component-tree nodes, so their bindings and declarative actions work unchanged.
+Reactive `rows` remain serializable data; define component cells in static `rows` or update the table's
+component tree. For virtual scrolling or very large datasets, use a grid library via the
+[wrapper recipe](wrappers.md).
 
 ## Reach for a raw element
 

--- a/js/src/ts/shell.ts
+++ b/js/src/ts/shell.ts
@@ -93,9 +93,10 @@ if (typeof customElements !== "undefined") {
 }
 
 // A lightweight data table (`spa-table`): renders `rows` (a list of objects) under `columns`, both set as
-// JS properties — so a bound / computed `rows` re-renders reactively. Cells are text (built with
-// createElement, never innerHTML). Not a virtual-scroll grid (that's regular-table); a themed `<table>`
-// for modest data.
+// JS properties — so a bound / computed `rows` re-renders reactively. Scalar cells are text (built with
+// createElement, never innerHTML); component-valued static cells are ordinary light-DOM children
+// projected into their cell through a named slot. Not a virtual-scroll grid; a themed `<table>` for
+// modest data.
 const TABLE_CSS = `:host{display:block;overflow:auto}
 table{border-collapse:collapse;width:100%;font-size:.9rem;color:inherit}
 th,td{text-align:left;padding:.4rem .65rem;border-bottom:1px solid ${BORDER};white-space:nowrap}
@@ -103,6 +104,24 @@ thead th{background:${SURFACE_2};font-weight:600;position:sticky;top:0}
 tbody tr:hover td{background:${SURFACE_2}}`;
 
 type TableCol = { key: string; label: string };
+const CELL_SLOT = "__spaday_cell_slot__";
+
+function tableCell(td: HTMLTableCellElement, value: unknown): void {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 1 &&
+    typeof (value as Record<string, unknown>)[CELL_SLOT] === "string"
+  ) {
+    const slot = document.createElement("slot");
+    slot.name = String((value as Record<string, unknown>)[CELL_SLOT]);
+    td.append(slot);
+    return;
+  }
+  td.textContent = value == null ? "" : String(value);
+}
+
 function tableColumns(
   cols: unknown,
   rows: Record<string, unknown>[],
@@ -167,9 +186,7 @@ if (typeof customElements !== "undefined" && !customElements.get("spa-table")) {
         const tbody = table.createTBody();
         for (const row of this.data) {
           const tr = tbody.insertRow();
-          for (const c of cols)
-            tr.insertCell().textContent =
-              row[c.key] == null ? "" : String(row[c.key]);
+          for (const c of cols) tableCell(tr.insertCell(), row[c.key]);
         }
         const old = this.root.querySelector("table");
         if (old) old.replaceWith(table);

--- a/js/tests/shell.spec.js
+++ b/js/tests/shell.spec.js
@@ -110,3 +110,68 @@ test("spa-table renders rows under columns and re-renders when the bound field c
     ["GOOG", "7"],
   ]); // reactively re-rendered from the changed field
 });
+
+test("spa-table projects rich component cells with working actions", async ({
+  page,
+}) => {
+  const r = await page.evaluate(() => {
+    const { mount, registerHandler } = window.__spaday;
+    let call = null;
+    registerHandler("inspect-order", (event, currentTarget) => {
+      call = {
+        event: event.type,
+        id: currentTarget.id,
+        symbol: currentTarget.getAttribute("data-symbol"),
+      };
+    });
+    const el = mount(document.body, {
+      tag: "spa-table",
+      props: {
+        columns: { List: [{ Str: "symbol" }, { Str: "action" }] },
+        rows: {
+          List: [
+            {
+              Map: {
+                symbol: { Str: "AAPL" },
+                action: {
+                  Map: { __spaday_cell_slot__: { Str: "cell-0" } },
+                },
+              },
+            },
+          ],
+        },
+      },
+      slots: {
+        "cell-0": [
+          {
+            tag: "button",
+            props: {
+              id: { Str: "inspect" },
+              "data-symbol": { Str: "AAPL" },
+              textContent: { Str: "Inspect" },
+            },
+            events: {
+              click: { kind: "js", handler: "inspect-order" },
+            },
+          },
+        ],
+      },
+    });
+    const slot = el.shadowRoot.querySelector('slot[name="cell-0"]');
+    const button = slot.assignedElements()[0];
+    button.click();
+    return {
+      call,
+      cellText: button.textContent,
+      assignedTag: button.tagName,
+      slotName: button.getAttribute("slot"),
+    };
+  });
+
+  expect(r).toEqual({
+    call: { event: "click", id: "inspect", symbol: "AAPL" },
+    cellText: "Inspect",
+    assignedTag: "BUTTON",
+    slotName: "cell-0",
+  });
+});

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -267,11 +267,27 @@ class Table(Component):
         Table(columns=["symbol", "qty", "price"]).compute("rows", field("orders"))
 
     ``columns`` may be plain keys (``["symbol"]`` — the label is the key) or ``{"key": …, "label": …}``
-    dicts; omit it to infer the columns from the first row. Pass ``rows`` for a static table. (For virtual
-    scrolling / very large datasets, wrap regular-table — Phase 7.)
+    dicts; omit it to infer the columns from the first row. Pass ``rows`` for a static table. A static
+    cell may be a :class:`Component`; it is rendered as a normal component tree node, including its
+    bindings and events. Other cell values render as text. For virtual scrolling or very large datasets,
+    use a dedicated grid wrapper.
     """
 
     tag = "spa-table"
 
     def __init__(self, *, columns: list | None = None, rows: list | None = None, key: str | None = None, **props: Any) -> None:
-        super().__init__(key=key, props={"columns": columns, "rows": rows}, **props)
+        normalized_rows = None if rows is None else []
+        rich_cells: list[tuple[str, Component]] = []
+        for row in rows or []:
+            normalized_row = {}
+            for name, value in row.items():
+                if isinstance(value, Component):
+                    slot = f"cell-{len(rich_cells)}"
+                    normalized_row[name] = {"__spaday_cell_slot__": slot}
+                    rich_cells.append((slot, value))
+                else:
+                    normalized_row[name] = value
+            normalized_rows.append(normalized_row)
+        super().__init__(key=key, props={"columns": columns, "rows": normalized_rows}, **props)
+        for slot, component in rich_cells:
+            self.child_in(slot, component)

--- a/spaday/tests/test_shell.py
+++ b/spaday/tests/test_shell.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from spaday import apply, diff, element
-from spaday.actions import field, not_
+from spaday.actions import NamedJs, field, not_
 from spaday.components.shell import App, AppShell, Body, Column, Footer, Gutter, Main, Nav, Region, Row, Show, Stack, Table, Tabs, Toolbar
 
 
@@ -194,6 +194,23 @@ def test_table_authors_a_spa_table():
     assert node["tag"] == "spa-table"
     assert node["props"]["columns"] == {"List": [{"Str": "symbol"}, {"Str": "qty"}]}
     assert node["props"]["rows"] == {"List": [{"Map": {"symbol": {"Str": "AAPL"}, "qty": {"Int": 10}}}]}
+
+
+def test_table_projects_component_cells_through_named_slots():
+    button = element("button").text("Inspect").on("click", NamedJs("inspect-order"))
+    table = Table(columns=["symbol", "action"], rows=[{"symbol": "AAPL", "action": button}])
+    node = table.to_node()
+
+    assert node["props"]["rows"]["List"][0]["Map"]["action"] == {"Map": {"__spaday_cell_slot__": {"Str": "cell-0"}}}
+    assert node["slots"]["cell-0"] == [
+        {
+            "tag": "button",
+            "props": {"textContent": {"Str": "Inspect"}},
+            "events": {"click": {"kind": "js", "handler": "inspect-order"}},
+        }
+    ]
+    tree = table.to_json()
+    assert json.loads(apply(tree, diff(tree, tree))) == node
 
 
 def test_table_rows_are_reactive():


### PR DESCRIPTION
Core `Table` cells currently stringify every value, which prevents controls and other rich components from participating in table layouts.

This change lets static row cells contain ordinary spaday `Component` nodes. Python serializes those components as named-slot children, and `<spa-table>` projects them into matching cells. Existing scalar and reactive row values continue to render as text. Because rich cells stay in the normal component tree, bindings and declarative actions work unchanged, including `NamedJs` buttons backed by pre-registered JavaScript handlers.