### PR TITLE
Adopt transports 0.6 client events

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,12 +53,6 @@ jobs:
       - name: Install dependencies
         run: make develop
 
-      - name: Install component integrations
-        run: >-
-          uv pip install
-          "spaday-webawesome @ git+https://github.com/1kbgz/spaday-webawesome.git@907c70dfed6750f5cfa208c275950f7f07b115e0"
-          "spaday-lightweight-charts @ git+https://github.com/1kbgz/spaday-lightweight-charts.git@89fe26dc163b4db4e20584b23c4d2b30f3c03451"
-
       - name: Lint
         run: make lint
         if: matrix.os == 'ubuntu-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +75,17 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -334,10 +378,11 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "transports"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e558f67f140a12124639e4c78862f7139b8e42b64be604643f0f0870220f8b23"
+checksum = "4b4d6698122a3614b8d51bf5ebbd906c3931837cc154bdd40ac633747fdf86c1"
 dependencies = [
+ "ciborium",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -392,6 +437,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -79,9 +79,15 @@ comm, in JSON or MessagePack, with multi-tenant sessions, without spaday reimple
 
 The boundary is strict and enforced in the types: spaday owns the UI (the tree, bindings, the signal
 store) and knows nothing about the wire; transports owns the wire (a `Client` that mirrors a model and
-sends edits) and knows nothing about UI. A single small adapter marries them — it sees transports only
-through a four-method interface. So you can back the same reactive store with a transports session on a
-webserver, or with the synced state of a Jupyter widget, and the UI code is identical.
+sends edits) and knows nothing about UI. A single small adapter marries them through the client's model
+access, edit, and accepted-change surface. So you can back the same reactive store with a transports
+session on a webserver, or with the synced state of a Jupyter widget, and the UI code is identical.
+
+Accepted patch paths flow directly into the affected store branches, preserving unchanged object identity
+and avoiding a full model decode. Rejected edits arrive with an authoritative snapshot that restores the
+UI; their separate rejection notification, stale revisions, and message types from newer servers do not
+cause redundant store refreshes. This keeps high-frequency updates narrow while allowing the transports
+protocol to evolve independently of the rendering runtime.
 
 ## The page generates itself
 

--- a/js/package.json
+++ b/js/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@1kbgz/transports": "^0.3.0",
+    "@1kbgz/transports": "^0.6.0",
     "@playwright/test": "^1.62.0",
     "cpy": "^13.2.2",
     "esbuild": "^0.28.0",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@1kbgz/transports':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@playwright/test':
         specifier: ^1.62.0
         version: 1.62.0
@@ -41,8 +41,8 @@ importers:
 
 packages:
 
-  '@1kbgz/transports@0.3.0':
-    resolution: {integrity: sha512-YfYAF0r/9UnsXjHRRbchTWWMQa3vMe7qHfUrM37pAt9M0uq0NhPPHuUdzZwzurChjLYZZeD3f0e/zGHQtFDfmQ==}
+  '@1kbgz/transports@0.6.0':
+    resolution: {integrity: sha512-FlTpYsxUUXyly9B3izn8MDrmnMVrHfDMtW6vkfG1Nwdxm5vMwwpMZkJxhA4Px4JN0iUUsQydG1r5D8D6H7Q5LA==}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -1250,7 +1250,7 @@ packages:
 
 snapshots:
 
-  '@1kbgz/transports@0.3.0': {}
+  '@1kbgz/transports@0.6.0': {}
 
   '@esbuild/aix-ppc64@0.28.0':
     optional: true

--- a/js/src/ts/store-sync.ts
+++ b/js/src/ts/store-sync.ts
@@ -5,7 +5,7 @@
 // authoritative model and exposes a `Client` to read/edit it. It knows nothing about UI.
 //
 // `connectStore` marries them WITHOUT importing transports: it speaks to the client through the small
-// `ModelClient` interface below — spaday's entire view of "the wire" is these four methods — and
+// `ModelClient` interface below — spaday's entire view of "the wire" — and
 // converts between the wire's tagged values and plain JS via an injected `ValueCodec` (transports'
 // `fromValue`/`toValue`). So the boundary is enforced in the types: bind a `Store` to a transports
 // model and inbound patches flow model → fields → bound props, while a two-way control's change becomes
@@ -26,6 +26,8 @@ type ReceiveChange =
 
 export interface ModelClient {
   recv(data: string | Uint8Array): ReceiveChange | undefined | void;
+  /** Accepted-change listener provided by current transports clients. Optional for older clients. */
+  onChange?(listener: (change: ReceiveChange) => void): () => void;
   ids(): number[];
   value(id: number): unknown; // the model as a tagged core Value
   edit(id: number, value: unknown): string; // an encoded edit frame to send back
@@ -161,6 +163,10 @@ function applyPlainOp(
  * form binds to. Set it false when a top-level field is an **opaque map/dict** (a chart's time-keyed
  * `data`, a Perspective layout): the field is mirrored whole, so replacing it is one store set + one edit
  * (not one per key), and `compute`/`bind` read the whole value.
+ *
+ * Current transports clients expose accepted snapshots and patches through `onChange`; `connectStore`
+ * subscribes automatically, including when the client owns the connection. With an older client,
+ * `StoreLink.receive` falls back to the value mirrored by `recv`.
  */
 export function connectStore(
   store: Store,
@@ -245,15 +251,37 @@ export function connectStore(
     }
   };
 
+  const accept = (change: ReceiveChange) => {
+    if (id === undefined) id = change.id;
+    if (change.id !== id) return;
+    inbound = true;
+    try {
+      if (change.t === "patch") receivePatch(change);
+      else receiveSnapshot();
+    } finally {
+      inbound = false;
+    }
+  };
+
+  const listensForChanges = client.onChange !== undefined;
+  if (client.onChange) unsubs.push(client.onChange(accept));
+
   return {
     receive(data) {
       const change = client.recv(data);
+      // Current transports clients deliver only accepted snapshots/patches through onChange. A stale
+      // patch, reject, or future message type therefore does no store work. Older clients have no
+      // listener API, so retain their recv-return/full-snapshot compatibility paths below.
+      if (listensForChanges) return;
+      if (change) {
+        accept(change);
+        return;
+      }
       if (id === undefined) id = client.ids()[0];
       if (id === undefined) return; // no model yet (snapshot not received)
       inbound = true;
       try {
-        if (change?.t === "patch" && change.id === id) receivePatch(change);
-        else if (!change || change.t === "snapshot") receiveSnapshot();
+        receiveSnapshot();
       } finally {
         inbound = false;
       }

--- a/js/tests/store-sync.spec.js
+++ b/js/tests/store-sync.spec.js
@@ -1,9 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 // The spaday ↔ transports seam (connectStore): bind a Store to a transports model through a fake Client
-// (recv/ids/value/edit) with an identity codec. This exercises spaday's adapter — the mapping of model
-// fields ↔ store fields ↔ bound props, and the echo guard — without transports itself, which is exactly
-// the point: the adapter's whole view of the wire is the ModelClient interface.
+// (recv/onChange/ids/value/edit) with an identity codec. This exercises spaday's adapter — the mapping
+// of model fields ↔ store fields ↔ bound props, and the echo guard — without transports itself, which
+// is exactly the point: the adapter's whole view of the wire is the ModelClient interface.
 
 // In-page: a transports-Client-shaped fake holding a plain model (recv merges an inbound frame, value
 // returns it, edit records the outbound frame), plus an identity codec since the fake stores plain JS.
@@ -37,6 +37,48 @@ const PATCH_FAKE = () => {
       const change = JSON.parse(data);
       if (change.t === "snapshot") this.model = change.value;
       return change;
+    },
+    ids() {
+      return [1];
+    },
+    value() {
+      this.valueCalls += 1;
+      return this.model;
+    },
+    edit(_id, value) {
+      return JSON.stringify(value);
+    },
+  };
+  const codec = {
+    fromCalls: 0,
+    fromValue(value) {
+      this.fromCalls += 1;
+      return value;
+    },
+    toValue: (value) => value,
+  };
+  return { client, codec };
+};
+
+const LISTENER_FAKE = () => {
+  const listeners = [];
+  const client = {
+    model: {},
+    valueCalls: 0,
+    recv(data) {
+      const change = JSON.parse(data);
+      if (change.t === "snapshot") this.model = change.value;
+      if (change.t !== "snapshot" && change.t !== "patch") return undefined;
+      if (change.stale) return undefined;
+      for (const listener of [...listeners]) listener(change);
+      return change;
+    },
+    onChange(listener) {
+      listeners.push(listener);
+      return () => listeners.splice(listeners.indexOf(listener), 1);
+    },
+    emit(change) {
+      for (const listener of [...listeners]) listener(change);
     },
     ids() {
       return [1];
@@ -251,6 +293,89 @@ test("inbound patch applies list insertion and removal without a model read", as
   expect(result).toEqual({
     rows: [5, 2],
     status: null,
+    valueCalls: 0,
+    decodedValues: 1,
+  });
+});
+
+test("onChange drives accepted updates and ignores non-change frames", async ({
+  page,
+}) => {
+  const result = await page.evaluate((makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { Store, connectStore } = window.__spaday;
+    const store = new Store();
+    const link = connectStore(store, client, () => {}, codec);
+    link.receive(
+      JSON.stringify({
+        t: "snapshot",
+        id: 1,
+        rev: 0,
+        value: { profile: { name: "old" }, rows: [1, 2] },
+      }),
+    );
+    const rows = store.get("rows");
+    let notifications = 0;
+    store.subscribe("profile.name", () => {
+      notifications += 1;
+    });
+    client.valueCalls = 0;
+    codec.fromCalls = 0;
+
+    link.receive(JSON.stringify({ t: "reject", id: 1, rev: 0, error: "bad" }));
+    link.receive(JSON.stringify({ t: "presence", id: 1 }));
+    link.receive(
+      JSON.stringify({
+        t: "patch",
+        id: 1,
+        stale: true,
+        patch: { rev: 0, ops: [] },
+      }),
+    );
+    client.emit({
+      t: "patch",
+      id: 1,
+      patch: {
+        rev: 1,
+        ops: [
+          {
+            Set: {
+              path: [{ Key: "profile" }, { Key: "name" }],
+              value: "new",
+            },
+          },
+        ],
+      },
+    });
+    link.dispose();
+    client.emit({
+      t: "patch",
+      id: 1,
+      patch: {
+        rev: 2,
+        ops: [
+          {
+            Set: {
+              path: [{ Key: "profile" }, { Key: "name" }],
+              value: "disposed",
+            },
+          },
+        ],
+      },
+    });
+    return {
+      name: store.get("profile.name"),
+      rowsPreserved: store.get("rows") === rows,
+      notifications,
+      valueCalls: client.valueCalls,
+      decodedValues: codec.fromCalls,
+    };
+  }, LISTENER_FAKE.toString());
+
+  expect(result).toEqual({
+    name: "new",
+    rowsPreserved: true,
+    notifications: 1,
     valueCalls: 0,
     decodedValues: 1,
   });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dependencies = []
 widget = ["anywidget"]
 webawesome = ["spaday-webawesome>=0.1.0"]
 lightweight-charts = ["spaday-lightweight-charts>=0.1.0"]
-examples = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets", "spaday-webawesome>=0.1.0", "spaday-lightweight-charts>=0.1.0"]
-cluster = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
-perspective = ["pydantic>=2", "transports", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6", "spaday-perspective>=0.1.0", "superstore>=0.3.1"]  # external panel + Mode B server; superstore generates the orders + chart series
+examples = ["pydantic>=2", "transports>=0.6,<0.7", "starlette", "uvicorn", "websockets", "spaday-webawesome>=0.1.0", "spaday-lightweight-charts>=0.1.0"]
+cluster = ["pydantic>=2", "transports>=0.6,<0.7", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
+perspective = ["pydantic>=2", "transports>=0.6,<0.7", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6", "spaday-perspective>=0.1.0", "superstore>=0.3.1"]  # external panel + Mode B server; superstore generates the orders + chart series
 aiohttp = ["aiohttp"]  # the aiohttp backend (spaday.backends.aiohttp)
 flask = ["flask"]  # the Flask backend (spaday.backends.flask)
 tornado = ["tornado"]  # the Tornado backend (spaday.backends.tornado)
@@ -64,11 +64,13 @@ develop = [
     "pytest",
     "pytest-cov",
     "ruff",
+    "spaday-lightweight-charts>=0.1.0",  # example gallery browser tests
     "spaday-perspective>=0.1.0",  # gateway + omnibus browser example tests
+    "spaday-webawesome>=0.1.0",  # form and example gallery browser tests
     "starlette",  # the Starlette backend — covered by test_backend_starlette (import spaday stays starlette-free)
     "superstore>=0.3.1",  # the omnibus example's data generator (orders + chart series)
     "tornado",  # the Tornado backend — covered by test_backend_tornado
-    "transports",  # reactive, form, cluster, embed, gateway, and omnibus example tests
+    "transports>=0.6,<0.7",  # reactive, form, cluster, embed, gateway, and omnibus example tests
     "twine",
     "ty",
     "uv",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,4 +18,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # spaday's prop/state `Value` IS transports' core `Value`, and its tree/patch ride transports' `Frame` +
 # codecs (see rust/src/value.rs, rust/src/wire.rs). Tracks the published transports release.
-transports = "0.4"
+transports = "0.6"


### PR DESCRIPTION
## Description

Adopt transports 0.6 across Python, JavaScript, and Rust. `connectStore` now consumes accepted changes through `Client.onChange`, applies only affected store branches, and avoids full-model refreshes for rejects, stale revisions, and future message types while retaining compatibility with older clients.

Remove temporary GitHub installs from CI now that component integrations are released. The development extra installs `spaday-webawesome` and `spaday-lightweight-charts` 0.1.x from PyPI for core example coverage.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [x] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [x] Changelog / version bump (if applicable)
