### PR TITLE
Add keyed reactive repeaters

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -12,6 +12,8 @@ The Python surface of spaday. Peer-package component classes are not listed here
    :member-order: bysource
 
 .. autofunction:: spaday.element
+
+.. autoclass:: spaday.components.shell.Each
 ```
 
 ## Action DSL
@@ -39,6 +41,8 @@ Behavior attached to a component with `Component.on`; see [Add behavior and reac
 .. autofunction:: spaday.not_
 .. autofunction:: spaday.prop
 .. autofunction:: spaday.field
+.. autofunction:: spaday.item
+.. autofunction:: spaday.scope
 .. autofunction:: spaday.eq
 .. autofunction:: spaday.all_
 .. autofunction:: spaday.any_

--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -176,10 +176,53 @@ registerHandler("inspect-order", (_event, button) => {
 Rich cells are normal component-tree nodes, so their bindings and declarative actions work unchanged.
 Reactive `rows` remain serializable data; define component cells in static `rows` or update the table's
 component tree. For virtual scrolling or very large datasets, use `RegularTable` from
-`spaday-regular-table`; it only renders the current viewport. Its browser element supports
-`updateRow`, `insertRow`, and `removeRow` without replacing the full dataset, and emits `table-draw`
-after scrolling or redraws so a named JavaScript handler can decorate visible cells with buttons or
-other rich DOM.
+`spaday-regular-table`; it only renders the current viewport. Column `cell` descriptors create buttons,
+badges, formatted values, or custom elements from serializable Python data. Bind its `rowPatch` prop or
+set `stream_url` for revisioned update, insert, and remove batches without replacing the full dataset.
+Rich-cell events accept normal spaday actions, so these workflows need no companion JavaScript.
+
+## Render an action for every live record
+
+Use `Each` when every record needs a component subtree rather than table cells. Bind the outer
+collection with `field=`, identify items with `key=`, and read the current record with `item()`:
+
+```python
+from spaday import CallEndpoint, Strong, concat, element, item, obj, scope
+from spaday.components.shell import Column, Each, Row, Show
+
+records = Each(
+    Row(
+        Strong().compute("textContent", item("name")),
+        Show(element("span").text("Ready"), when=item("ready")),
+        element("button").text("X").on(
+            "click",
+            CallEndpoint(
+                "DELETE",
+                concat("/stage/", scope("staging.channel")),
+                obj({"id": item("id")}),
+            ),
+        ),
+    ),
+    items=item("records"),
+    key="id",
+    scope="record",
+)
+
+staging_panel = Each(
+    Column(records),
+    field="stagings",
+    key="id",
+    scope="staging",
+)
+```
+
+`item("path")` reads the innermost item. `scope("name.path")` reads the nearest current or ancestor
+scope with that name. `field("name")` always reads global store state.
+
+Keys must be unique strings or finite numbers. Replacing, inserting, removing, or reordering the bound
+collection updates at most once per animation frame. Existing keys retain their live root element,
+focus, cursor position, local properties, bindings, and action scope. Item scopes are read-only; use an
+action to update global state, send a model patch, or call an endpoint.
 
 ## Reach for a raw element
 

--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -188,11 +188,11 @@ collection with `field=`, identify items with `key=`, and read the current recor
 
 ```python
 from spaday import CallEndpoint, Strong, concat, element, item, obj, scope
-from spaday.components.shell import Column, Each, Row, Show
+from spaday.components import Column, Each, Row, Show
 
 records = Each(
     Row(
-        Strong().compute("textContent", item("name")),
+        Strong(item("name")),
         Show(element("span").text("Ready"), when=item("ready")),
         element("button").text("X").on(
             "click",
@@ -223,6 +223,10 @@ Keys must be unique strings or finite numbers. Replacing, inserting, removing, o
 collection updates at most once per animation frame. Existing keys retain their live root element,
 focus, cursor position, local properties, bindings, and action scope. Item scopes are read-only; use an
 action to update global state, send a model patch, or call an endpoint.
+
+Run the complete [keyed records example](../../spaday/examples/keyed_records.py) to try nested channels,
+server-driven add/update/remove/reorder operations, per-record endpoint payloads, and preserved local
+input state without page-specific JavaScript.
 
 ## Reach for a raw element
 

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -18,6 +18,10 @@ extern "C" {
     fn event_value(this: &Host) -> JsValue;
     #[wasm_bindgen(method, js_name = getField)]
     fn get_field(this: &Host, name: &str) -> JsValue;
+    #[wasm_bindgen(method, js_name = getItem)]
+    fn get_item(this: &Host, path: &str) -> JsValue;
+    #[wasm_bindgen(method, js_name = getScope)]
+    fn get_scope(this: &Host, name: &str, path: &str) -> JsValue;
     #[wasm_bindgen(method, js_name = setField)]
     fn set_field(this: &Host, name: &str, value: JsValue);
     #[wasm_bindgen(method)]
@@ -112,7 +116,9 @@ fn run(action: &spaday::Action, host: &Host) {
 }
 
 fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
-    use spaday::Expr::{Concat, Event, Field, Lit, Not, Obj, Prop};
+    use spaday::Expr::{
+        All, Any, Concat, Cond, Eq, Event, Field, Item, Lit, Not, Obj, Prop, Scope,
+    };
     match expr {
         // json_compatible: JSON objects become plain JS objects (not Maps), so they round-trip through
         // `JSON.stringify` (e.g. a CallEndpoint body) and set cleanly as props.
@@ -121,7 +127,23 @@ fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
             .unwrap_or(JsValue::UNDEFINED),
         Event => host.event_value(),
         Field { name } => host.get_field(name),
+        Item { path } => host.get_item(path),
+        Scope { name, path } => host.get_scope(name, path),
         Not { of } => JsValue::from_bool(!truthy(&eval(of, host))),
+        Eq { a, b } => JsValue::from_bool(js_sys::Object::is(&eval(a, host), &eval(b, host))),
+        All { of } => JsValue::from_bool(of.iter().all(|value| truthy(&eval(value, host)))),
+        Any { of } => JsValue::from_bool(of.iter().any(|value| truthy(&eval(value, host)))),
+        Cond {
+            test,
+            then,
+            otherwise,
+        } => {
+            if truthy(&eval(test, host)) {
+                eval(then, host)
+            } else {
+                eval(otherwise, host)
+            }
+        }
         Prop { target, name } => {
             resolve(target, host).map_or(JsValue::NULL, |el| host.get_prop(&el, name))
         }

--- a/js/src/ts/actions.ts
+++ b/js/src/ts/actions.ts
@@ -8,7 +8,7 @@
 import { interpret as wasmInterpret } from "../../dist/pkg/spaday";
 import { getHandler } from "./handlers";
 import { setProp } from "./runtime";
-import type { Store } from "./signals";
+import type { Scope, Store } from "./signals";
 import { assertReady } from "./wasm-ready";
 
 /** The context an action runs in: the DOM event, the listener's element, and the mounted signal store
@@ -17,6 +17,7 @@ export interface ActionContext {
   event: Event;
   currentTarget: Element;
   store?: Store;
+  scope?: Scope;
 }
 
 /** Run one action (the core's plain DSL wire form) against the DOM in the given event context. */
@@ -49,6 +50,9 @@ function host(ctx: ActionContext) {
     },
     // a reactive state field from the mounted signal store (undefined if the tree has no store)
     getField: (name: string) => ctx.store?.get(name),
+    getItem: (path: string) => ctx.scope?.get(path),
+    getScope: (name: string, path: string) =>
+      ctx.scope?.resolve(name)?.get(path),
     // write a reactive state field (SetField/ToggleField) — a no-op if the tree has no store
     setField: (name: string, value: unknown) => ctx.store?.set(name, value),
     emit: (event: string, detail: unknown) =>

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -51,7 +51,7 @@ export { mount, applyPatch, hydrate } from "./runtime";
 export type { Binding, Node } from "./runtime";
 
 // Reactive engine: a signal store whose fields back the tree's reactive `bindings` (prop ↔ field).
-export { Store } from "./signals";
+export { Scope, Store } from "./signals";
 export type { Field } from "./signals";
 
 // The transports seam: bidirectionally sync a Store with a transports-mirrored model. Imports nothing

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -7,7 +7,7 @@
 // handlers, rebinding/detaching them as incremental `SetEvent`/`RemoveEvent` patches arrive.
 
 import { interpret } from "./actions";
-import { evalExpr, exprFields, Store } from "./signals";
+import { evalExpr, exprFields, exprScopes, Scope, Store } from "./signals";
 import { untag, Value } from "./value";
 
 export interface Binding {
@@ -37,8 +37,13 @@ const DEFAULT_SLOT = "default";
  * Build the DOM for a tree and append it to `container`; returns the root element. Pass a `store` to
  * activate the tree's reactive `bindings` (prop ↔ state field); without one, bindings are inert.
  */
-export function mount(container: Element, tree: Node, store?: Store): Element {
-  const el = build(tree, store);
+export function mount(
+  container: Element,
+  tree: Node,
+  store?: Store,
+  scope?: Scope,
+): Element {
+  const el = build(tree, store, scope);
   container.appendChild(el);
   return el;
 }
@@ -52,9 +57,10 @@ export function applyPatch(
   root: Element,
   patch: { ops: Op[] },
   store?: Store,
+  scope?: Scope,
 ): Element {
   let current = root;
-  for (const op of patch.ops) current = applyOp(current, op, store);
+  for (const op of patch.ops) current = applyOp(current, op, store, scope);
   return current;
 }
 
@@ -68,35 +74,43 @@ export function hydrate(
   container: Element,
   tree: Node,
   store?: Store,
+  scope?: Scope,
 ): Element {
   const el = container.firstElementChild;
-  if (!el) return mount(container, tree, store);
-  hydrateNode(el, tree, store);
+  if (!el) return mount(container, tree, store, scope);
+  hydrateNode(el, tree, store, scope);
   return el;
 }
 
-function hydrateNode(el: Element, node: Node, store?: Store): void {
+function hydrateNode(
+  el: Element,
+  node: Node,
+  store?: Store,
+  scope?: Scope,
+): void {
   for (const [name, value] of Object.entries(node.props ?? {})) {
     setProp(el, name, untag(value)); // re-affirm props; sets complex/property-only ones the HTML omitted
   }
   if (node.tag === "spa-show") {
-    wireShow(el, node, store); // structural children are client-mounted (the HTML rendered none)
+    wireShow(el, node, store, scope); // structural children are client-mounted (the HTML rendered none)
+  } else if (node.tag === "spa-each") {
+    wireEach(el, node, store, scope);
   } else {
     for (const [slot, children] of Object.entries(node.slots ?? {})) {
       const existing = childrenInSlot(el, slot);
       children.forEach((child, i) => {
-        if (existing[i]) hydrateNode(existing[i], child, store);
-        else appendInSlot(el, slot, build(child, store)); // HTML missing this child → build it
+        if (existing[i]) hydrateNode(existing[i], child, store, scope);
+        else appendInSlot(el, slot, build(child, store, scope)); // HTML missing this child → build it
       });
     }
   }
   for (const [name, action] of Object.entries(node.events ?? {})) {
-    bindEvent(el, name, action, store); // actions ride the wire as the core's DSL form (plain JSON)
+    bindEvent(el, name, action, store, scope); // actions ride the wire as the core's DSL form (plain JSON)
   }
-  if (store) {
+  if (store || scope) {
     for (const [prop, spec] of Object.entries(node.bindings ?? {})) {
-      if (node.tag === "spa-show" && prop === "when") continue; // structural — handled by wireShow
-      wireBinding(el, prop, spec, store);
+      if (isStructuralBinding(node, prop)) continue;
+      wireBinding(el, prop, spec, store, scope);
     }
   }
 }
@@ -110,13 +124,14 @@ function bindEvent(
   name: string,
   action: unknown,
   store?: Store,
+  scope?: Scope,
 ): void {
   let map = listeners.get(el);
   if (!map) listeners.set(el, (map = new Map()));
   const existing = map.get(name);
   if (existing) el.removeEventListener(name, existing); // replace, don't stack
   const handler: EventListener = (event) =>
-    interpret(action, { event, currentTarget: el, store }); // store lets an action's `field` expr read state
+    interpret(action, { event, currentTarget: el, store, scope });
   el.addEventListener(name, handler);
   map.set(name, handler);
 }
@@ -133,6 +148,7 @@ function unbindEvent(el: Element, name: string): void {
 // Live binding teardowns per element/prop, so an incremental patch can rewire or detach them. A binding
 // subscribes the prop to its state field; a two-way binding also writes the field when the control changes.
 const bindings = new WeakMap<Element, Map<string, () => void>>();
+const structuralNodes = new WeakMap<Element, Node>();
 const VALUE_EVENTS = ["change", "input", "wa-tab-show"]; // a control writes its bound field on these (wa-tab-show: a wa-tab-group's active tab changed)
 
 function readProp(el: Element, name: string): unknown {
@@ -156,7 +172,8 @@ function wireBinding(
   el: Element,
   prop: string,
   spec: Binding,
-  store: Store,
+  store?: Store,
+  scope?: Scope,
 ): void {
   unwireBinding(el, prop); // replace any prior wiring for this prop
   const teardowns: Array<() => void> = [];
@@ -164,12 +181,15 @@ function wireBinding(
   if (spec.compute !== undefined) {
     // computed (derived) binding: recompute the prop from the expression whenever any field it reads
     // changes. One-way by nature — there is nothing to write back.
-    const recompute = () => apply(evalExpr(spec.compute, store));
+    const recompute = () => apply(evalExpr(spec.compute, store, scope));
     recompute(); // initial value
-    for (const field of exprFields(spec.compute)) {
-      teardowns.push(store.subscribe(field, recompute));
-    }
-  } else if (spec.field !== undefined) {
+    if (store)
+      for (const field of exprFields(spec.compute)) {
+        teardowns.push(store.subscribe(field, recompute));
+      }
+    for (const dependency of exprScopes(spec.compute, scope))
+      teardowns.push(dependency.subscribe(recompute));
+  } else if (spec.field !== undefined && store) {
     if (store.has(spec.field)) apply(store.get(spec.field)); // initial field → prop
     teardowns.push(store.subscribe(spec.field, (v) => apply(v)));
     if (spec.mode === "two-way") {
@@ -206,42 +226,234 @@ function unwireBinding(el: Element, prop: string): void {
 // truthy and TORN DOWN + removed (not merely hidden) when it is falsy — reactive creation/removal of real
 // elements. The wrapper itself stays put (authored `display:contents`), so sibling paths don't shift as
 // children come and go.
-function wireShow(el: Element, node: Node, store?: Store): void {
+function wireShow(el: Element, node: Node, store?: Store, scope?: Scope): void {
+  structuralNodes.set(el, node);
   const cond = node.bindings?.when;
   const childDefs = node.slots?.[DEFAULT_SLOT] ?? [];
-  if (!store || !cond) {
-    for (const c of childDefs) appendInSlot(el, DEFAULT_SLOT, build(c, store)); // inert: render always
+  let mounted: Element[] = [];
+  const clear = (): void => {
+    for (const child of mounted) {
+      teardownTree(child);
+      child.remove();
+    }
+    mounted = [];
+  };
+  const inert =
+    !cond || (cond.compute === undefined ? !store : !store && !scope);
+  if (inert) {
+    for (const child of childDefs) {
+      const built = build(child, store, scope);
+      appendInSlot(el, DEFAULT_SLOT, built);
+      mounted.push(built);
+    }
+    let map = bindings.get(el);
+    if (!map) bindings.set(el, (map = new Map()));
+    map.set("when", clear);
     return;
   }
   const evaluate = (): boolean =>
     cond.compute !== undefined
-      ? !!evalExpr(cond.compute, store)
-      : !!store.get(cond.field!);
-  let mounted: Element[] = [];
+      ? !!evalExpr(cond.compute, store, scope)
+      : !!store!.get(cond.field!);
   const render = (): void => {
     if (evaluate()) {
       if (mounted.length === 0) {
         for (const c of childDefs) {
-          const ce = build(c, store);
+          const ce = build(c, store, scope);
           appendInSlot(el, DEFAULT_SLOT, ce);
           mounted.push(ce);
         }
       }
-    } else if (mounted.length) {
-      for (const ce of mounted) {
-        teardownTree(ce);
-        ce.remove();
-      }
-      mounted = [];
-    }
+    } else if (mounted.length) clear();
   };
   render(); // initial state
   const deps =
     cond.compute !== undefined ? [...exprFields(cond.compute)] : [cond.field!];
-  const subs = deps.map((f) => store.subscribe(f, render));
+  const subs = store ? deps.map((f) => store.subscribe(f, render)) : [];
+  if (cond.compute !== undefined)
+    for (const dependency of exprScopes(cond.compute, scope))
+      subs.push(dependency.subscribe(render));
   let map = bindings.get(el); // record teardown so removing the spa-show unsubscribes (via teardownTree)
   if (!map) bindings.set(el, (map = new Map()));
-  map.set("when", () => subs.forEach((u) => u()));
+  map.set("when", () => {
+    for (const unsubscribe of subs) unsubscribe();
+    clear();
+  });
+}
+
+interface EachInstance {
+  element: Element;
+  scope: Scope;
+}
+
+function eachIdentity(item: unknown, key: string): string {
+  const value = new Scope(item).get(key);
+  if (typeof value === "string") return `string:${value}`;
+  if (typeof value === "number" && Number.isFinite(value))
+    return `number:${value}`;
+  throw new Error(
+    `spa-each key ${JSON.stringify(key)} must exist and contain a string or finite number`,
+  );
+}
+
+function keyedItems(items: unknown[], key: string): Array<[string, unknown]> {
+  const seen = new Set<string>();
+  return items.map((item) => {
+    const identity = eachIdentity(item, key);
+    if (seen.has(identity))
+      throw new Error(
+        `spa-each key ${JSON.stringify(key)} contains duplicate value ${JSON.stringify(new Scope(item).get(key))}`,
+      );
+    seen.add(identity);
+    return [identity, item];
+  });
+}
+
+// `spa-each`: a client-owned keyed reconciler. The serialized default child is a template definition,
+// not live DOM. Item replacements update a reactive Scope; moves retain the existing root element.
+function wireEach(
+  el: Element,
+  node: Node,
+  store?: Store,
+  parentScope?: Scope,
+): void {
+  structuralNodes.set(el, node);
+  const source = node.bindings?.items;
+  const template = node.slots?.[DEFAULT_SLOT] ?? [];
+  const itemKey = String(untag(node.props?.itemKey!));
+  const scopeValue = node.props?.scopeName
+    ? untag(node.props.scopeName)
+    : undefined;
+  const scopeName = scopeValue == null ? undefined : String(scopeValue);
+  if (template.length !== 1)
+    throw new Error("spa-each requires exactly one component template");
+
+  let instances = new Map<string, EachInstance>();
+  let frame: number | undefined;
+  const evaluate = (): unknown[] => {
+    const value = source?.compute
+      ? evalExpr(source.compute, store, parentScope)
+      : source?.field && store
+        ? store.get(source.field)
+        : [];
+    return Array.isArray(value) ? value : [];
+  };
+  const reconcile = (): void => {
+    frame = undefined;
+    const items = keyedItems(evaluate(), itemKey); // validate the full key set before any mutation
+    const focused =
+      document.activeElement instanceof HTMLElement &&
+      el.contains(document.activeElement)
+        ? document.activeElement
+        : undefined;
+    const selection =
+      focused instanceof HTMLInputElement ||
+      focused instanceof HTMLTextAreaElement
+        ? ([
+            focused.selectionStart,
+            focused.selectionEnd,
+            focused.selectionDirection,
+          ] as const)
+        : undefined;
+    const stale = new Map(instances);
+    const next = new Map<string, EachInstance>();
+    for (const [index, [identity, item]] of items.entries()) {
+      let instance = instances.get(identity);
+      if (instance) {
+        instance.scope.set(item);
+      } else {
+        const itemScope = new Scope(item, scopeName, parentScope);
+        instance = {
+          element: build(template[0], store, itemScope),
+          scope: itemScope,
+        };
+      }
+      const current = el.children[index];
+      if (current !== instance.element) {
+        const movable = el as Element & {
+          moveBefore?: (node: Element, child: Element | null) => void;
+        };
+        if (
+          instance.element.parentElement === el &&
+          typeof movable.moveBefore === "function"
+        )
+          movable.moveBefore(instance.element, current ?? null);
+        else el.insertBefore(instance.element, current ?? null);
+      }
+      stale.delete(identity);
+      next.set(identity, instance);
+    }
+    for (const instance of stale.values()) {
+      teardownTree(instance.element);
+      instance.element.remove();
+    }
+    if (focused) {
+      focused.focus({ preventScroll: true });
+      if (
+        selection &&
+        (focused instanceof HTMLInputElement ||
+          focused instanceof HTMLTextAreaElement)
+      )
+        focused.setSelectionRange(
+          selection[0],
+          selection[1],
+          selection[2] ?? undefined,
+        );
+    }
+    instances = next;
+  };
+  const schedule = (): void => {
+    if (frame === undefined) frame = requestAnimationFrame(reconcile);
+  };
+
+  reconcile();
+  const subs: Array<() => void> = [];
+  if (source?.compute !== undefined) {
+    if (store)
+      for (const field of exprFields(source.compute))
+        subs.push(store.subscribe(field, schedule));
+    for (const dependency of exprScopes(source.compute, parentScope))
+      subs.push(dependency.subscribe(schedule));
+  } else if (source?.field && store) {
+    subs.push(store.subscribe(source.field, schedule));
+  }
+  let map = bindings.get(el);
+  if (!map) bindings.set(el, (map = new Map()));
+  map.set("items", () => {
+    if (frame !== undefined) cancelAnimationFrame(frame);
+    for (const unsubscribe of subs) unsubscribe();
+    for (const instance of instances.values()) {
+      teardownTree(instance.element);
+      instance.element.remove();
+    }
+    instances.clear();
+  });
+}
+
+function isStructuralBinding(node: Node, prop: string): boolean {
+  return (
+    (node.tag === "spa-show" && prop === "when") ||
+    (node.tag === "spa-each" && prop === "items")
+  );
+}
+
+function rewireStructuralBinding(
+  el: Element,
+  name: string,
+  binding: Binding | undefined,
+  store?: Store,
+  scope?: Scope,
+): boolean {
+  const node = structuralNodes.get(el);
+  if (!node || !isStructuralBinding(node, name)) return false;
+  const nextBindings = { ...node.bindings };
+  if (binding) nextBindings[name] = binding;
+  else delete nextBindings[name];
+  const next = { ...node, bindings: nextBindings };
+  unwireBinding(el, name);
+  if (next.tag === "spa-show") wireShow(el, next, store, scope);
+  else wireEach(el, next, store, scope);
+  return true;
 }
 
 // Tear down the reactive bindings (store subscriptions) registered across an element subtree, so removing
@@ -254,28 +466,32 @@ function teardownTree(el: Element): void {
       for (const teardown of map.values()) teardown();
       bindings.delete(e);
     }
+    structuralNodes.delete(e);
   }
 }
 
-function build(node: Node, store?: Store): Element {
+function build(node: Node, store?: Store, scope?: Scope): Element {
   const el = document.createElement(node.tag);
   for (const [name, value] of Object.entries(node.props ?? {})) {
     setProp(el, name, untag(value));
   }
   if (node.tag === "spa-show") {
-    wireShow(el, node, store); // conditionally mounts the node's default-slot children
+    wireShow(el, node, store, scope); // conditionally mounts the node's default-slot children
+  } else if (node.tag === "spa-each") {
+    wireEach(el, node, store, scope);
   } else {
     for (const [slot, children] of Object.entries(node.slots ?? {})) {
-      for (const child of children) appendInSlot(el, slot, build(child, store));
+      for (const child of children)
+        appendInSlot(el, slot, build(child, store, scope));
     }
   }
   for (const [name, action] of Object.entries(node.events ?? {})) {
-    bindEvent(el, name, action, store); // actions ride the wire as the core's DSL form (plain JSON)
+    bindEvent(el, name, action, store, scope); // actions ride the wire as the core's DSL form (plain JSON)
   }
-  if (store) {
+  if (store || scope) {
     for (const [prop, spec] of Object.entries(node.bindings ?? {})) {
-      if (node.tag === "spa-show" && prop === "when") continue; // structural — handled by wireShow
-      wireBinding(el, prop, spec, store);
+      if (isStructuralBinding(node, prop)) continue;
+      wireBinding(el, prop, spec, store, scope);
     }
   }
   return el;
@@ -351,7 +567,7 @@ function resolve(root: Element, path: Path): Element {
   return el;
 }
 
-function applyOp(root: Element, op: Op, store?: Store): Element {
+function applyOp(root: Element, op: Op, store?: Store, scope?: Scope): Element {
   if ("SetProp" in op) {
     setProp(
       resolve(root, op.SetProp.path),
@@ -362,19 +578,23 @@ function applyOp(root: Element, op: Op, store?: Store): Element {
     removeProp(resolve(root, op.RemoveProp.path), op.RemoveProp.name);
   } else if ("SetEvent" in op) {
     const { path, name, action } = op.SetEvent;
-    bindEvent(resolve(root, path), name, action, store);
+    bindEvent(resolve(root, path), name, action, store, scope);
   } else if ("RemoveEvent" in op) {
     const { path, name } = op.RemoveEvent;
     unbindEvent(resolve(root, path), name);
   } else if ("SetBinding" in op) {
     const { path, name, binding } = op.SetBinding;
-    if (store) wireBinding(resolve(root, path), name, binding, store);
+    const el = resolve(root, path);
+    if (!rewireStructuralBinding(el, name, binding, store, scope))
+      if (store || scope) wireBinding(el, name, binding, store, scope);
   } else if ("RemoveBinding" in op) {
     const { path, name } = op.RemoveBinding;
-    unwireBinding(resolve(root, path), name);
+    const el = resolve(root, path);
+    if (!rewireStructuralBinding(el, name, undefined, store, scope))
+      unwireBinding(el, name);
   } else if ("InsertChild" in op) {
     const { path, slot, index, node } = op.InsertChild;
-    insertInSlot(resolve(root, path), slot, index, build(node, store));
+    insertInSlot(resolve(root, path), slot, index, build(node, store, scope));
   } else if ("RemoveChild" in op) {
     const { path, slot, index } = op.RemoveChild;
     const child = childrenInSlot(resolve(root, path), slot)[index];
@@ -389,7 +609,7 @@ function applyOp(root: Element, op: Op, store?: Store): Element {
   } else if ("Replace" in op) {
     const target = resolve(root, op.Replace.path);
     teardownTree(target); // release the replaced subtree's store subscriptions
-    const replacement = build(op.Replace.node, store);
+    const replacement = build(op.Replace.node, store, scope);
     target.replaceWith(replacement);
     if (op.Replace.path.length === 0) return replacement; // the root element itself was swapped
   }

--- a/js/src/ts/signals.ts
+++ b/js/src/ts/signals.ts
@@ -6,12 +6,64 @@
 
 export type Field = string; // a field name, or a dotted path into nested state (e.g. "address.street")
 type Subscriber = (value: unknown) => void;
+type SubscriberIndex = {
+  field?: Field;
+  children: Map<string, SubscriberIndex>;
+};
 
 const isObj = (v: unknown): v is Record<string, unknown> =>
   v != null && typeof v === "object" && !Array.isArray(v);
 
-/** Is `a` a strict ancestor path of `b`? e.g. "address" of "address.street". */
-const isAncestor = (a: Field, b: Field): boolean => b.startsWith(a + ".");
+function readPath(value: unknown, path: string): unknown {
+  if (!path) return value;
+  let current = value;
+  for (const part of path.split(".")) {
+    if (Array.isArray(current)) {
+      const index = Number(part);
+      if (!Number.isSafeInteger(index) || index < 0 || index >= current.length)
+        return undefined;
+      current = current[index];
+    } else if (isObj(current) && part in current) {
+      current = current[part];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+/** A reactive lexical item scope. Named lookup chooses the nearest matching current/ancestor scope. */
+export class Scope {
+  private subscribers = new Set<() => void>();
+
+  constructor(
+    private value: unknown,
+    readonly name?: string,
+    readonly parent?: Scope,
+  ) {}
+
+  get(path = ""): unknown {
+    return readPath(this.value, path);
+  }
+
+  resolve(name: string): Scope | undefined {
+    for (let scope: Scope | undefined = this; scope; scope = scope.parent) {
+      if (scope.name === name) return scope;
+    }
+    return undefined;
+  }
+
+  set(value: unknown): void {
+    if (Object.is(this.value, value)) return;
+    this.value = value;
+    for (const subscriber of [...this.subscribers]) subscriber();
+  }
+
+  subscribe(subscriber: () => void): () => void {
+    this.subscribers.add(subscriber);
+    return () => this.subscribers.delete(subscriber);
+  }
+}
 
 /** Immutably set a path within `obj`, cloning each level so every parent gets a fresh identity. */
 function setPath(
@@ -30,6 +82,7 @@ function setPath(
 export class Store {
   private values: Map<Field, unknown>;
   private subscribers: Map<Field, Set<Subscriber>> = new Map();
+  private subscriberIndex: SubscriberIndex = { children: new Map() };
 
   constructor(initial: Record<Field, unknown> = {}) {
     this.values = new Map(Object.entries(initial));
@@ -57,6 +110,54 @@ export class Store {
     return true;
   }
 
+  private index(field: Field): void {
+    let node = this.subscriberIndex;
+    for (const part of field.split(".")) {
+      let child = node.children.get(part);
+      if (!child) {
+        child = { children: new Map() };
+        node.children.set(part, child);
+      }
+      node = child;
+    }
+    node.field = field;
+  }
+
+  private unindex(field: Field): void {
+    const chain: Array<[SubscriberIndex, string, SubscriberIndex]> = [];
+    let node = this.subscriberIndex;
+    for (const part of field.split(".")) {
+      const child = node.children.get(part);
+      if (!child) return;
+      chain.push([node, part, child]);
+      node = child;
+    }
+    delete node.field;
+    for (let i = chain.length - 1; i >= 0; i -= 1) {
+      const [parent, part, child] = chain[i];
+      if (child.field || child.children.size) break;
+      parent.children.delete(part);
+    }
+  }
+
+  private related(field: Field): Field[] {
+    const related: Field[] = [];
+    let node = this.subscriberIndex;
+    for (const part of field.split(".")) {
+      const child = node.children.get(part);
+      if (!child) return related;
+      node = child;
+      if (node.field) related.push(node.field);
+    }
+    const descendants = [...node.children.values()];
+    while (descendants.length) {
+      const child = descendants.pop()!;
+      if (child.field) related.push(child.field);
+      descendants.push(...child.children.values());
+    }
+    return related;
+  }
+
   /**
    * Set a field and notify subscribers; a no-op if unchanged. A dotted `field` sets a nested leaf,
    * rebuilding its parents immutably, and notifies the leaf plus its ancestors (whose identity changed)
@@ -64,9 +165,7 @@ export class Store {
    */
   set(field: Field, value: unknown): void {
     if (Object.is(this.get(field), value)) return;
-    const related = [...this.subscribers.keys()].filter(
-      (k) => k === field || isAncestor(k, field) || isAncestor(field, k),
-    );
+    const related = this.related(field);
     const before = new Map(related.map((k) => [k, this.get(k)]));
     const parts = field.split(".");
     if (parts.length === 1) {
@@ -81,18 +180,26 @@ export class Store {
     }
     for (const k of related) {
       const now = this.get(k);
-      if (!Object.is(before.get(k), now))
-        for (const cb of [...this.subscribers.get(k)!]) cb(now);
+      const subscribers = this.subscribers.get(k);
+      if (!Object.is(before.get(k), now) && subscribers)
+        for (const cb of [...subscribers]) cb(now);
     }
   }
 
   /** Subscribe to a field; returns an unsubscribe function. */
   subscribe(field: Field, cb: Subscriber): () => void {
     let subs = this.subscribers.get(field);
-    if (!subs) this.subscribers.set(field, (subs = new Set()));
+    if (!subs) {
+      this.subscribers.set(field, (subs = new Set()));
+      this.index(field);
+    }
     subs.add(cb);
     return () => {
       subs!.delete(cb);
+      if (!subs!.size && this.subscribers.get(field) === subs) {
+        this.subscribers.delete(field);
+        this.unindex(field);
+      }
     };
   }
 }
@@ -100,35 +207,42 @@ export class Store {
 // A field-expression: serializable data the runtime evaluates against the store to drive a *computed*
 // binding (a prop derived from state fields). It shares the action DSL's `{expr: kind, ...}` shape plus
 // a `field` reference; only the store-relevant forms are evaluated here.
-export function evalExpr(expr: unknown, store: Store): unknown {
+export function evalExpr(expr: unknown, store?: Store, scope?: Scope): unknown {
   if (!expr || typeof expr !== "object") return expr;
   const e = expr as Record<string, unknown>;
   switch (e.expr) {
     case "lit":
       return e.value;
     case "field":
-      return store.get(e.name as string);
+      return store?.get(e.name as string);
+    case "item":
+      return scope?.get(e.path as string);
+    case "scope":
+      return scope?.resolve(e.name as string)?.get(e.path as string);
     case "not":
-      return !evalExpr(e.of, store);
+      return !evalExpr(e.of, store, scope);
     case "eq":
-      return evalExpr(e.a, store) === evalExpr(e.b, store);
+      return Object.is(
+        evalExpr(e.a, store, scope),
+        evalExpr(e.b, store, scope),
+      );
     case "all":
-      return (e.of as unknown[]).every((x) => !!evalExpr(x, store));
+      return (e.of as unknown[]).every((x) => !!evalExpr(x, store, scope));
     case "any":
-      return (e.of as unknown[]).some((x) => !!evalExpr(x, store));
+      return (e.of as unknown[]).some((x) => !!evalExpr(x, store, scope));
     case "cond":
-      return evalExpr(e.test, store)
-        ? evalExpr(e.then, store)
-        : evalExpr(e["else"], store);
+      return evalExpr(e.test, store, scope)
+        ? evalExpr(e.then, store, scope)
+        : evalExpr(e["else"], store, scope);
     case "obj": {
       const out: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(e.fields as Record<string, unknown>))
-        out[k] = evalExpr(v, store);
+        out[k] = evalExpr(v, store, scope);
       return out;
     }
     case "concat":
       return (e.parts as unknown[])
-        .map((part) => String(evalExpr(part, store)))
+        .map((part) => String(evalExpr(part, store, scope)))
         .join("");
     default:
       return undefined;
@@ -147,6 +261,28 @@ export function exprFields(
     if (key === "value") continue; // a `lit` payload is data, not a sub-expression
     if (Array.isArray(value)) value.forEach((v) => exprFields(v, out));
     else if (value && typeof value === "object") exprFields(value, out);
+  }
+  return out;
+}
+
+/** The reactive item scopes an expression reads. Missing named scopes have no dependency. */
+export function exprScopes(
+  expr: unknown,
+  scope?: Scope,
+  out: Set<Scope> = new Set(),
+): Set<Scope> {
+  if (!expr || typeof expr !== "object") return out;
+  const e = expr as Record<string, unknown>;
+  if (e.expr === "item" && scope) out.add(scope);
+  if (e.expr === "scope" && scope && typeof e.name === "string") {
+    const named = scope.resolve(e.name);
+    if (named) out.add(named);
+  }
+  for (const [key, value] of Object.entries(e)) {
+    if (key === "value") continue;
+    if (Array.isArray(value))
+      value.forEach((nested) => exprScopes(nested, scope, out));
+    else if (value && typeof value === "object") exprScopes(value, scope, out);
   }
   return out;
 }

--- a/js/src/ts/store-sync.ts
+++ b/js/src/ts/store-sync.ts
@@ -14,8 +14,18 @@
 import { Store } from "./signals";
 
 /** Spaday's whole view of a transports `Client`: receive a frame, find the model, read it, edit it. */
+type PathSeg = { Key: string } | { Index: number };
+type PatchOp =
+  | { Set: { path: PathSeg[]; value: unknown } }
+  | { Remove: { path: PathSeg[] } }
+  | { Insert: { path: PathSeg[]; index: number; value: unknown } }
+  | { RemoveAt: { path: PathSeg[]; index: number } };
+type ReceiveChange =
+  | { t: "snapshot"; id: number }
+  | { t: "patch"; id: number; patch: { rev: number; ops: PatchOp[] } };
+
 export interface ModelClient {
-  recv(data: string | Uint8Array): void;
+  recv(data: string | Uint8Array): ReceiveChange | undefined | void;
   ids(): number[];
   value(id: number): unknown; // the model as a tagged core Value
   edit(id: number, value: unknown): string; // an encoded edit frame to send back
@@ -23,7 +33,7 @@ export interface ModelClient {
 
 /** Convert between tagged core Values and plain JS fields (transports' `fromValue` / `toValue`). */
 export interface ValueCodec {
-  fromValue(value: unknown): Record<string, unknown> | null;
+  fromValue(value: unknown): unknown;
   toValue(plain: unknown): unknown;
 }
 
@@ -63,6 +73,80 @@ function setPath(
   return clone;
 }
 
+function updatePath(
+  value: unknown,
+  path: PathSeg[],
+  update: (current: unknown) => unknown,
+): unknown {
+  if (!path.length) return update(value);
+  const [segment, ...rest] = path;
+  if ("Key" in segment) {
+    if (!isObj(value)) throw new Error("patch path expected an object");
+    if (rest.length && !(segment.Key in value))
+      throw new Error(
+        `patch path key ${JSON.stringify(segment.Key)} not found`,
+      );
+    return {
+      ...value,
+      [segment.Key]: updatePath(value[segment.Key], rest, update),
+    };
+  }
+  if (!Array.isArray(value)) throw new Error("patch path expected an array");
+  if (segment.Index < 0 || segment.Index >= value.length)
+    throw new Error(
+      `patch path index ${segment.Index} out of bounds (len ${value.length})`,
+    );
+  const next = [...value];
+  next[segment.Index] = updatePath(next[segment.Index], rest, update);
+  return next;
+}
+
+function applyPlainOp(
+  current: unknown,
+  path: PathSeg[],
+  op: PatchOp,
+  codec: ValueCodec,
+): unknown {
+  if ("Set" in op)
+    return updatePath(current, path, () => codec.fromValue(op.Set.value));
+  if ("Remove" in op) {
+    if (!path.length) return undefined;
+    const segment = path[path.length - 1];
+    if (!segment || !("Key" in segment))
+      throw new Error("remove path must end in an object key");
+    return updatePath(current, path.slice(0, -1), (container) => {
+      if (!isObj(container)) throw new Error("remove path expected an object");
+      const next = { ...container };
+      delete next[segment.Key];
+      return next;
+    });
+  }
+  if ("Insert" in op) {
+    return updatePath(current, path, (container) => {
+      if (!Array.isArray(container))
+        throw new Error("insert path expected an array");
+      if (op.Insert.index < 0 || op.Insert.index > container.length)
+        throw new Error(
+          `insert index ${op.Insert.index} out of bounds (len ${container.length})`,
+        );
+      const next = [...container];
+      next.splice(op.Insert.index, 0, codec.fromValue(op.Insert.value));
+      return next;
+    });
+  }
+  return updatePath(current, path, (container) => {
+    if (!Array.isArray(container))
+      throw new Error("remove path expected an array");
+    if (op.RemoveAt.index < 0 || op.RemoveAt.index >= container.length)
+      throw new Error(
+        `remove index ${op.RemoveAt.index} out of bounds (len ${container.length})`,
+      );
+    const next = [...container];
+    next.splice(op.RemoveAt.index, 1);
+    return next;
+  });
+}
+
 /**
  * Bidirectionally sync a `Store` with a transports-mirrored model. Model fields map by name to store
  * fields — and a nested sub-model flattens to dotted `parent.child` fields: inbound frames pull them
@@ -91,39 +175,88 @@ export function connectStore(
   const wired = new Set<string>();
   const unsubs: Array<() => void> = [];
 
+  const wireField = (field: string) => {
+    const key = namespace ? `${namespace}.${field}` : field;
+    if (wired.has(key)) return;
+    wired.add(key);
+    unsubs.push(
+      store.subscribe(key, (value) => {
+        if (inbound || id === undefined) return;
+        const decoded = codec.fromValue(client.value(id));
+        const current = isObj(decoded) ? decoded : {};
+        send(
+          client.edit(
+            id,
+            codec.toValue(setPath(current, field.split("."), value)),
+          ),
+        );
+      }),
+    );
+  };
+
+  const receiveSnapshot = () => {
+    if (id === undefined) return;
+    const decoded = codec.fromValue(client.value(id));
+    if (!isObj(decoded)) return;
+    const entries = flatten ? leaves(decoded) : Object.entries(decoded);
+    for (const [field, value] of entries) {
+      const key = namespace ? `${namespace}.${field}` : field;
+      store.set(key, value);
+      wireField(field.split(".")[0]);
+    }
+  };
+
+  const receivePatch = (change: Extract<ReceiveChange, { t: "patch" }>) => {
+    const staged = new Map<string, { field: string; value: unknown }>();
+    try {
+      for (const op of change.patch.ops) {
+        const body =
+          "Set" in op
+            ? op.Set
+            : "Remove" in op
+              ? op.Remove
+              : "Insert" in op
+                ? op.Insert
+                : op.RemoveAt;
+        const [head, ...rest] = body.path;
+        if (!head) {
+          receiveSnapshot();
+          return;
+        }
+        if (!("Key" in head))
+          throw new Error("model patch path must start with a map key");
+        const field = head.Key;
+        const key = namespace ? `${namespace}.${field}` : field;
+        const current = staged.has(key)
+          ? staged.get(key)!.value
+          : store.get(key);
+        staged.set(key, {
+          field,
+          value: applyPlainOp(current, rest, op, codec),
+        });
+      }
+    } catch {
+      receiveSnapshot();
+      return;
+    }
+    for (const [key, update] of staged) {
+      store.set(key, update.value);
+      wireField(update.field);
+    }
+  };
+
   return {
     receive(data) {
-      client.recv(data);
+      const change = client.recv(data);
       if (id === undefined) id = client.ids()[0];
       if (id === undefined) return; // no model yet (snapshot not received)
-      const model = codec.fromValue(client.value(id));
-      if (!model) return;
       inbound = true;
-      // flatten=true recurses sub-models to dotted leaves (a form's `schedule.start`); flatten=false
-      // keeps each top-level field whole, so an opaque map (a chart's time-keyed `data`) is one field.
-      const entries = flatten ? leaves(model) : Object.entries(model);
-      for (const [field, value] of entries) {
-        // store under the namespace (so models on one Store don't collide), but the outbound edit must
-        // carry the BARE model field — keep the loop-local `field` for it, never slice the namespaced key.
-        const key = namespace ? `${namespace}.${field}` : field;
-        store.set(key, value); // model → store (→ any bound props); nested → a dotted field
-        if (!wired.has(key)) {
-          wired.add(key);
-          unsubs.push(
-            store.subscribe(key, (v) => {
-              if (inbound || id === undefined) return; // ignore echoes of an inbound update
-              const current = codec.fromValue(client.value(id)) ?? {};
-              send(
-                client.edit(
-                  id,
-                  codec.toValue(setPath(current, field.split("."), v)),
-                ),
-              );
-            }),
-          );
-        }
+      try {
+        if (change?.t === "patch" && change.id === id) receivePatch(change);
+        else if (!change || change.t === "snapshot") receiveSnapshot();
+      } finally {
+        inbound = false;
       }
-      inbound = false;
     },
     dispose() {
       for (const unsub of unsubs) unsub();

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -151,6 +151,46 @@ test("Emit dispatches a bubbling custom event", async ({ page }) => {
   expect(detail).toBe("hi");
 });
 
+test("All and Any expressions evaluate through the action interpreter", async ({
+  page,
+}) => {
+  const detail = await page.evaluate(() => {
+    const button = window.__spaday.mount(document.body, {
+      tag: "button",
+      events: {
+        click: {
+          kind: "emit",
+          event: "logic",
+          detail: {
+            expr: "obj",
+            fields: {
+              all: {
+                expr: "all",
+                of: [
+                  { expr: "lit", value: true },
+                  { expr: "lit", value: 1 },
+                ],
+              },
+              any: {
+                expr: "any",
+                of: [
+                  { expr: "lit", value: false },
+                  { expr: "lit", value: "yes" },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+    return new Promise((resolve) => {
+      button.addEventListener("logic", (event) => resolve(event.detail));
+      button.click();
+    });
+  });
+  expect(detail).toEqual({ all: true, any: true });
+});
+
 test("SendPatch fires a routable spaday:patch intent carrying the event value", async ({
   page,
 }) => {
@@ -355,6 +395,64 @@ test("CallEndpoint composes a body from the signal store via field exprs", async
   });
   await page.waitForTimeout(150);
   expect(JSON.parse(seen[0])).toEqual({ symbol: "AAPL", qty: 250 });
+});
+
+test("actions resolve item and named ancestor scope expressions", async ({
+  page,
+}) => {
+  const seen = [];
+  await page.route("**/api/record", (route) => {
+    seen.push(route.request().postData());
+    return route.fulfill({ status: 200, body: "ok" });
+  });
+  await page.evaluate(() => {
+    const { mount, Scope, Store } = window.__spaday;
+    const staging = new Scope({ channel: "orders" }, "staging");
+    const record = new Scope({ id: 42, ready: true }, "record", staging);
+    const btn = mount(
+      document.body,
+      {
+        tag: "button",
+        events: {
+          click: {
+            kind: "call",
+            method: "POST",
+            url: "/api/record",
+            body: {
+              expr: "obj",
+              fields: {
+                id: { expr: "item", path: "id" },
+                channel: {
+                  expr: "scope",
+                  name: "staging",
+                  path: "channel",
+                },
+                state: {
+                  expr: "cond",
+                  test: {
+                    expr: "eq",
+                    a: { expr: "item", path: "ready" },
+                    b: { expr: "lit", value: true },
+                  },
+                  then: { expr: "lit", value: "ready" },
+                  else: { expr: "lit", value: "waiting" },
+                },
+              },
+            },
+          },
+        },
+      },
+      new Store(),
+      record,
+    );
+    btn.click();
+  });
+  await page.waitForTimeout(150);
+  expect(JSON.parse(seen[0])).toEqual({
+    id: 42,
+    channel: "orders",
+    state: "ready",
+  });
 });
 
 test("CallEndpoint composes its URL from signal-store fields", async ({

--- a/js/tests/each.spec.js
+++ b/js/tests/each.spec.js
@@ -1,0 +1,525 @@
+import fs from "fs";
+import { test, expect } from "@playwright/test";
+import { initSync } from "../dist/pkg/spaday";
+
+test.beforeAll(() => {
+  initSync({ module: fs.readFileSync("./dist/pkg/spaday_bg.wasm") });
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/tests/runtime.html");
+  await page.waitForFunction(() => window.__spaday);
+});
+
+test("spa-each reconciles keyed instances without losing live state", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async () => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({
+      rows: [
+        { id: 1, name: "A" },
+        { id: 2, name: "B" },
+      ],
+    });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: { itemKey: { Str: "id" } },
+        bindings: { items: { field: "rows", mode: "one-way" } },
+        slots: {
+          default: [
+            {
+              tag: "input",
+              bindings: {
+                value: {
+                  compute: { expr: "item", path: "name" },
+                  mode: "one-way",
+                },
+              },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    const first = root.children[0];
+    const second = root.children[1];
+    second.focus();
+    second.selectionStart = 1;
+    second.dataset.local = "kept";
+    store.set("rows", [
+      { id: 2, name: "Bee" },
+      { id: 3, name: "C" },
+      { id: 1, name: "A" },
+    ]);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    const after = [...root.children];
+    store.set("rows", [{ id: 2, name: "Bee" }]);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    return {
+      sameMoved: after[0] === second && after[2] === first,
+      values: after.map((element) => element.value),
+      focusKept: document.activeElement === second,
+      cursorKept: second.selectionStart,
+      propertyKept: second.dataset.local,
+      finalCount: root.children.length,
+      finalSame: root.firstElementChild === second,
+    };
+  });
+
+  expect(result).toEqual({
+    sameMoved: true,
+    values: ["Bee", "C", "A"],
+    focusKept: true,
+    cursorKept: 1,
+    propertyKept: "kept",
+    finalCount: 1,
+    finalSame: true,
+  });
+});
+
+test("native moves preserve custom-element connection state", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async () => {
+    const { mount, Store } = window.__spaday;
+    class MoveProbe extends HTMLElement {
+      connectedMoveCallback() {
+        this.moves = (this.moves ?? 0) + 1;
+      }
+      disconnectedCallback() {
+        this.disconnects = (this.disconnects ?? 0) + 1;
+      }
+    }
+    if (!customElements.get("move-probe"))
+      customElements.define("move-probe", MoveProbe);
+    const store = new Store({ rows: [{ id: 1 }, { id: 2 }] });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: { itemKey: { Str: "id" } },
+        bindings: { items: { field: "rows", mode: "one-way" } },
+        slots: { default: [{ tag: "move-probe" }] },
+      },
+      store,
+    );
+    const movedElement = root.children[1];
+    store.set("rows", [{ id: 2 }, { id: 1 }]);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    return {
+      supported: typeof root.moveBefore === "function",
+      moved: root.children[0] === movedElement,
+      moves: movedElement.moves ?? 0,
+      disconnects: movedElement.disconnects ?? 0,
+    };
+  });
+  expect(result.moved).toBe(true);
+  expect(result.moves).toBe(result.supported ? 1 : 0);
+  expect(result.disconnects).toBe(result.supported ? 0 : 1);
+});
+
+test("nested repeaters resolve inner, named outer, and global scope", async ({
+  page,
+}) => {
+  const text = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({
+      prefix: "global",
+      stagings: [
+        {
+          id: "s1",
+          channel: "stable",
+          records: [{ id: "r1", name: "package" }],
+        },
+      ],
+    });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: {
+          itemKey: { Str: "id" },
+          scopeName: { Str: "staging" },
+        },
+        bindings: { items: { field: "stagings", mode: "one-way" } },
+        slots: {
+          default: [
+            {
+              tag: "spa-each",
+              props: { itemKey: { Str: "id" } },
+              bindings: {
+                items: {
+                  compute: { expr: "item", path: "records" },
+                  mode: "one-way",
+                },
+              },
+              slots: {
+                default: [
+                  {
+                    tag: "span",
+                    bindings: {
+                      textContent: {
+                        compute: {
+                          expr: "concat",
+                          parts: [
+                            { expr: "field", name: "prefix" },
+                            { expr: "lit", value: ":" },
+                            {
+                              expr: "scope",
+                              name: "staging",
+                              path: "channel",
+                            },
+                            { expr: "lit", value: ":" },
+                            { expr: "item", path: "name" },
+                          ],
+                        },
+                        mode: "one-way",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    return root.textContent;
+  });
+  expect(text).toBe("global:stable:package");
+});
+
+test("updating one item does not recompute an unchanged sibling", async ({
+  page,
+}) => {
+  const updates = await page.evaluate(async () => {
+    const { mount, Store } = window.__spaday;
+    class ItemProbe extends HTMLElement {
+      set label(value) {
+        this.updates = (this.updates ?? 0) + 1;
+        this.textContent = value;
+      }
+    }
+    if (!customElements.get("item-probe"))
+      customElements.define("item-probe", ItemProbe);
+    const unchanged = { id: 1, name: "A" };
+    const store = new Store({
+      rows: [unchanged, { id: 2, name: "B" }],
+    });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: { itemKey: { Str: "id" } },
+        bindings: { items: { field: "rows", mode: "one-way" } },
+        slots: {
+          default: [
+            {
+              tag: "item-probe",
+              bindings: {
+                label: {
+                  compute: { expr: "item", path: "name" },
+                  mode: "one-way",
+                },
+              },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    store.set("rows", [unchanged, { id: 2, name: "Bee" }]);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    return [...root.children].map((element) => element.updates);
+  });
+  expect(updates).toEqual([1, 2]);
+});
+
+test("nested show and actions use current scope after a keyed move", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async () => {
+    const { mount, Store } = window.__spaday;
+    const requests = [];
+    window.fetch = async (url, init) => {
+      requests.push({ url: String(url), body: JSON.parse(init.body) });
+      return new Response("", { status: 204 });
+    };
+    const store = new Store({
+      rows: [
+        { id: 1, name: "A", ready: false },
+        { id: 2, name: "B", ready: true },
+      ],
+    });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: { itemKey: { Str: "id" }, scopeName: { Str: "row" } },
+        bindings: { items: { field: "rows", mode: "one-way" } },
+        slots: {
+          default: [
+            {
+              tag: "section",
+              slots: {
+                default: [
+                  {
+                    tag: "spa-show",
+                    bindings: {
+                      when: {
+                        compute: { expr: "item", path: "ready" },
+                        mode: "one-way",
+                      },
+                    },
+                    slots: {
+                      default: [
+                        {
+                          tag: "strong",
+                          props: { textContent: { Str: "ready" } },
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    tag: "button",
+                    events: {
+                      click: {
+                        kind: "call",
+                        method: "POST",
+                        url: {
+                          expr: "concat",
+                          parts: [
+                            { expr: "lit", value: "/rows/" },
+                            { expr: "item", path: "id" },
+                          ],
+                        },
+                        body: {
+                          expr: "obj",
+                          fields: {
+                            name: {
+                              expr: "scope",
+                              name: "row",
+                              path: "name",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    const first = root.children[0];
+    store.set("rows", [
+      { id: 2, name: "Bee", ready: false },
+      { id: 1, name: "A", ready: true },
+    ]);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    root.children[0].querySelector("button").click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return {
+      moved: root.children[1] === first,
+      ready: [...root.children].map(
+        (element) => !!element.querySelector("strong"),
+      ),
+      requests,
+    };
+  });
+  expect(result).toEqual({
+    moved: true,
+    ready: [false, true],
+    requests: [{ url: "/rows/2", body: { name: "Bee" } }],
+  });
+});
+
+test("invalid keys leave existing DOM unchanged", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ rows: [{ id: 1 }] });
+    const errors = [];
+    window.addEventListener("error", (event) => {
+      errors.push(event.error?.message ?? event.message);
+      event.preventDefault();
+    });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: { itemKey: { Str: "id" } },
+        bindings: { items: { field: "rows", mode: "one-way" } },
+        slots: { default: [{ tag: "div" }] },
+      },
+      store,
+    );
+    const original = root.firstElementChild;
+    store.set("rows", [{ id: 2 }, { id: 2 }]);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    return {
+      same: root.firstElementChild === original,
+      count: root.children.length,
+      error: errors[0],
+    };
+  });
+  expect(result.same).toBe(true);
+  expect(result.count).toBe(1);
+  expect(result.error).toContain('key "id" contains duplicate value 2');
+});
+
+test("a SetBinding patch rewires the repeater source", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const { applyPatch, mount, Store } = window.__spaday;
+    const store = new Store({
+      first: [{ id: 1, name: "A" }],
+      second: [{ id: 2, name: "B" }],
+    });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: { itemKey: { Str: "id" } },
+        bindings: { items: { field: "first", mode: "one-way" } },
+        slots: {
+          default: [
+            {
+              tag: "span",
+              bindings: {
+                textContent: {
+                  compute: { expr: "item", path: "name" },
+                  mode: "one-way",
+                },
+              },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    applyPatch(
+      root,
+      {
+        ops: [
+          {
+            SetBinding: {
+              path: [],
+              name: "items",
+              binding: { field: "second", mode: "one-way" },
+            },
+          },
+        ],
+      },
+      store,
+    );
+    const rewired = root.textContent;
+    store.set("second", [{ id: 3, name: "C" }]);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    return { rewired, updated: root.textContent };
+  });
+  expect(result).toEqual({ rewired: "B", updated: "C" });
+});
+
+test("removing a repeater cancels its pending reconciliation", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async () => {
+    const { applyPatch, mount, Store } = window.__spaday;
+    const store = new Store({ rows: [{ id: 1 }] });
+    const root = mount(
+      document.body,
+      {
+        tag: "main",
+        slots: {
+          default: [
+            {
+              tag: "spa-each",
+              props: { itemKey: { Str: "id" } },
+              bindings: { items: { field: "rows", mode: "one-way" } },
+              slots: { default: [{ tag: "span" }] },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    store.set("rows", [{ id: 1 }, { id: 2 }]);
+    applyPatch(
+      root,
+      {
+        ops: [
+          {
+            RemoveChild: { path: [], slot: "default", index: 0 },
+          },
+        ],
+      },
+      store,
+    );
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    return {
+      children: root.children.length,
+      bodyRepeaters: document.querySelectorAll("spa-each").length,
+    };
+  });
+  expect(result).toEqual({ children: 0, bodyRepeaters: 0 });
+});
+
+test("bursts coalesce and removed instances unsubscribe", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const { mount, Store } = window.__spaday;
+    window.eachProbeConnections = 0;
+    class ProbeElement extends HTMLElement {
+      connectedCallback() {
+        window.eachProbeConnections += 1;
+      }
+      set marker(value) {
+        this.updates = (this.updates ?? 0) + 1;
+        this.lastMarker = value;
+      }
+    }
+    if (!customElements.get("each-probe"))
+      customElements.define("each-probe", ProbeElement);
+    const store = new Store({ rows: [{ id: 1 }], marker: "a" });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: { itemKey: { Str: "id" } },
+        bindings: { items: { field: "rows", mode: "one-way" } },
+        slots: {
+          default: [
+            {
+              tag: "each-probe",
+              bindings: { marker: { field: "marker", mode: "one-way" } },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    const removed = root.firstElementChild;
+    store.set("rows", [{ id: 1 }, { id: 2 }]);
+    store.set("rows", [{ id: 1 }, { id: 2 }, { id: 3 }]);
+    store.set("rows", []);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    store.set("marker", "b");
+    return {
+      count: root.children.length,
+      connections: window.eachProbeConnections,
+      removedUpdates: removed.updates,
+      removedMarker: removed.lastMarker,
+    };
+  });
+  expect(result).toEqual({
+    count: 0,
+    connections: 1,
+    removedUpdates: 1,
+    removedMarker: "a",
+  });
+});

--- a/js/tests/examples-visual.spec.js
+++ b/js/tests/examples-visual.spec.js
@@ -16,6 +16,7 @@ const EXAMPLES = [
   { name: "form", selector: "wa-input" },
   { name: "fragment", selector: "#spaday-root wa-button" },
   { name: "gateway", selector: "perspective-panel" },
+  { name: "keyed_records", selector: "spa-each .record" },
   { name: "reactive", selector: "spa-main" },
   { name: "ssr", selector: "spa-app" },
   { name: "webawesome_content", selector: "wa-card" },
@@ -143,6 +144,39 @@ test.describe("example visual smoke tests", () => {
           );
           expect(after.from).toBeCloseTo(before.from);
           expect(after.to).toBeCloseTo(before.to);
+        }
+
+        if (example.name === "keyed_records") {
+          const stable = page.locator(".channel").filter({
+            has: page.getByRole("heading", { name: "stable" }),
+          });
+          const spaday = stable
+            .locator(".record")
+            .filter({ hasText: "spaday" });
+          const note = spaday.getByRole("textbox", { name: "Local note" });
+          await note.fill("preserved across a move");
+          await stable.getByRole("button", { name: "Reverse order" }).click();
+          await expect(note).toHaveValue("preserved across a move");
+
+          const transports = stable
+            .locator(".record")
+            .filter({ hasText: "transports" });
+          await transports
+            .getByRole("button", { name: "Toggle ready" })
+            .click();
+          await expect(
+            transports.getByText("Ready", { exact: true }),
+          ).toBeVisible();
+
+          const before = await stable.locator(".record").count();
+          await stable.getByRole("button", { name: "Add record" }).click();
+          await expect(stable.locator(".record")).toHaveCount(before + 1);
+          await stable
+            .locator(".record")
+            .last()
+            .getByRole("button", { name: "Remove" })
+            .click();
+          await expect(stable.locator(".record")).toHaveCount(before);
         }
       } catch (error) {
         throw new Error(

--- a/js/tests/hydrate.spec.js
+++ b/js/tests/hydrate.spec.js
@@ -103,3 +103,40 @@ test("client-mounts spa-show children on hydrate (rendered empty by SSR)", async
   });
   expect(text).toBe("shown"); // the structural subtree was mounted client-side
 });
+
+test("client-mounts spa-each instances on hydrate", async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const { hydrate, Store } = window.__spaday;
+    const container = document.createElement("div");
+    container.innerHTML =
+      '<spa-each style="display:contents" itemkey="id"></spa-each>';
+    const original = container.firstElementChild;
+    const root = hydrate(
+      container,
+      {
+        tag: "spa-each",
+        props: {
+          style: { Str: "display:contents" },
+          itemKey: { Str: "id" },
+        },
+        bindings: { items: { field: "rows", mode: "one-way" } },
+        slots: {
+          default: [
+            {
+              tag: "span",
+              bindings: {
+                textContent: {
+                  compute: { expr: "item", path: "name" },
+                  mode: "one-way",
+                },
+              },
+            },
+          ],
+        },
+      },
+      new Store({ rows: [{ id: 1, name: "hydrated" }] }),
+    );
+    return { adopted: root === original, text: root.textContent };
+  });
+  expect(result).toEqual({ adopted: true, text: "hydrated" });
+});

--- a/js/tests/runtime.html
+++ b/js/tests/runtime.html
@@ -13,6 +13,7 @@
         init,
         registerHandler,
         Store,
+        Scope,
         connectStore,
       } from "/dist/esm/index.js";
       await init({ module_or_path: "/dist/pkg/spaday_bg.wasm" }); // the action interpreter runs in wasm
@@ -24,6 +25,7 @@
         tag,
         registerHandler,
         Store,
+        Scope,
         connectStore,
       };
     </script>

--- a/js/tests/show.spec.js
+++ b/js/tests/show.spec.js
@@ -74,6 +74,25 @@ test("a compute condition shows children when the expression is truthy", async (
   expect(result.after).toBe(1);
 });
 
+test("a storeless compute condition remains inert and renders its children", async ({
+  page,
+}) => {
+  const count = await page.evaluate(() => {
+    const root = window.__spaday.mount(document.createElement("div"), {
+      tag: "spa-show",
+      bindings: {
+        when: {
+          compute: { expr: "field", name: "missing" },
+          mode: "one-way",
+        },
+      },
+      slots: { default: [{ tag: "p" }] },
+    });
+    return root.querySelectorAll("p").length;
+  });
+  expect(count).toBe(1);
+});
+
 test("re-shown children are freshly bound to the current store value", async ({
   page,
 }) => {

--- a/js/tests/signals.spec.js
+++ b/js/tests/signals.spec.js
@@ -266,6 +266,79 @@ test("a concat expr composes strings from fields reactively", async ({
   expect(result).toEqual({ initial: "Basket A", after: "Basket B" });
 });
 
+test("item and named scope expressions resolve lexically and update reactively", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Scope, Store } = window.__spaday;
+    const store = new Store({ prefix: "Row" });
+    const staging = new Scope({ channel: "alpha", enabled: true }, "staging");
+    const record = new Scope({ id: 7, ready: true }, "record", staging);
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "span",
+        bindings: {
+          textContent: {
+            compute: {
+              expr: "concat",
+              parts: [
+                { expr: "field", name: "prefix" },
+                { expr: "lit", value: ":" },
+                { expr: "scope", name: "staging", path: "channel" },
+                { expr: "lit", value: ":" },
+                {
+                  expr: "cond",
+                  test: {
+                    expr: "all",
+                    of: [
+                      { expr: "item", path: "ready" },
+                      {
+                        expr: "scope",
+                        name: "staging",
+                        path: "enabled",
+                      },
+                    ],
+                  },
+                  then: { expr: "item", path: "id" },
+                  else: { expr: "lit", value: "waiting" },
+                },
+              ],
+            },
+            mode: "one-way",
+          },
+        },
+      },
+      store,
+      record,
+    );
+    const values = [root.textContent];
+    staging.set({ channel: "beta", enabled: true });
+    values.push(root.textContent);
+    record.set({ id: 8, ready: false });
+    values.push(root.textContent);
+    store.set("prefix", "Item");
+    values.push(root.textContent);
+    const shadow = new Scope({ channel: "nearest" }, "staging", record);
+    return {
+      values,
+      missingItem: record.get("missing"),
+      missingScope: record.resolve("missing")?.get(),
+      shadowedScope: shadow.resolve("staging")?.get("channel"),
+    };
+  });
+
+  expect(result.values).toEqual([
+    "Row:alpha:7",
+    "Row:beta:7",
+    "Row:beta:waiting",
+    "Item:beta:waiting",
+  ]);
+  expect(result.missingItem).toBeUndefined();
+  expect(result.missingScope).toBeUndefined();
+  expect(result.shadowedScope).toBe("nearest");
+});
+
 test("a root-class binding toggles a class on <html> from a field", async ({
   page,
 }) => {
@@ -317,6 +390,54 @@ test("nested-path fields: set/get a dotted path; notify the leaf and its ancesto
   expect(result.leaf).toEqual(["Oak"]);
   expect(result.parentFired).toBe(1);
   expect(result.siblingFired).toBe(0);
+});
+
+test("subscriber paths retain ancestor and descendant notifications after index pruning", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { Store } = window.__spaday;
+    const store = new Store({
+      profile: { name: { first: "Ada", last: "Lovelace" } },
+      unrelated: 0,
+    });
+    const seen = { parent: 0, leaf: 0, descendant: 0, unrelated: 0 };
+    store.subscribe("profile", () => (seen.parent += 1));
+    const unsubscribe = store.subscribe("profile.name", () => (seen.leaf += 1));
+    store.subscribe("profile.name.first", () => (seen.descendant += 1));
+    store.subscribe("unrelated", () => (seen.unrelated += 1));
+
+    store.set("profile.name", { first: "Grace", last: "Hopper" });
+    unsubscribe();
+    store.set("profile.name.first", "Rear Admiral Grace");
+    return seen;
+  });
+
+  expect(result).toEqual({
+    parent: 2,
+    leaf: 1,
+    descendant: 2,
+    unrelated: 0,
+  });
+});
+
+test("a notification can unsubscribe a related descendant", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { Store } = window.__spaday;
+    const store = new Store({ profile: { name: "Ada" } });
+    let descendant = 0;
+    const unsubscribe = store.subscribe(
+      "profile.name",
+      () => (descendant += 1),
+    );
+    store.subscribe("profile", unsubscribe);
+    store.set("profile", { name: "Grace" });
+    return descendant;
+  });
+
+  expect(result).toBe(0);
 });
 
 test("a binding to a dotted path reacts to nested state, two-way", async ({

--- a/js/tests/store-sync.spec.js
+++ b/js/tests/store-sync.spec.js
@@ -29,6 +29,37 @@ const FAKE = () => {
   return { client, codec: { fromValue: (v) => v, toValue: (v) => v } };
 };
 
+const PATCH_FAKE = () => {
+  const client = {
+    model: {},
+    valueCalls: 0,
+    recv(data) {
+      const change = JSON.parse(data);
+      if (change.t === "snapshot") this.model = change.value;
+      return change;
+    },
+    ids() {
+      return [1];
+    },
+    value() {
+      this.valueCalls += 1;
+      return this.model;
+    },
+    edit(_id, value) {
+      return JSON.stringify(value);
+    },
+  };
+  const codec = {
+    fromCalls: 0,
+    fromValue(value) {
+      this.fromCalls += 1;
+      return value;
+    },
+    toValue: (value) => value,
+  };
+  return { client, codec };
+};
+
 test.beforeEach(async ({ page }) => {
   await page.goto("/tests/runtime.html");
   await page.waitForFunction(() => window.__spaday);
@@ -109,6 +140,175 @@ test("inbound updates a two-way control, and applying an inbound frame does not 
   }, FAKE.toString());
   expect(result.checked).toBe(true); // the inbound value reached the bound control
   expect(result.echoes).toBe(0); // echo guard: inbound updates are not sent straight back out
+});
+
+test("inbound patch updates only its changed store branch", async ({
+  page,
+}) => {
+  const result = await page.evaluate((makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { Store, connectStore } = window.__spaday;
+    const store = new Store();
+    const link = connectStore(store, client, () => {}, codec);
+    link.receive(
+      JSON.stringify({
+        t: "snapshot",
+        id: 1,
+        value: {
+          profile: { name: "old", active: true },
+          rows: [{ id: 1 }, { id: 2 }],
+        },
+      }),
+    );
+    const rows = store.get("rows");
+    let rowNotifications = 0;
+    store.subscribe("rows", () => {
+      rowNotifications += 1;
+    });
+    client.valueCalls = 0;
+    codec.fromCalls = 0;
+
+    link.receive(
+      JSON.stringify({
+        t: "patch",
+        id: 1,
+        patch: {
+          rev: 1,
+          ops: [
+            {
+              Set: {
+                path: [{ Key: "profile" }, { Key: "name" }],
+                value: "new",
+              },
+            },
+          ],
+        },
+      }),
+    );
+    return {
+      name: store.get("profile.name"),
+      rowsPreserved: store.get("rows") === rows,
+      rowNotifications,
+      valueCalls: client.valueCalls,
+      decodedValues: codec.fromCalls,
+    };
+  }, PATCH_FAKE.toString());
+
+  expect(result).toEqual({
+    name: "new",
+    rowsPreserved: true,
+    rowNotifications: 0,
+    valueCalls: 0,
+    decodedValues: 1,
+  });
+});
+
+test("inbound patch applies list insertion and removal without a model read", async ({
+  page,
+}) => {
+  const result = await page.evaluate((makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { Store, connectStore } = window.__spaday;
+    const store = new Store();
+    const link = connectStore(store, client, () => {}, codec);
+    link.receive(
+      JSON.stringify({
+        t: "snapshot",
+        id: 1,
+        value: { rows: [1, 2], status: "ready" },
+      }),
+    );
+    client.valueCalls = 0;
+    codec.fromCalls = 0;
+    link.receive(
+      JSON.stringify({
+        t: "patch",
+        id: 1,
+        patch: {
+          rev: 1,
+          ops: [
+            {
+              Insert: {
+                path: [{ Key: "rows" }],
+                index: 1,
+                value: 5,
+              },
+            },
+            { RemoveAt: { path: [{ Key: "rows" }], index: 0 } },
+            { Remove: { path: [{ Key: "status" }] } },
+          ],
+        },
+      }),
+    );
+    return {
+      rows: store.get("rows"),
+      status: store.get("status") ?? null,
+      valueCalls: client.valueCalls,
+      decodedValues: codec.fromCalls,
+    };
+  }, PATCH_FAKE.toString());
+
+  expect(result).toEqual({
+    rows: [5, 2],
+    status: null,
+    valueCalls: 0,
+    decodedValues: 1,
+  });
+});
+
+test("an invalid patch falls back atomically to the client snapshot", async ({
+  page,
+}) => {
+  const result = await page.evaluate((makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { Store, connectStore } = window.__spaday;
+    const store = new Store();
+    const link = connectStore(store, client, () => {}, codec, undefined, false);
+    link.receive(
+      JSON.stringify({
+        t: "snapshot",
+        id: 1,
+        value: { profile: { name: "old" }, rows: [1] },
+      }),
+    );
+    let profileNotifications = 0;
+    store.subscribe("profile", () => {
+      profileNotifications += 1;
+    });
+    client.model = { profile: { name: "server" }, rows: [9] };
+    client.valueCalls = 0;
+    link.receive(
+      JSON.stringify({
+        t: "patch",
+        id: 1,
+        patch: {
+          rev: 1,
+          ops: [
+            {
+              Set: {
+                path: [{ Key: "profile" }, { Key: "name" }],
+                value: "transient",
+              },
+            },
+            { RemoveAt: { path: [{ Key: "rows" }], index: 5 } },
+          ],
+        },
+      }),
+    );
+    return {
+      profile: store.get("profile"),
+      rows: store.get("rows"),
+      profileNotifications,
+      valueCalls: client.valueCalls,
+    };
+  }, PATCH_FAKE.toString());
+
+  expect(result).toEqual({
+    profile: { name: "server" },
+    rows: [9],
+    profileNotifications: 1,
+    valueCalls: 1,
+  });
 });
 
 test("inbound: a nested sub-model field flows to a dotted-path binding", async ({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,5 +283,6 @@ exclude_patterns = [
     "REVIEW.md",
     "TODO.md",
     ".github",
+    "spaday-*",
     "spaday/examples/README.md",
 ]

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -10,6 +10,7 @@
 //! - `Ref`:  `{"ref":"this"}` · `{"ref":"id","id":"panel"}`
 //! - `Expr`: `{"expr":"lit","value":<json>}` · `{"expr":"event"}` · `{"expr":"not","of":<Expr>}` ·
 //!   `{"expr":"prop","target":<Ref>,"name":"checked"}` · `{"expr":"field","name":"qty"}` ·
+//!   `{"expr":"item","path":"id"}` · `{"expr":"scope","name":"staging","path":"channel"}` ·
 //!   `{"expr":"obj","fields":{<name>:<Expr>}}` · `{"expr":"concat","parts":[<Expr>,..]}`
 //! - `Action`: `{"kind":"set",target,prop,value}` · `{"kind":"toggle",target,prop}` ·
 //!   `{"kind":"set-field","field","value":<Expr>}` · `{"kind":"toggle-field","field"}` ·
@@ -52,6 +53,23 @@ pub enum Expr {
     /// The current value of a reactive state `field` from the signal store the tree was mounted with —
     /// e.g. compose `CallEndpoint`'s body from a form's two-way-bound fields. (Also a binding expr.)
     Field { name: String },
+    /// A value at `path` in the innermost keyed-repeater item. Empty path returns the whole item.
+    Item { path: String },
+    /// A value at `path` in the nearest current/ancestor repeater scope named `name`.
+    Scope { name: String, path: String },
+    /// Strict equality of two expressions.
+    Eq { a: Box<Expr>, b: Box<Expr> },
+    /// True when every expression is truthy.
+    All { of: Vec<Expr> },
+    /// True when any expression is truthy.
+    Any { of: Vec<Expr> },
+    /// Choose `then` when `test` is truthy, otherwise `otherwise`.
+    Cond {
+        test: Box<Expr>,
+        then: Box<Expr>,
+        #[serde(rename = "else")]
+        otherwise: Box<Expr>,
+    },
     /// Compose a JSON object from named sub-expressions — e.g. a whole model as a `CallEndpoint` body:
     /// `{"expr":"obj","fields":{"symbol":{"expr":"prop","target":{"ref":"id","id":"sym"},"name":"value"}}}`.
     Obj {
@@ -481,5 +499,38 @@ mod tests {
                 "result": null,
             }),
         );
+    }
+
+    #[test]
+    fn item_scope_and_shared_binding_expressions_round_trip() {
+        let expr = Expr::Cond {
+            test: Box::new(Expr::All {
+                of: vec![
+                    Expr::Eq {
+                        a: Box::new(Expr::Item {
+                            path: "ready".into(),
+                        }),
+                        b: Box::new(Expr::Lit { value: json!(true) }),
+                    },
+                    Expr::Scope {
+                        name: "staging".into(),
+                        path: "enabled".into(),
+                    },
+                ],
+            }),
+            then: Box::new(Expr::Item { path: "id".into() }),
+            otherwise: Box::new(Expr::Lit { value: json!(null) }),
+        };
+        let wire = json!({
+            "expr": "cond",
+            "test": {"expr": "all", "of": [
+                {"expr": "eq", "a": {"expr": "item", "path": "ready"}, "b": {"expr": "lit", "value": true}},
+                {"expr": "scope", "name": "staging", "path": "enabled"}
+            ]},
+            "then": {"expr": "item", "path": "id"},
+            "else": {"expr": "lit", "value": null}
+        });
+        assert_eq!(serde_json::to_value(&expr).unwrap(), wire);
+        assert_eq!(serde_json::from_value::<Expr>(wire).unwrap(), expr);
     }
 }

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -160,6 +160,20 @@ fn diff_node(path: &Path, old: &Node, new: &Node, ops: &mut Vec<Op>) {
         return;
     }
 
+    // Structural wrappers own their rendered children. Their serialized slots are templates rather
+    // than addressable live DOM, so changing a template must replace the wrapper as one opaque unit.
+    // `spa-each` configuration also determines item identity and scope, and cannot be patched in place.
+    let structural_template_changed =
+        matches!(old.tag.as_str(), "spa-show" | "spa-each") && old.slots != new.slots;
+    let each_config_changed = old.tag == "spa-each" && old.props != new.props;
+    if structural_template_changed || each_config_changed {
+        ops.push(Op::Replace {
+            path: path.to_vec(),
+            node: new.clone(),
+        });
+        return;
+    }
+
     if old.key != new.key {
         ops.push(Op::SetKey {
             path: path.to_vec(),
@@ -531,6 +545,36 @@ mod diff_tests {
         let new = Node::new("wa-card").prop("y", 2i64);
         let patch = assert_round_trip(&old, &new);
         assert!(matches!(patch.ops.as_slice(), [Op::Replace { .. }]));
+    }
+
+    #[test]
+    fn test_structural_template_change_replaces_wrapper() {
+        for tag in ["spa-show", "spa-each"] {
+            let old = Node::new(tag).child(Node::new("span").prop("text", "old"));
+            let new = Node::new(tag).child(Node::new("span").prop("text", "new"));
+            let patch = assert_round_trip(&old, &new);
+            assert!(matches!(patch.ops.as_slice(), [Op::Replace { .. }]));
+        }
+    }
+
+    #[test]
+    fn test_each_binding_change_remains_incremental() {
+        use crate::node::{BindMode, Binding};
+        let binding = |field: &str| Binding {
+            field: Some(field.into()),
+            compute: None,
+            mode: BindMode::OneWay,
+        };
+        let old = Node::new("spa-each")
+            .prop("itemKey", "id")
+            .bind("items", binding("old"))
+            .child(Node::new("span"));
+        let new = Node::new("spa-each")
+            .prop("itemKey", "id")
+            .bind("items", binding("new"))
+            .child(Node::new("span"));
+        let patch = assert_round_trip(&old, &new);
+        assert!(matches!(patch.ops.as_slice(), [Op::SetBinding { .. }]));
     }
 
     #[test]

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -19,10 +19,12 @@ from .actions import (
     eq,
     event_value,
     field,
+    item,
     lit,
     not_,
     obj,
     prop,
+    scope,
     this,
 )
 from .bootstrap import Wire
@@ -81,6 +83,7 @@ __all__ = [
     "eq",
     "event_value",
     "field",
+    "item",
     "generate",
     "lit",
     "not_",
@@ -88,6 +91,7 @@ __all__ = [
     # CEM binding generator
     "parse_cem",
     "prop",
+    "scope",
     # server-side rendering (light-DOM HTML for first paint; client hydrates)
     "render_html",
     "resolve_component_packages",

--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -18,8 +18,8 @@ Actions: ``SetProp`` / ``Toggle`` / ``Sequence`` / ``Emit`` (client-side); ``Set
 (write the mounted signal store, so a plain button can drive reactive state); ``SendPatch`` (a model-edit
 intent the app routes to its wire, e.g. transports); ``If`` (conditionals); ``CallEndpoint`` (a REST
 round-trip); and ``NamedJs`` (a no-``eval`` escape hatch to a pre-registered handler). Expressions:
-``lit`` / ``event_value`` / ``field`` / ``not_`` / ``prop`` / ``obj`` / ``concat``; targets ``this`` /
-``by_id``.
+``lit`` / ``event_value`` / ``field`` / ``item`` / ``scope`` / ``not_`` / ``prop`` / ``obj`` /
+``concat``; targets ``this`` / ``by_id``.
 ``bind`` here is a one-way event-driven helper; reactive prop↔state bindings (one- or two-way) are
 authored with ``Component.bind`` and interpreted by the runtime's signal store.
 """
@@ -101,6 +101,42 @@ def field(name: str) -> Expr:
     """The current value of a reactive state field — for a *computed* binding (``Component.compute``),
     evaluated against the signal store in the browser, e.g. ``not_(field("enabled"))``."""
     return _Field(name)
+
+
+class _Item(Expr):
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"expr": "item", "path": self.path}
+
+
+def item(path: str = "") -> Expr:
+    """Read ``path`` from the innermost ``Each`` item.
+
+    An empty path returns the complete item. Missing paths evaluate to ``undefined`` in the browser.
+    """
+    return _Item(path)
+
+
+class _Scope(Expr):
+    def __init__(self, name: str, path: str) -> None:
+        self.name, self.path = name, path
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"expr": "scope", "name": self.name, "path": self.path}
+
+
+def scope(reference: str) -> Expr:
+    """Read a named current or ancestor item scope.
+
+    ``scope("staging.channel")`` reads ``channel`` from the nearest scope named ``staging``;
+    ``scope("staging")`` returns that scope's complete item.
+    """
+    name, _, path = reference.partition(".")
+    if not name:
+        raise ValueError("scope reference must start with a name")
+    return _Scope(name, path)
 
 
 class _Eq(Expr):

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -159,8 +159,8 @@ class Component:
         """Reactively set ``prop`` to a value *computed* from state fields (one-way).
 
         ``expr`` is a field expression (:func:`~spaday.actions.field` / ``eq`` / ``not_`` / ``all_`` /
-        ``any_`` / ``lit``) evaluated in the browser against the signal store and recomputed whenever any
-        field it reads changes, e.g. ``compute("disabled", not_(field("enabled")))``.
+        ``any_`` / ``lit`` / ``item`` / ``scope``) evaluated in the browser and recomputed whenever any
+        global field or repeater scope it reads changes, e.g. ``compute("disabled", not_(field("enabled")))``.
         """
         self._bindings[prop] = {"compute": expr.to_dict(), "mode": "one-way"}
         return self

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -13,6 +13,8 @@ the runtime interprets the action in the browser on the DOM event, with no round
 import json
 from typing import Any, Union
 
+from .actions import Expr
+
 #: The conventional name of a component's unnamed (default) slot (matches the Rust core).
 DEFAULT_SLOT = "default"
 
@@ -95,12 +97,15 @@ class Component:
         self._slots.setdefault(slot, []).append(element("span", textContent=node) if isinstance(node, str) else node)
         return self
 
-    def text(self, value: str) -> "Component":
-        """Set the element's text content (e.g. a button or option label).
+    def text(self, value: str | Expr) -> "Component":
+        """Set the element's literal or reactive text content (e.g. a button or option label).
 
         Text is set as the ``textContent`` DOM property by the runtime, so this is for leaf elements
-        whose label *is* their text (don't combine it with child nodes).
+        whose label *is* their text (don't combine it with child nodes). An expression such as
+        ``item("name")`` becomes a computed binding.
         """
+        if isinstance(value, Expr):
+            return self.compute("textContent", value)
         self._props["textContent"] = value
         return self
 
@@ -222,16 +227,16 @@ def element(tag: str, *children: Child, key: str | None = None, **props: Any) ->
     return node
 
 
-def Text(text: str, **props: Any) -> Component:
+def Text(text: str | Expr, **props: Any) -> Component:
     """An inline text node — a ``<span>``. ``Row("Echo: ", echo)`` does the same via a bare string child."""
-    return element("span", textContent=text, **props)
+    return element("span", **props).text(text)
 
 
-def Strong(text: str, **props: Any) -> Component:
+def Strong(text: str | Expr, **props: Any) -> Component:
     """Bold inline text — a ``<strong>``."""
-    return element("strong", textContent=text, **props)
+    return element("strong", **props).text(text)
 
 
-def Paragraph(text: str, **props: Any) -> Component:
+def Paragraph(text: str | Expr, **props: Any) -> Component:
     """A paragraph — a ``<p>``."""
-    return element("p", textContent=text, **props)
+    return element("p", **props).text(text)

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from ..component import Child, Component, element
 
-__all__ = ["App", "AppShell", "Body", "Column", "Footer", "Gutter", "Main", "Nav", "Region", "Row", "Show", "Stack", "Table", "Toolbar"]
+__all__ = ["App", "AppShell", "Body", "Column", "Each", "Footer", "Gutter", "Main", "Nav", "Region", "Row", "Show", "Stack", "Table", "Toolbar"]
 
 
 class App(Component):
@@ -212,7 +212,8 @@ class Show(Component):
 
         Show(LightweightChart(...), field="show_chart")
 
-    Active only when the tree is mounted with a signal ``Store`` (``mount(body, tree, store)``).
+    A ``field`` condition requires a signal ``Store``. A computed condition may instead read the
+    current ``Each`` item or a named repeater scope.
     """
 
     tag = "spa-show"
@@ -225,6 +226,50 @@ class Show(Component):
             self._bindings["when"] = {"compute": when.to_dict(), "mode": "one-way"}
         else:
             raise ValueError("Show requires field= (a store field) or when= (a field-expression)")
+
+
+class Each(Component):
+    """Render one live component subtree per item in a reactive collection, reusing instances by key.
+
+    ``field`` reads a global store collection. ``items`` accepts an expression, including
+    :func:`~spaday.actions.item` for a nested collection. Inside ``template``, ``item()`` reads the
+    current item and ``scope("name.path")`` reads a named current or ancestor repeater scope::
+
+        Each(Row(Strong().compute("textContent", item("name"))), field="rows", key="id", scope="row")
+
+    The first release supports one component template root and read-only item scopes. Item keys must be
+    unique strings or finite numbers. Reordering preserves each live root element and its local state.
+    """
+
+    tag = "spa-each"
+
+    def __init__(
+        self,
+        template: Component,
+        *,
+        field: str | None = None,
+        items: Any | None = None,
+        key: str,
+        scope: str | None = None,
+        **props: Any,
+    ) -> None:
+        if not isinstance(template, Component):
+            raise TypeError("Each template must be one Component")
+        if (field is None) == (items is None):
+            raise ValueError("Each requires exactly one of field= or items=")
+        if not isinstance(key, str) or not key:
+            raise ValueError("Each key must be a non-empty item field")
+        if scope is not None and (not scope or "." in scope):
+            raise ValueError("Each scope must be a non-empty name without dots")
+        super().__init__(template, props={"style": "display:contents", "itemKey": key, "scopeName": scope}, **props)
+        if field is not None:
+            self._bindings["items"] = {"field": field, "mode": "one-way"}
+        else:
+            try:
+                expression = items.to_dict()
+            except AttributeError as exc:
+                raise TypeError("Each items must be an expression") from exc
+            self._bindings["items"] = {"compute": expression, "mode": "one-way"}
 
 
 class Table(Component):

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -64,6 +64,7 @@ with `python -m`, then open its listed URL.
 | Present rich content           | [`webawesome_content.py`](./webawesome_content.py)       | <http://127.0.0.1:8013> | cards, carousel, comparison, formatters, Markdown, QR code, split and scroller layouts   |
 | Use browser utility components | [`webawesome_observers.py`](./webawesome_observers.py)   | <http://127.0.0.1:8014> | include, mutation, intersection and resize observers, zoomable frame                     |
 | Build a local data dashboard   | [`data_dashboard.py`](./data_dashboard.py)               | <http://127.0.0.1:8015> | shell regions, reactive table, tabs, conditional chart, local theme                      |
+| Build a live actionable list   | [`keyed_records.py`](./keyed_records.py)                 | <http://127.0.0.1:8016> | nested keyed collections, item-scoped actions, server CRUD, identity-preserving moves    |
 
 Run one, for example:
 
@@ -76,23 +77,25 @@ The five `webawesome_*` modules collectively instantiate every generated compone
 
 ## Focused data and rendering examples
 
-| Goal                                          | Module                         | Extra         | Run                                                           |
-| --------------------------------------------- | ------------------------------ | ------------- | ------------------------------------------------------------- |
-| Bind controls to a server-authoritative model | [`reactive.py`](./reactive.py) | `examples`    | `python -m spaday.examples.reactive`                          |
-| Generate a bound form from a Pydantic model   | [`form.py`](./form.py)         | `examples`    | `python -m spaday.examples.form`                              |
-| Share one live chart across multiple workers  | [`cluster.py`](./cluster.py)   | `cluster`     | `uvicorn spaday.examples.cluster:app --workers 4 --port 8003` |
-| Server-render and hydrate a themed tree       | [`ssr.py`](./ssr.py)           | `examples`    | `python -m spaday.examples.ssr`                               |
-| Build a REST and Perspective gateway UI       | [`gateway.py`](./gateway.py)   | `perspective` | `python -m spaday.examples.gateway`                           |
+| Goal                                          | Module                                   | Extra         | Run                                                           |
+| --------------------------------------------- | ---------------------------------------- | ------------- | ------------------------------------------------------------- |
+| Bind controls to a server-authoritative model | [`reactive.py`](./reactive.py)           | `examples`    | `python -m spaday.examples.reactive`                          |
+| Generate a bound form from a Pydantic model   | [`form.py`](./form.py)                   | `examples`    | `python -m spaday.examples.form`                              |
+| Share one live chart across multiple workers  | [`cluster.py`](./cluster.py)             | `cluster`     | `uvicorn spaday.examples.cluster:app --workers 4 --port 8003` |
+| Server-render and hydrate a themed tree       | [`ssr.py`](./ssr.py)                     | `examples`    | `python -m spaday.examples.ssr`                               |
+| Build a REST and Perspective gateway UI       | [`gateway.py`](./gateway.py)             | `perspective` | `python -m spaday.examples.gateway`                           |
+| Build a keyed server-driven staging queue     | [`keyed_records.py`](./keyed_records.py) | `examples`    | `python -m spaday.examples.keyed_records`                     |
 
 The applications listen on:
 
-| Module        | URL                     | Key behavior to verify                                                |
-| ------------- | ----------------------- | --------------------------------------------------------------------- |
-| `reactive.py` | <http://127.0.0.1:8001> | edits synchronize between two tabs through `connectStore`             |
-| `form.py`     | <http://127.0.0.1:8002> | generated controls edit the hosted Pydantic model                     |
-| `cluster.py`  | <http://127.0.0.1:8003> | clients connected to different workers receive the same bounded chart |
-| `ssr.py`      | <http://127.0.0.1:8005> | page source contains rendered elements that the browser hydrates      |
-| `gateway.py`  | <http://127.0.0.1:8006> | validated REST orders appear in the Perspective blotter               |
+| Module             | URL                     | Key behavior to verify                                                |
+| ------------------ | ----------------------- | --------------------------------------------------------------------- |
+| `reactive.py`      | <http://127.0.0.1:8001> | edits synchronize between two tabs through `connectStore`             |
+| `form.py`          | <http://127.0.0.1:8002> | generated controls edit the hosted Pydantic model                     |
+| `cluster.py`       | <http://127.0.0.1:8003> | clients connected to different workers receive the same bounded chart |
+| `ssr.py`           | <http://127.0.0.1:8005> | page source contains rendered elements that the browser hydrates      |
+| `gateway.py`       | <http://127.0.0.1:8006> | validated REST orders appear in the Perspective blotter               |
+| `keyed_records.py` | <http://127.0.0.1:8016> | per-record actions patch nested lists without replacing live row DOM  |
 
 `cluster.py` uses `tcp://127.0.0.1:5599` and `tcp://127.0.0.1:5600` for its default ZeroMQ backplane.
 Set `SPADAY_CLUSTER_FRONT` and `SPADAY_CLUSTER_BACK` when running multiple independent clusters.
@@ -178,3 +181,4 @@ pn.panel(widget)
 | [`webawesome_content.py`](./webawesome_content.py)       | rich content                          |
 | [`webawesome_observers.py`](./webawesome_observers.py)   | browser observers and utilities       |
 | [`data_dashboard.py`](./data_dashboard.py)               | shell, table, and chart dashboard     |
+| [`keyed_records.py`](./keyed_records.py)                 | keyed server-driven record actions    |

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -64,7 +64,7 @@ with `python -m`, then open its listed URL.
 | Present rich content           | [`webawesome_content.py`](./webawesome_content.py)       | <http://127.0.0.1:8013> | cards, carousel, comparison, formatters, Markdown, QR code, split and scroller layouts   |
 | Use browser utility components | [`webawesome_observers.py`](./webawesome_observers.py)   | <http://127.0.0.1:8014> | include, mutation, intersection and resize observers, zoomable frame                     |
 | Build a local data dashboard   | [`data_dashboard.py`](./data_dashboard.py)               | <http://127.0.0.1:8015> | shell regions, reactive table, tabs, conditional chart, local theme                      |
-| Build a live actionable list   | [`keyed_records.py`](./keyed_records.py)                 | <http://127.0.0.1:8016> | nested keyed collections, item-scoped actions, server CRUD, identity-preserving moves    |
+| Build a live actionable list   | [`keyed_records.py`](./keyed_records.py)                 | <http://127.0.0.1:8017> | nested keyed collections, item-scoped actions, server CRUD, identity-preserving moves    |
 
 Run one, for example:
 
@@ -95,7 +95,7 @@ The applications listen on:
 | `cluster.py`       | <http://127.0.0.1:8003> | clients connected to different workers receive the same bounded chart |
 | `ssr.py`           | <http://127.0.0.1:8005> | page source contains rendered elements that the browser hydrates      |
 | `gateway.py`       | <http://127.0.0.1:8006> | validated REST orders appear in the Perspective blotter               |
-| `keyed_records.py` | <http://127.0.0.1:8016> | per-record actions patch nested lists without replacing live row DOM  |
+| `keyed_records.py` | <http://127.0.0.1:8017> | per-record actions patch nested lists without replacing live row DOM  |
 
 `cluster.py` uses `tcp://127.0.0.1:5599` and `tcp://127.0.0.1:5600` for its default ZeroMQ backplane.
 Set `SPADAY_CLUSTER_FRONT` and `SPADAY_CLUSTER_BACK` when running multiple independent clusters.

--- a/spaday/examples/keyed_records.py
+++ b/spaday/examples/keyed_records.py
@@ -1,6 +1,6 @@
 """A server-driven staging queue with rich, keyed rows and no page-specific JavaScript.
 
-Run ``python -m spaday.examples.keyed_records`` and open http://127.0.0.1:8016/.
+Run ``python -m spaday.examples.keyed_records`` and open http://127.0.0.1:8017/.
 
 Every channel and record is a normal Python-authored component subtree. REST actions carry the current
 item's values to Python; transports sends the resulting model patch back. ``Each`` preserves the DOM
@@ -211,4 +211,4 @@ def create_app():
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(create_app(), host="127.0.0.1", port=8016)
+    uvicorn.run(create_app(), host="127.0.0.1", port=8017)

--- a/spaday/examples/keyed_records.py
+++ b/spaday/examples/keyed_records.py
@@ -1,0 +1,214 @@
+"""A server-driven staging queue with rich, keyed rows and no page-specific JavaScript.
+
+Run ``python -m spaday.examples.keyed_records`` and open http://127.0.0.1:8016/.
+
+Every channel and record is a normal Python-authored component subtree. REST actions carry the current
+item's values to Python; transports sends the resulting model patch back. ``Each`` preserves the DOM
+for unchanged keys, so local input, focus, and component state survive updates and reordering.
+"""
+
+from itertools import count
+
+import transports
+from pydantic import BaseModel
+from starlette.responses import JSONResponse
+from starlette.routing import Route, WebSocketRoute
+
+from spaday import CallEndpoint, Strong, Text, concat, element, item, not_, obj, scope
+from spaday.backends.starlette import serve
+from spaday.components import App, Column, Each, Footer, Main, Nav, Row, Show
+
+
+class Record(BaseModel):
+    id: int
+    package: str
+    version: str
+    ready: bool = False
+
+
+class Channel(BaseModel):
+    name: str
+    records: list[Record]
+    empty: bool = False
+
+
+class Queue(BaseModel):
+    channels: list[Channel]
+
+
+queue = Queue(
+    channels=[
+        Channel(
+            name="stable",
+            records=[
+                Record(id=1, package="spaday", version="0.4.1", ready=True),
+                Record(id=2, package="transports", version="0.5.0"),
+            ],
+        ),
+        Channel(
+            name="canary",
+            records=[Record(id=3, package="spaday-regular-table", version="0.1.0")],
+        ),
+    ]
+)
+_ids = count(4)
+_packages = ("spaday-trees", "spaday-perspective", "spaday-regular-layout")
+
+session = transports.Session()
+session.host(queue)
+server = transports.Server(session)
+
+
+def _replace_records(channel_name: str, records: list[Record]) -> None:
+    """Replace one channel immutably so transports can emit a narrow structural patch."""
+    queue.channels = [
+        channel.model_copy(update={"records": records, "empty": not records}) if channel.name == channel_name else channel
+        for channel in queue.channels
+    ]
+
+
+def _records(channel_name: str) -> list[Record]:
+    return next(channel.records for channel in queue.channels if channel.name == channel_name)
+
+
+async def add_record(request):
+    channel_name = request.path_params["channel"]
+    record_id = next(_ids)
+    record = Record(
+        id=record_id,
+        package=_packages[record_id % len(_packages)],
+        version=f"0.1.{record_id}",
+    )
+    _replace_records(channel_name, [*_records(channel_name), record])
+    return JSONResponse(record.model_dump())
+
+
+async def reverse_records(request):
+    channel_name = request.path_params["channel"]
+    _replace_records(channel_name, list(reversed(_records(channel_name))))
+    return JSONResponse({"ok": True})
+
+
+async def toggle_record(request):
+    channel_name = request.path_params["channel"]
+    record_id = request.path_params["record_id"]
+    records = [record.model_copy(update={"ready": not record.ready}) if record.id == record_id else record for record in _records(channel_name)]
+    _replace_records(channel_name, records)
+    return JSONResponse({"id": record_id})
+
+
+async def remove_record(request):
+    channel_name = request.path_params["channel"]
+    record_id = request.path_params["record_id"]
+    body = await request.json()
+    if body.get("id") != record_id:
+        return JSONResponse({"error": "body id does not match route"}, status_code=400)
+    _replace_records(channel_name, [record for record in _records(channel_name) if record.id != record_id])
+    return JSONResponse({"id": record_id})
+
+
+def record_template():
+    """One live record subtree; expressions resolve against its current item scope."""
+    endpoint = concat("/api/channels/", scope("channel.name"), "/records/", item("id"))
+    return element(
+        "article",
+        Row(
+            Column(
+                Strong(item("package")),
+                element("code").text(item("version")),
+                gap="0.2rem",
+            ),
+            Show(element("span", class_="badge ready").text("Ready"), when=item("ready")),
+            Show(element("span", class_="badge pending").text("Pending"), when=not_(item("ready"))),
+            element("button", type="button").text("Toggle ready").on("click", CallEndpoint("POST", endpoint)),
+            element("button", type="button", class_="danger").text("Remove").on("click", CallEndpoint("DELETE", endpoint, obj({"id": item("id")}))),
+            gap="0.65rem",
+        ),
+        element("input", placeholder="Local note — type here, then reverse the channel").prop("aria-label", "Local note"),
+        class_="record",
+    )
+
+
+def channel_template():
+    """One channel subtree containing a nested keyed record collection."""
+    base = concat("/api/channels/", item("name"), "/records")
+    return element(
+        "section",
+        Row(
+            element("h2").text(item("name")),
+            element("button", type="button").text("Add record").on("click", CallEndpoint("POST", base)),
+            element("button", type="button").text("Reverse order").on("click", CallEndpoint("POST", concat(base, "/reverse"))),
+            gap="0.65rem",
+        ),
+        Show(element("p", class_="empty").text("Nothing staged in this channel."), when=item("empty")),
+        Each(record_template(), items=item("records"), key="id"),
+        class_="channel",
+    )
+
+
+def build_page():
+    """Build the staging queue component tree."""
+    return App(
+        Nav(Strong("Release staging queue"), Text("server-driven · keyed · Python-authored")),
+        Main(
+            Column(
+                element("h1").text("Rich actions in live collections"),
+                element("p").text(
+                    "Add, update, remove, or reorder records. Type in a local note first: keyed reconciliation keeps it attached to the same record."
+                ),
+                Each(channel_template(), field="channels", key="name", scope="channel"),
+                gap="1rem",
+            )
+        ),
+        Footer("Each operation goes to Python; transports returns only the changed model paths. No custom JavaScript."),
+    )
+
+
+STYLE = """<style>
+body { margin: 0; font: 15px/1.45 system-ui, sans-serif; color: #18212f; background: #f4f7fb; }
+spa-app { min-height: 100vh; --spa-gap: 1rem; --spa-border: #dce3ed; --spa-surface: #fff; }
+spa-nav { color: #fff; background: #142238; }
+spa-nav span { color: #a9bdd9; }
+spa-main { width: min(960px, calc(100% - 2rem)); margin: 0 auto; }
+h1, h2, p { margin: 0; }
+h1 { font-size: 1.65rem; }
+.channel { display: grid; gap: .75rem; padding: 1rem; border: 1px solid #dce3ed; border-radius: .8rem; background: #fff; box-shadow: 0 6px 22px #1d35570d; }
+.channel h2 { margin-right: auto; font-size: 1.1rem; text-transform: capitalize; }
+.record { display: grid; gap: .65rem; padding: .85rem; border: 1px solid #e1e7f0; border-radius: .65rem; background: #fbfcfe; }
+.record spa-row > spa-stack { margin-right: auto; min-width: 13rem; }
+.record input { box-sizing: border-box; width: 100%; padding: .55rem .65rem; border: 1px solid #cbd5e1; border-radius: .45rem; }
+button { padding: .45rem .7rem; border: 1px solid #b7c5d8; border-radius: .45rem; color: #22334a; background: #fff; cursor: pointer; }
+button:hover { background: #edf3fa; }
+button.danger { color: #9f2430; border-color: #e6b8bd; }
+.badge { padding: .2rem .5rem; border-radius: 999px; font-size: .75rem; font-weight: 700; }
+.ready { color: #176b43; background: #dcf5e8; }
+.pending { color: #8a5b0b; background: #fff0c9; }
+.empty { padding: 1rem; color: #65758b; text-align: center; border: 1px dashed #cbd5e1; border-radius: .6rem; }
+code { color: #617089; }
+@media (max-width: 700px) { .record spa-row { align-items: stretch; flex-direction: column; } }
+</style>"""
+
+
+def create_app():
+    """Create the runnable Starlette application."""
+    return serve(
+        build_page,
+        wire="transports",
+        tree="frame",
+        routes=[
+            WebSocketRoute("/ws", transports.ws_endpoint(server)),
+            Route("/api/channels/{channel}/records", add_record, methods=["POST"]),
+            Route("/api/channels/{channel}/records/reverse", reverse_records, methods=["POST"]),
+            Route("/api/channels/{channel}/records/{record_id:int}", toggle_record, methods=["POST"]),
+            Route("/api/channels/{channel}/records/{record_id:int}", remove_record, methods=["DELETE"]),
+        ],
+        background=[transports.autosync(server)],
+        head=STYLE,
+        title="spaday — keyed records",
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(create_app(), host="127.0.0.1", port=8016)

--- a/spaday/render.py
+++ b/spaday/render.py
@@ -13,8 +13,8 @@ What is intentionally *not* rendered here:
   browser (full Declarative-Shadow-DOM SSR would need the component library running server-side).
 - **Events / bindings.** Attached on hydrate, not present in the HTML.
 - **Complex props** (lists / maps, e.g. a chart's ``data``) — can't be attributes; set on hydrate.
-- **``spa-show`` children** — structural reactivity is client-side, so the element renders empty and its
-  subtree is mounted during hydrate.
+- **``spa-show`` / ``spa-each`` children** — structural reactivity is client-side, so the elements render
+  empty and their subtrees are mounted during hydrate.
 """
 
 import html
@@ -49,7 +49,7 @@ def _render(node: dict, slot: str) -> str:
     inner = ""
     if text is not None:
         inner = html.escape(str(text))
-    elif tag != "spa-show":  # spa-show children are mounted client-side during hydrate
+    elif tag not in {"spa-show", "spa-each"}:  # structural children are mounted client-side during hydrate
         for slot_name, children in node.get("slots", {}).items():
             for child in children:
                 inner += _render(child, slot_name)

--- a/spaday/tests/test_actions.py
+++ b/spaday/tests/test_actions.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from spaday import apply, diff, element
 from spaday.actions import (
     CallEndpoint,
@@ -20,10 +22,12 @@ from spaday.actions import (
     cond,
     event_value,
     field,
+    item,
     lit,
     not_,
     obj,
     prop,
+    scope,
     this,
 )
 
@@ -75,6 +79,22 @@ def test_cond_wire_shape_coerces_branches_to_literals():
         "then": {"expr": "lit", "value": "dark"},
         "else": {"expr": "lit", "value": "light"},
     }
+
+
+def test_item_and_named_scope_wire_shapes():
+    assert item("record.id").to_dict() == {"expr": "item", "path": "record.id"}
+    assert item().to_dict() == {"expr": "item", "path": ""}
+    assert scope("staging.channel").to_dict() == {
+        "expr": "scope",
+        "name": "staging",
+        "path": "channel",
+    }
+    assert scope("staging").to_dict() == {"expr": "scope", "name": "staging", "path": ""}
+
+
+def test_scope_requires_a_name():
+    with pytest.raises(ValueError, match="start with a name"):
+        scope("")
 
 
 def test_logical_combinators_coerce_values_to_expressions():

--- a/spaday/tests/test_examples.py
+++ b/spaday/tests/test_examples.py
@@ -39,6 +39,25 @@ def test_serve_reactive_generates_a_bootstrap_page():
         assert page.status_code == 200 and "mount(document.body, node, store)" in page.text
 
 
+def test_keyed_records_example_serves_scoped_actions_and_crud_routes():
+    example = pytest.importorskip("spaday.examples.keyed_records", reason="needs transports + starlette")
+    from spaday.bootstrap import tree_json
+
+    tree = tree_json(example.build_page)
+    assert '"tag": "spa-each"' in tree
+    assert '"expr": "item"' in tree
+    assert '"expr": "scope"' in tree
+
+    with _client(example.create_app()) as client:
+        assert client.get("/").status_code == 200
+        added = client.post("/api/channels/stable/records").json()
+        assert added["package"]
+        toggled = client.post(f"/api/channels/stable/records/{added['id']}")
+        assert toggled.status_code == 200
+        removed = client.request("DELETE", f"/api/channels/stable/records/{added['id']}", json={"id": added["id"]})
+        assert removed.status_code == 200
+
+
 # ── Some HTML: mount() a wired panel into an existing app ─────────────────────────────────────────
 
 

--- a/spaday/tests/test_render.py
+++ b/spaday/tests/test_render.py
@@ -1,8 +1,8 @@
 """Server-side rendering: a component tree → light-DOM HTML for first paint (hydrated client-side)."""
 
 from spaday import element, render_html
-from spaday.actions import Toggle, this
-from spaday.components.shell import App, Main, Show, Stack
+from spaday.actions import Toggle, item, this
+from spaday.components.shell import App, Each, Main, Show, Stack
 
 
 def test_renders_tag_attrs_and_text():
@@ -33,6 +33,11 @@ def test_spa_show_renders_empty():
     # structural reactivity is client-side: the element renders, its subtree is mounted on hydrate
     html = render_html(Show(field="on").child(element("span").text("x")))
     assert html == '<spa-show style="display:contents"></spa-show>'
+
+
+def test_spa_each_renders_empty():
+    html = render_html(Each(element("span").compute("textContent", item("name")), field="rows", key="id"))
+    assert html == '<spa-each style="display:contents" itemKey="id"></spa-each>'
 
 
 def test_escapes_attributes_and_text():

--- a/spaday/tests/test_shell.py
+++ b/spaday/tests/test_shell.py
@@ -3,8 +3,8 @@ import json
 import pytest
 
 from spaday import Paragraph, Strong, Text, apply, diff, element
-from spaday.actions import NamedJs, field, not_
-from spaday.components.shell import App, AppShell, Body, Column, Footer, Gutter, Main, Nav, Region, Row, Show, Stack, Table, Toolbar
+from spaday.actions import NamedJs, field, item, not_
+from spaday.components.shell import App, AppShell, Body, Column, Each, Footer, Gutter, Main, Nav, Region, Row, Show, Stack, Table, Toolbar
 
 
 def test_shell_classes_emit_spa_tags():
@@ -182,6 +182,52 @@ def test_show_when_authors_a_compute_binding():
 def test_show_requires_a_condition():
     with pytest.raises(ValueError):
         Show()
+
+
+def test_each_authors_a_keyed_collection_template():
+    node = Each(element("span").compute("textContent", item("name")), field="rows", key="id", scope="row").to_node()
+
+    assert node["tag"] == "spa-each"
+    assert node["props"] == {
+        "style": {"Str": "display:contents"},
+        "itemKey": {"Str": "id"},
+        "scopeName": {"Str": "row"},
+    }
+    assert node["bindings"]["items"] == {"field": "rows", "mode": "one-way"}
+    assert node["slots"]["default"] == [
+        {
+            "tag": "span",
+            "bindings": {"textContent": {"compute": {"expr": "item", "path": "name"}, "mode": "one-way"}},
+        }
+    ]
+
+
+def test_each_accepts_a_nested_collection_expression():
+    node = Each(element("span"), items=item("records"), key="id").to_node()
+    assert node["bindings"]["items"] == {
+        "compute": {"expr": "item", "path": "records"},
+        "mode": "one-way",
+    }
+    assert "scopeName" not in node["props"]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"key": "id"}, "exactly one"),
+        ({"field": "rows", "items": item("rows"), "key": "id"}, "exactly one"),
+        ({"field": "rows", "key": ""}, "non-empty item field"),
+        ({"field": "rows", "key": "id", "scope": "outer.row"}, "without dots"),
+    ],
+)
+def test_each_validates_its_source_key_and_scope(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        Each(element("span"), **kwargs)
+
+
+def test_each_requires_one_component_template():
+    with pytest.raises(TypeError, match="one Component"):
+        Each("text", field="rows", key="id")
 
 
 def test_table_authors_a_spa_table():

--- a/spaday/tests/test_shell.py
+++ b/spaday/tests/test_shell.py
@@ -75,6 +75,12 @@ def test_component_keys_primitives_and_prop_validation():
         element("x-data", value=object()).to_node()
 
 
+def test_text_helpers_accept_reactive_expressions():
+    expected = {"textContent": {"compute": {"expr": "item", "path": "name"}, "mode": "one-way"}}
+    for component in (Text(item("name")), Strong(item("name")), Paragraph(item("name")), element("code").text(item("name"))):
+        assert component.to_node()["bindings"] == expected
+
+
 def test_app_shell_composes_named_regions_into_the_frame():
     shell = (
         AppShell()
@@ -185,7 +191,7 @@ def test_show_requires_a_condition():
 
 
 def test_each_authors_a_keyed_collection_template():
-    node = Each(element("span").compute("textContent", item("name")), field="rows", key="id", scope="row").to_node()
+    node = Each(Text(item("name")), field="rows", key="id", scope="row").to_node()
 
     assert node["tag"] == "spa-each"
     assert node["props"] == {


### PR DESCRIPTION
Add Each as a keyed structural binding with per-item and named ancestor scopes. Reconciliation reuses, inserts, removes, and reorders live component subtrees while bindings, Show conditions, reactive text, and action payloads resolve against the current item.

Inbound transports patches update only affected Store branches, with atomic fallback to the authoritative client mirror. Structural templates diff as opaque units, structural bindings can be rewired incrementally, and native DOM moves preserve opted-in custom-element state.