### PR TITLE
Add keyed table row updates

### DIFF
--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -135,8 +135,13 @@ a seeded [`store=`](serving.md) or a hosted model over [transports](transports.m
 from spaday import field
 from spaday.components.shell import Table
 
-Table(columns=["symbol", "qty", "price"]).compute("rows", field("orders"))
+Table(columns=["id", "symbol", "qty", "price"], row_key="id").compute("rows", field("orders"))
 ```
+
+Set `row_key` to a field whose value is a unique string or number. When reactive `rows` changes, the
+browser reuses and reorders existing rows by that identity, updates changed cells, inserts new rows, and
+removes missing rows. Omit `row_key` to retain full-table rendering. The application still replaces its
+`rows` state normally; no separate imperative table state is required.
 
 `columns` may be plain keys (`["symbol"]` — the label is the key) or `{"key": …, "label": …}` dicts; omit
 it to infer the columns from the first row. Pass `rows=[…]` for a static table. Scalar cells render as

--- a/js/src/ts/shell.ts
+++ b/js/src/ts/shell.ts
@@ -95,8 +95,9 @@ if (typeof customElements !== "undefined") {
 // A lightweight data table (`spa-table`): renders `rows` (a list of objects) under `columns`, both set as
 // JS properties — so a bound / computed `rows` re-renders reactively. Scalar cells are text (built with
 // createElement, never innerHTML); component-valued static cells are ordinary light-DOM children
-// projected into their cell through a named slot. Not a virtual-scroll grid; a themed `<table>` for
-// modest data.
+// projected into their cell through a named slot. `rowKey` opts into keyed row/cell reconciliation;
+// without it, updates retain the original full-render behavior. Not a virtual-scroll grid; a themed
+// `<table>` for modest data.
 const TABLE_CSS = `:host{display:block;overflow:auto}
 table{border-collapse:collapse;width:100%;font-size:.9rem;color:inherit}
 th,td{text-align:left;padding:.4rem .65rem;border-bottom:1px solid ${BORDER};white-space:nowrap}
@@ -114,12 +115,22 @@ function tableCell(td: HTMLTableCellElement, value: unknown): void {
     Object.keys(value).length === 1 &&
     typeof (value as Record<string, unknown>)[CELL_SLOT] === "string"
   ) {
+    const name = String((value as Record<string, unknown>)[CELL_SLOT]);
+    const existing = td.firstElementChild;
+    if (
+      td.childNodes.length === 1 &&
+      existing instanceof HTMLSlotElement &&
+      existing.name === name
+    )
+      return;
     const slot = document.createElement("slot");
-    slot.name = String((value as Record<string, unknown>)[CELL_SLOT]);
-    td.append(slot);
+    slot.name = name;
+    td.replaceChildren(slot);
     return;
   }
-  td.textContent = value == null ? "" : String(value);
+  const text = value == null ? "" : String(value);
+  if (td.childElementCount === 0 && td.textContent === text) return;
+  td.textContent = text;
 }
 
 function tableColumns(
@@ -145,12 +156,59 @@ function tableColumns(
   );
 }
 
+function sameColumns(a: TableCol[], b: TableCol[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every(
+      (column, i) => column.key === b[i].key && column.label === b[i].label,
+    )
+  );
+}
+
+function rowIdentity(row: Record<string, unknown>, rowKey: string): string {
+  const value = row[rowKey];
+  if (typeof value === "string") return `string:${value}`;
+  if (typeof value === "number" && Number.isFinite(value))
+    return `number:${value}`;
+  throw new Error(
+    `spa-table row_key ${JSON.stringify(rowKey)} must exist and contain a string or finite number`,
+  );
+}
+
+function keyedRows(
+  rows: Record<string, unknown>[],
+  rowKey: string,
+): Array<[string, Record<string, unknown>]> {
+  const seen = new Set<string>();
+  return rows.map((row) => {
+    const identity = rowIdentity(row, rowKey);
+    if (seen.has(identity))
+      throw new Error(
+        `spa-table row_key ${JSON.stringify(rowKey)} contains duplicate value ${JSON.stringify(row[rowKey])}`,
+      );
+    seen.add(identity);
+    return [identity, row];
+  });
+}
+
+function updateTableRow(
+  tr: HTMLTableRowElement,
+  row: Record<string, unknown>,
+  cols: TableCol[],
+): void {
+  while (tr.cells.length < cols.length) tr.insertCell();
+  while (tr.cells.length > cols.length) tr.deleteCell(-1);
+  cols.forEach((column, i) => tableCell(tr.cells[i], row[column.key]));
+}
+
 if (typeof customElements !== "undefined" && !customElements.get("spa-table")) {
   customElements.define(
     "spa-table",
     class extends HTMLElement {
       private cols: unknown = null;
       private data: Record<string, unknown>[] = [];
+      private key: string | null = null;
+      private renderedCols: TableCol[] = [];
       private root: ShadowRoot;
       constructor() {
         super();
@@ -158,14 +216,23 @@ if (typeof customElements !== "undefined" && !customElements.get("spa-table")) {
         const style = document.createElement("style");
         style.textContent = TABLE_CSS;
         this.root.append(style);
-        this.render();
+        this.render(true);
       }
       set columns(v: unknown) {
         this.cols = v;
-        this.render();
+        this.render(true);
       }
       get columns(): unknown {
         return this.cols;
+      }
+      set rowKey(v: unknown) {
+        const next = v == null ? null : String(v);
+        if (next === this.key) return;
+        this.key = next;
+        this.render(true);
+      }
+      get rowKey(): unknown {
+        return this.key;
       }
       set rows(v: unknown) {
         this.data = Array.isArray(v) ? (v as Record<string, unknown>[]) : [];
@@ -174,8 +241,35 @@ if (typeof customElements !== "undefined" && !customElements.get("spa-table")) {
       get rows(): unknown {
         return this.data;
       }
-      private render(): void {
+      private reconcileRows(
+        tbody: HTMLTableSectionElement,
+        cols: TableCol[],
+      ): void {
+        const rows = keyedRows(this.data, this.key!); // validates before mutating the DOM
+        const existing = new Map(
+          [...tbody.rows].map((tr) => [tr.dataset.spadayRowKey!, tr]),
+        );
+        for (const [identity, row] of rows) {
+          const tr = existing.get(identity) ?? document.createElement("tr");
+          tr.dataset.spadayRowKey = identity;
+          updateTableRow(tr, row, cols);
+          tbody.append(tr); // inserts a new row or moves an existing row into the requested order
+          existing.delete(identity);
+        }
+        for (const tr of existing.values()) tr.remove();
+      }
+      private render(force = false): void {
         const cols = tableColumns(this.cols, this.data);
+        const old = this.root.querySelector("table");
+        if (
+          old &&
+          this.key !== null &&
+          !force &&
+          sameColumns(cols, this.renderedCols)
+        ) {
+          this.reconcileRows(old.tBodies[0], cols);
+          return;
+        }
         const table = document.createElement("table");
         const hr = table.createTHead().insertRow();
         for (const c of cols) {
@@ -184,13 +278,15 @@ if (typeof customElements !== "undefined" && !customElements.get("spa-table")) {
           hr.append(th);
         }
         const tbody = table.createTBody();
-        for (const row of this.data) {
-          const tr = tbody.insertRow();
-          for (const c of cols) tableCell(tr.insertCell(), row[c.key]);
-        }
-        const old = this.root.querySelector("table");
+        if (this.key !== null) this.reconcileRows(tbody, cols);
+        else
+          for (const row of this.data) {
+            const tr = tbody.insertRow();
+            updateTableRow(tr, row, cols);
+          }
         if (old) old.replaceWith(table);
         else this.root.append(table);
+        this.renderedCols = cols;
       }
     },
   );

--- a/js/tests/shell.spec.js
+++ b/js/tests/shell.spec.js
@@ -111,6 +111,94 @@ test("spa-table renders rows under columns and re-renders when the bound field c
   ]); // reactively re-rendered from the changed field
 });
 
+test("spa-table reconciles keyed row updates, additions, removals, and moves", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({
+      orders: [
+        { id: "a", symbol: "AAPL", qty: 10 },
+        { id: "b", symbol: "MSFT", qty: 5 },
+      ],
+    });
+    const el = mount(
+      document.body,
+      {
+        tag: "spa-table",
+        props: {
+          columns: {
+            List: [{ Str: "id" }, { Str: "symbol" }, { Str: "qty" }],
+          },
+          rowKey: { Str: "id" },
+        },
+        bindings: {
+          rows: { compute: { expr: "field", name: "orders" }, mode: "one-way" },
+        },
+      },
+      store,
+    );
+    const table = el.shadowRoot.querySelector("table");
+    const [a, b] = [...table.tBodies[0].rows];
+    const bSymbolText = b.cells[1].firstChild;
+
+    store.set("orders", [
+      { id: "b", symbol: "MSFT", qty: 7 },
+      { id: "c", symbol: "GOOG", qty: 9 },
+    ]);
+
+    const rows = [...table.tBodies[0].rows];
+    return {
+      tablePreserved: el.shadowRoot.querySelector("table") === table,
+      movedRowPreserved: rows[0] === b,
+      unchangedCellPreserved: rows[0].cells[1].firstChild === bSymbolText,
+      removedRowDetached: !a.isConnected,
+      addedRowIsNew: rows[1] !== a && rows[1] !== b,
+      values: rows.map((row) => [...row.cells].map((cell) => cell.textContent)),
+    };
+  });
+
+  expect(result).toEqual({
+    tablePreserved: true,
+    movedRowPreserved: true,
+    unchangedCellPreserved: true,
+    removedRowDetached: true,
+    addedRowIsNew: true,
+    values: [
+      ["b", "MSFT", "7"],
+      ["c", "GOOG", "9"],
+    ],
+  });
+});
+
+test("spa-table rejects missing and duplicate row keys", async ({ page }) => {
+  const errors = await page.evaluate(() => {
+    const el = window.__spaday.mount(document.body, {
+      tag: "spa-table",
+      props: {
+        columns: { List: [{ Str: "id" }] },
+        rowKey: { Str: "id" },
+        rows: { List: [] },
+      },
+    });
+    const assign = (rows) => {
+      try {
+        el.rows = rows;
+        return null;
+      } catch (error) {
+        return error.message;
+      }
+    };
+    return {
+      missing: assign([{ name: "missing" }]),
+      duplicate: assign([{ id: 1 }, { id: 1 }]),
+    };
+  });
+
+  expect(errors.missing).toContain('row_key "id" must exist');
+  expect(errors.duplicate).toContain('row_key "id" contains duplicate value 1');
+});
+
 test("spa-table projects rich component cells with working actions", async ({
   page,
 }) => {

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -16,6 +16,7 @@ Children nest positionally (a string child is a text node); spacing comes from :
 becomes a left or right gutter by where it sits in a :class:`Body`.
 """
 
+import math
 from enum import Enum
 from typing import Any
 
@@ -264,21 +265,42 @@ class Table(Component):
     """A lightweight data table — a ``spa-table`` that renders ``rows`` (a list of dicts) under
     ``columns``. Both are reactive: bind or compute ``rows`` to a state field and the table re-renders::
 
-        Table(columns=["symbol", "qty", "price"]).compute("rows", field("orders"))
+        Table(columns=["symbol", "qty", "price"], row_key="id").compute("rows", field("orders"))
 
     ``columns`` may be plain keys (``["symbol"]`` — the label is the key) or ``{"key": …, "label": …}``
     dicts; omit it to infer the columns from the first row. Pass ``rows`` for a static table. A static
     cell may be a :class:`Component`; it is rendered as a normal component tree node, including its
-    bindings and events. Other cell values render as text. For virtual scrolling or very large datasets,
-    use a dedicated grid wrapper.
+    bindings and events. Other cell values render as text. Set ``row_key`` to a field containing a unique
+    string or number; reactive row changes then reuse, update, insert, remove, and reorder existing table
+    rows by that identity. For virtual scrolling or very large datasets, use a dedicated grid wrapper.
     """
 
     tag = "spa-table"
 
-    def __init__(self, *, columns: list | None = None, rows: list | None = None, key: str | None = None, **props: Any) -> None:
+    def __init__(
+        self,
+        *,
+        columns: list | None = None,
+        rows: list | None = None,
+        row_key: str | None = None,
+        key: str | None = None,
+        **props: Any,
+    ) -> None:
         normalized_rows = None if rows is None else []
         rich_cells: list[tuple[str, Component]] = []
+        identities: set[tuple[str, str | float]] = set()
         for row in rows or []:
+            if row_key is not None:
+                value = row.get(row_key)
+                if isinstance(value, str):
+                    identity = ("string", value)
+                elif isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value):
+                    identity = ("number", float(value))
+                else:
+                    raise ValueError(f"Table row_key {row_key!r} must exist and contain a string or finite number")
+                if identity in identities:
+                    raise ValueError(f"Table row_key {row_key!r} contains duplicate value {value!r}")
+                identities.add(identity)
             normalized_row = {}
             for name, value in row.items():
                 if isinstance(value, Component):
@@ -288,6 +310,6 @@ class Table(Component):
                 else:
                     normalized_row[name] = value
             normalized_rows.append(normalized_row)
-        super().__init__(key=key, props={"columns": columns, "rows": normalized_rows}, **props)
+        super().__init__(key=key, props={"columns": columns, "rowKey": row_key, "rows": normalized_rows}, **props)
         for slot, component in rich_cells:
             self.child_in(slot, component)

--- a/spaday/tests/test_shell.py
+++ b/spaday/tests/test_shell.py
@@ -214,6 +214,20 @@ def test_table_projects_component_cells_through_named_slots():
 
 
 def test_table_rows_are_reactive():
-    node = Table(columns=["a"]).compute("rows", field("orders")).to_node()
+    node = Table(columns=["id", "a"], row_key="id").compute("rows", field("orders")).to_node()
+    assert node["props"]["rowKey"] == {"Str": "id"}
     assert node["bindings"]["rows"] == {"compute": {"expr": "field", "name": "orders"}, "mode": "one-way"}
     assert "rows" not in node.get("props", {})  # computed, not a static prop
+
+
+@pytest.mark.parametrize(
+    ("rows", "message"),
+    [
+        ([{"name": "missing"}], "must exist"),
+        ([{"id": True}], "string or finite number"),
+        ([{"id": 1}, {"id": 1.0}], "duplicate value"),
+    ],
+)
+def test_table_static_row_keys_must_be_valid_and_unique(rows, message):
+    with pytest.raises(ValueError, match=message):
+        Table(columns=["id"], row_key="id", rows=rows)


### PR DESCRIPTION
`<spa-table>` currently replaces its complete internal `<table>` whenever reactive `rows` changes. Applications can replace their row state, but even a one-row update recreates every row and cell.

This change adds `Table(row_key="id")`. The browser validates that each key is a unique string or finite number, then reconciles `<tr>` elements by that identity. Changed rows update in place, new rows are inserted, missing rows are removed, and reordered rows move without losing DOM identity. Unchanged cells and rich component slots are preserved. Omitting `row_key` keeps existing full-render behavior.

Applications still update their ordinary `rows` state, preserving one state owner and compatibility with local stores and transports. No imperative table-side row store or action-DSL list mutation is introduced.

Python validates keys for static rows. Browser tests cover update, insertion, removal, reordering, row/table identity preservation, unchanged-cell preservation, and invalid keys. Documentation includes the state-driven usage pattern.
