### PR TITLE
Add Pyodide worker hosting

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,11 +25,32 @@ permissions:
 
 jobs:
   build:
+    name: build (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - name: ubuntu-latest
+            dist_path: dist
+            os: ubuntu-latest
+            python: "3.11"
+            target: native
+          - name: macos-latest
+            dist_path: dist
+            os: macos-latest
+            python: "3.11"
+            target: native
+          - name: windows-latest
+            dist_path: dist
+            os: windows-latest
+            python: "3.11"
+            target: native
+          - name: pyodide
+            dist_path: dist/pyodide
+            os: ubuntu-latest
+            python: "3.14"
+            target: pyodide
 
     steps:
       - name: Checkout
@@ -40,7 +61,7 @@ jobs:
       - name: Setup Python
         uses: actions-ext/python/setup@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
-          version: "3.11"
+          version: ${{ matrix.python }}
 
       - name: Setup Rust
         uses: actions-ext/rust/setup@2db8e3e4c56beb7320c7d730bd2c2d6a6447bf6b
@@ -52,51 +73,68 @@ jobs:
 
       - name: Install dependencies
         run: make develop
+        if: matrix.target == 'native'
+
+      - name: Install Pyodide browser dependencies
+        run: |
+          make develop-js
+          rustup target add wasm32-unknown-unknown
+          cd js
+          pnpm setup
+          pnpm build
+        if: matrix.target == 'pyodide'
 
       - name: Lint
         run: make lint
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.name == 'ubuntu-latest'
 
       - name: Checks
         run: make checks
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.name == 'ubuntu-latest'
 
       - name: Build
         run: make build
+        if: matrix.target == 'native'
 
       - name: Test
         run: make coverage
+        if: matrix.target == 'native'
+
+      - name: Build and test Pyodide wheel
+        run: make test-pyodide test-pyodide-browser
+        if: matrix.target == 'pyodide'
 
       - name: Upload test results (Python)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: test-results-${{ matrix.os }}
+          name: test-results-${{ matrix.name }}
           path: '**/junit.xml'
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.name == 'ubuntu-latest'
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
         with:
           files: '**/junit.xml'
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.name == 'ubuntu-latest'
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+        if: matrix.target == 'native'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
         with:
           platforms: all
-        if: runner.os == 'Linux' && runner.arch == 'X64'
+        if: matrix.name == 'ubuntu-latest' && runner.arch == 'X64'
 
       - name: Free disk space
         run: |
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/share/swift
           df -h /
         shell: bash
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.name == 'ubuntu-latest'
 
       - name: Build distributions (Linux)
         run: |
@@ -106,7 +144,7 @@ jobs:
           make dist-py-wheel
           make dist-check
         shell: bash
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.name == 'ubuntu-latest'
 
       - name: Build distributions (macOS/Windows)
         run: |
@@ -116,22 +154,22 @@ jobs:
         shell: bash
         env:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.target == 'native' && matrix.name != 'ubuntu-latest'
 
       - name: Test wheel
         uses: actions-ext/python/test-wheel@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: spaday
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.name == 'ubuntu-latest'
 
       - name: Test source distribution
         uses: actions-ext/python/test-sdist@6e1b91a408ea89f49bc8aff8724f83826f7b5446
         with:
           module: spaday
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.name == 'ubuntu-latest'
 
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: dist-${{ matrix.os }}
-          path: dist
+          name: dist-${{ matrix.name }}
+          path: ${{ matrix.dist_path }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "transports"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4d6698122a3614b8d51bf5ebbd906c3931837cc154bdd40ac633747fdf86c1"
+checksum = "e37cd628dace67d7abeab8ae56fc9131dd4f839420759eec6a06f1c4a06c455a"
 dependencies = [
  "ciborium",
  "rmp-serde",

--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,16 @@ tests-rs: test-rs
 coverage-rs:  ## run rust tests and collect test coverage
 	make -C rust coverage
 
-.PHONY: test coverage tests
+.PHONY: test test-pyodide test-pyodide-browser coverage tests
 test: test-py test-js test-rs  ## run all tests
+test-pyodide:  ## build and test the Python package in Pyodide
+	rustup target add wasm32-unknown-emscripten
+	uvx --from cibuildwheel==4.2.0 cibuildwheel --only cp314-pyodide_wasm32 --output-dir dist/pyodide .
+test-pyodide-browser:  ## test the Pyodide worker example in a browser
+	test -n "$(firstword $(wildcard dist/pyodide/*.whl))"
+	mkdir -p js/dist/pyodide
+	cp "$(firstword $(wildcard dist/pyodide/*.whl))" js/dist/pyodide/
+	cd js; SPADAY_PYODIDE_WHEEL="/dist/pyodide/$(notdir $(firstword $(wildcard dist/pyodide/*.whl)))" pnpm exec playwright test tests/pyodide.test.js
 coverage: coverage-py coverage-js coverage-rs  ## run all tests and collect test coverage
 
 # alias

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Select an installed integration by its entry-point name, for example `serve(page
   [add behavior and reactivity](docs/src/behavior.md),
   [serve and embed an app](docs/src/serving.md),
   [use it in a notebook](docs/src/notebook.md),
+  [run Python UI logic in Pyodide](docs/src/pyodide.md),
   [sync to a server over transports](docs/src/transports.md),
   [wrap an imperative JS library](docs/src/wrappers.md),
   [generate typed classes from a manifest](docs/src/cem.md).

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -113,6 +113,13 @@ Generate a page and deliver it on any backend; see [Serve and embed](serving.md)
    :members: update, state, on_state, on_intent
 ```
 
+## Web Worker host
+
+```{eval-rst}
+.. autoclass:: spaday.WorkerApp
+   :members: start, dispatch, start_json, dispatch_json
+```
+
 ## Core diff / apply
 
 The low-level component-tree engine (JSON wire form), shared byte-for-byte with the browser runtime.

--- a/docs/src/pyodide.md
+++ b/docs/src/pyodide.md
@@ -1,0 +1,86 @@
+# How to run a spaday app in Pyodide
+
+This guide shows you how to run Python UI logic in a Web Worker and apply its component-tree patches
+on the browser's main thread.
+
+## Build the wheel and browser runtime
+
+Install the development dependencies once, then build the runtime and Pyodide wheel:
+
+```bash
+make develop
+make build-js
+make test-pyodide
+```
+
+The Python 3.14 WebAssembly wheel is written to `dist/pyodide/`.
+
+## Open the example
+
+Serve the repository root:
+
+```bash
+python -m http.server 8000
+```
+
+Open the example with the wheel URL in its query string, replacing `<wheel>` with the filename in
+`dist/pyodide/`:
+
+```text
+http://127.0.0.1:8000/js/examples/pyodide.html?wheel=/dist/pyodide/<wheel>
+```
+
+Click **Increment in Python**. The Python handler sends a transports client proposal through its
+authoritative session, renders the accepted model as a new component tree, and returns the diff.
+`connectWorker` applies that patch without replacing the button.
+
+The Python application is in [`spaday/examples/pyodide.py`](../../spaday/examples/pyodide.py). The
+worker loader is in [`js/examples/pyodide-worker.js`](../../js/examples/pyodide-worker.js), and the page
+is in [`js/examples/pyodide.html`](../../js/examples/pyodide.html).
+
+## Connect your own worker
+
+Wrap a render function and intent handler with `WorkerApp`:
+
+```python
+from spaday import SendPatch, WorkerApp, element, lit
+
+count = 0
+
+
+def render():
+    return element("button").text(str(count)).on(
+        "click", SendPatch("counter", "increment", lit(1))
+    )
+
+
+def on_intent(intent):
+    global count
+    count += intent["detail"]["value"]
+
+
+app = WorkerApp(render, on_intent)
+```
+
+The worker must send `app.start_json()` after receiving `{type: "start"}` and pass later messages to
+`app.dispatch_json(...)`. On the main thread, initialize spaday's browser runtime and connect the
+worker:
+
+```javascript
+import { connectWorker, init } from "/js/dist/esm/index.js";
+
+await init({ module_or_path: "/js/dist/pkg/spaday_bg.wasm" });
+const worker = new Worker("/worker.js", { type: "module" });
+await connectWorker(document.querySelector("#app"), worker).ready;
+```
+
+Keep DOM and custom-element work on the main thread. Keep Python rendering, state changes, and
+tree diffing in the worker.
+
+## Run the browser test
+
+Run the focused Playwright test against the wheel already in `dist/pyodide/`:
+
+```bash
+make test-pyodide-browser
+```

--- a/js/build.mjs
+++ b/js/build.mjs
@@ -58,7 +58,9 @@ async function build() {
   await cpy("dist/**/*", "../spaday/extension", {
     filter: (file) =>
       !file.relativePath.startsWith("esm/") &&
-      !file.relativePath.startsWith("dist/esm/"),
+      !file.relativePath.startsWith("dist/esm/") &&
+      !file.relativePath.startsWith("pyodide/") &&
+      !file.relativePath.startsWith("dist/pyodide/"),
   });
   await cpy(
     "node_modules/@1kbgz/transports/dist/cdn/index.js*",

--- a/js/examples/pyodide-worker.js
+++ b/js/examples/pyodide-worker.js
@@ -1,0 +1,35 @@
+const PYODIDE_VERSION = "314.0.4";
+const wheel = new URL(self.location.href).searchParams.get("wheel") || "spaday";
+
+const ready = (async () => {
+  self.postMessage({ type: "status", message: "Loading Pyodide…" });
+  const { loadPyodide } = await import(
+    `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/pyodide.mjs`
+  );
+  const pyodide = await loadPyodide();
+  self.postMessage({ type: "status", message: "Installing spaday…" });
+  await pyodide.loadPackage("micropip");
+  pyodide.globals.set("wheel", wheel);
+  await pyodide.runPythonAsync(`
+import micropip
+await micropip.install([wheel, "transports==0.7.0"])
+
+from spaday.examples.pyodide import app
+`);
+  self.postMessage({ type: "status", message: "Starting Python app…" });
+  return pyodide;
+})();
+
+self.addEventListener("message", async (event) => {
+  try {
+    const pyodide = await ready;
+    if (event.data.type === "start") {
+      self.postMessage(JSON.parse(pyodide.runPython("app.start_json()")));
+      return;
+    }
+    pyodide.globals.set("intent_json", JSON.stringify(event.data));
+    self.postMessage(JSON.parse(pyodide.runPython("app.dispatch_json(intent_json)")));
+  } catch (error) {
+    self.postMessage({ type: "error", message: String(error) });
+  }
+});

--- a/js/examples/pyodide.html
+++ b/js/examples/pyodide.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>spaday in Pyodide</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+        background: #0b1020;
+        color: #e8ecf7;
+      }
+      body { display: grid; min-height: 100vh; margin: 0; place-items: center; }
+      main { width: min(42rem, calc(100% - 2rem)); }
+      #status { color: #aab4cc; }
+      #counter-card {
+        padding: 2rem;
+        border: 1px solid #26304a;
+        border-radius: 1rem;
+        background: #121a2f;
+        box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 25%);
+      }
+      .eyebrow { margin: 0; color: #78dce8; font-size: 0.75rem; letter-spacing: 0.1em; }
+      h1 { margin: 0.5rem 0 0.75rem; font-size: clamp(2rem, 6vw, 3.5rem); line-height: 1; }
+      .intro { color: #aab4cc; line-height: 1.6; }
+      .counter { display: flex; align-items: baseline; justify-content: space-between; margin: 2rem 0 1rem; padding: 1rem; border-radius: 0.75rem; background: #0b1020; }
+      .label { color: #7f8aa3; }
+      #count { color: #61d095; font-size: 2rem; }
+      button { padding: 0.75rem 1rem; border: 1px solid #394563; border-radius: 0.6rem; background: #1a2540; color: inherit; cursor: pointer; font: inherit; }
+      button:hover { border-color: #78dce8; }
+      #error { color: #ff8f9c; white-space: pre-wrap; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p id="status">Loading Python worker…</p>
+      <div id="app"></div>
+      <p id="error" hidden></p>
+    </main>
+    <script type="module">
+      import { connectWorker, init } from "../dist/esm/index.js";
+
+      const params = new URLSearchParams(location.search);
+      const workerUrl = new URL("./pyodide-worker.js", location.href);
+      if (params.has("wheel")) workerUrl.searchParams.set("wheel", params.get("wheel"));
+
+      try {
+        await init({ module_or_path: "../dist/pkg/spaday_bg.wasm" });
+        const worker = new Worker(workerUrl, { type: "module" });
+        worker.addEventListener("message", (event) => {
+          if (event.data.type === "status") {
+            document.querySelector("#status").textContent = event.data.message;
+          }
+        });
+        const link = connectWorker(document.querySelector("#app"), worker);
+        await link.ready;
+        document.documentElement.dataset.ready = "true";
+        document.querySelector("#status").textContent = "Python worker ready";
+      } catch (error) {
+        document.documentElement.dataset.error = "true";
+        document.querySelector("#status").textContent = "Unable to start";
+        const output = document.querySelector("#error");
+        output.hidden = false;
+        output.textContent = String(error);
+      }
+    </script>
+  </body>
+</html>

--- a/js/package.json
+++ b/js/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@1kbgz/transports": "^0.6.0",
+    "@1kbgz/transports": "^0.7.0",
     "@playwright/test": "^1.62.0",
     "cpy": "^13.2.2",
     "esbuild": "^0.28.0",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@1kbgz/transports':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.0
+        version: 0.7.0
       '@playwright/test':
         specifier: ^1.62.0
         version: 1.62.0
@@ -44,8 +44,8 @@ importers:
 
 packages:
 
-  '@1kbgz/transports@0.6.0':
-    resolution: {integrity: sha512-FlTpYsxUUXyly9B3izn8MDrmnMVrHfDMtW6vkfG1Nwdxm5vMwwpMZkJxhA4Px4JN0iUUsQydG1r5D8D6H7Q5LA==}
+  '@1kbgz/transports@0.7.0':
+    resolution: {integrity: sha512-y5LMt2/jVBGZvLYGaoNIAyK0UyAzxNuFwfAI0UmTU3R2VThF8KNtqBZBM6+pROwCa93tBTIZ2QrKpxJb1O4YHQ==}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -1522,7 +1522,7 @@ packages:
 
 snapshots:
 
-  '@1kbgz/transports@0.6.0': {}
+  '@1kbgz/transports@0.7.0': {}
 
   '@esbuild/aix-ppc64@0.28.0':
     optional: true

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -67,6 +67,10 @@ export type { ActionContext } from "./actions";
 export { registerHandler } from "./handlers";
 export type { NamedHandler } from "./handlers";
 
+// Web Worker host: Python owns tree state while this main-thread link owns and patches the DOM.
+export { connectWorker } from "./worker";
+export type { WorkerLink } from "./worker";
+
 // High-level layout/shell primitives — defines the spa-* custom elements on import.
 export { SHELL_TAGS } from "./shell";
 

--- a/js/src/ts/worker.ts
+++ b/js/src/ts/worker.ts
@@ -1,0 +1,75 @@
+import { applyPatch, mount, Node } from "./runtime";
+
+interface SnapshotMessage {
+  type: "snapshot";
+  tree: Node;
+}
+
+interface PatchMessage {
+  type: "patch";
+  patch: Parameters<typeof applyPatch>[1];
+}
+
+interface ErrorMessage {
+  type: "error";
+  message: string;
+}
+
+type WorkerMessage = SnapshotMessage | PatchMessage | ErrorMessage;
+
+export interface WorkerLink {
+  /** Resolves after the worker's initial Python-authored tree has mounted. */
+  ready: Promise<void>;
+  /** Stop forwarding intents, detach the worker listener, and remove the mounted root. */
+  dispose(): void;
+}
+
+/**
+ * Mount trees produced by a Python Web Worker and forward declarative `SendPatch` intents to it.
+ * Python computes component-tree patches; the browser applies them to the existing DOM.
+ */
+export function connectWorker(container: Element, worker: Worker): WorkerLink {
+  let root: Element | undefined;
+  let resolveReady!: () => void;
+  let rejectReady!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  const receive = (event: MessageEvent<WorkerMessage>) => {
+    const message = event.data;
+    if (message.type === "snapshot") {
+      if (root) root.remove();
+      root = mount(container, message.tree);
+      resolveReady();
+    } else if (message.type === "patch") {
+      if (!root) throw new Error("worker sent a patch before its snapshot");
+      root = applyPatch(root, message.patch);
+    } else if (message.type === "error") {
+      rejectReady(new Error(message.message));
+    }
+  };
+  const fail = (event: ErrorEvent) => rejectReady(new Error(event.message));
+  const forward = (event: Event) => {
+    worker.postMessage({
+      type: event.type,
+      detail: (event as CustomEvent).detail,
+    });
+  };
+
+  worker.addEventListener("message", receive);
+  worker.addEventListener("error", fail);
+  container.addEventListener("spaday:patch", forward);
+  worker.postMessage({ type: "start" });
+
+  return {
+    ready,
+    dispose() {
+      worker.removeEventListener("message", receive);
+      worker.removeEventListener("error", fail);
+      container.removeEventListener("spaday:patch", forward);
+      root?.remove();
+    },
+  };
+}

--- a/js/tests/examples-visual.spec.js
+++ b/js/tests/examples-visual.spec.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const REPO = fileURLToPath(new URL("../..", import.meta.url));
 const EXAMPLES_DIR = path.join(REPO, "spaday", "examples");
+const SPECIALIZED_EXAMPLES = new Set(["pyodide.py"]);
 const EXAMPLES = [
   { name: "__main__", selector: "spa-app" },
   { name: "cluster", selector: "lightweight-chart" },
@@ -88,7 +89,12 @@ async function stopExample(server) {
 function exampleFiles() {
   return fs
     .readdirSync(EXAMPLES_DIR)
-    .filter((name) => name.endsWith(".py") && name !== "__init__.py")
+    .filter(
+      (name) =>
+        name.endsWith(".py") &&
+        name !== "__init__.py" &&
+        !SPECIALIZED_EXAMPLES.has(name),
+    )
     .map((name) => name.slice(0, -3))
     .sort();
 }

--- a/js/tests/pyodide.test.js
+++ b/js/tests/pyodide.test.js
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+const wheel = process.env.SPADAY_PYODIDE_WHEEL;
+
+test("Python worker sends intents and incremental DOM patches", async ({
+  page,
+}) => {
+  test.skip(!wheel, "set SPADAY_PYODIDE_WHEEL to test the browser wheel");
+  test.setTimeout(180_000);
+
+  const url = new URL("/examples/pyodide.html", "http://127.0.0.1:3000");
+  url.searchParams.set("wheel", wheel);
+  await page.goto(url.toString());
+
+  try {
+    await expect(page.locator("html")).toHaveAttribute("data-ready", "true", {
+      timeout: 150_000,
+    });
+  } catch (error) {
+    throw new Error(
+      `${error}\nWorker status: ${await page.locator("#status").textContent()}\n${await page.locator("#error").textContent()}`,
+    );
+  }
+  await expect(page.locator("#count")).toHaveText("0");
+
+  await page.locator("#increment").evaluate((button) => {
+    button.dataset.identity = "preserved";
+  });
+  await page.locator("#increment").click();
+
+  await expect(page.locator("#count")).toHaveText("1");
+  await expect(page.locator("#increment")).toHaveAttribute(
+    "data-identity",
+    "preserved",
+  );
+});

--- a/js/tests/runtime.html
+++ b/js/tests/runtime.html
@@ -15,6 +15,7 @@
         Store,
         Scope,
         connectStore,
+        connectWorker,
       } from "/dist/esm/index.js";
       await init({ module_or_path: "/dist/pkg/spaday_bg.wasm" }); // the action interpreter runs in wasm
       window.__spaday = {
@@ -27,6 +28,7 @@
         Store,
         Scope,
         connectStore,
+        connectWorker,
       };
     </script>
   </head>

--- a/js/tests/worker.spec.js
+++ b/js/tests/worker.spec.js
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/tests/runtime.html");
+  await page.waitForFunction(() => window.__spaday);
+});
+
+test("worker snapshots, receives an intent, and patches existing DOM", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async () => {
+    class FakeWorker extends EventTarget {
+      messages = [];
+
+      postMessage(message) {
+        this.messages.push(message);
+        if (message.type === "start") {
+          this.dispatchEvent(
+            new MessageEvent("message", {
+              data: {
+                type: "snapshot",
+                tree: {
+                  tag: "button",
+                  props: { textContent: { Str: "0" } },
+                  events: {
+                    click: {
+                      kind: "patch",
+                      model: "counter",
+                      field: "increment",
+                      value: { expr: "lit", value: 1 },
+                    },
+                  },
+                },
+              },
+            }),
+          );
+        } else {
+          this.dispatchEvent(
+            new MessageEvent("message", {
+              data: {
+                type: "patch",
+                patch: {
+                  ops: [
+                    {
+                      SetProp: {
+                        path: [],
+                        name: "textContent",
+                        value: { Str: "1" },
+                      },
+                    },
+                  ],
+                },
+              },
+            }),
+          );
+        }
+      }
+    }
+
+    const worker = new FakeWorker();
+    const container = document.createElement("div");
+    const link = window.__spaday.connectWorker(container, worker);
+    await link.ready;
+    const button = container.querySelector("button");
+    button.dataset.identity = "preserved";
+    button.click();
+
+    return {
+      text: button.textContent,
+      identity: button.dataset.identity,
+      intent: worker.messages[1],
+    };
+  });
+
+  expect(result).toEqual({
+    text: "1",
+    identity: "preserved",
+    intent: {
+      type: "spaday:patch",
+      detail: { model: "counter", field: "increment", value: 1 },
+    },
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "hatchling",
     "hatch-js",
-    "hatch-rs",
+    "hatch-rs>=0.3.0",
 ]
 build-backend = "hatchling.build"
 
@@ -37,9 +37,9 @@ dependencies = []
 widget = ["anywidget"]
 webawesome = ["spaday-webawesome>=0.1.0"]
 lightweight-charts = ["spaday-lightweight-charts>=0.1.0"]
-examples = ["pydantic>=2", "transports>=0.6,<0.7", "starlette", "uvicorn", "websockets", "spaday-webawesome>=0.1.0", "spaday-lightweight-charts>=0.1.0"]
-cluster = ["pydantic>=2", "transports>=0.6,<0.7", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
-perspective = ["pydantic>=2", "transports>=0.6,<0.7", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6", "spaday-perspective>=0.1.0", "superstore>=0.3.1"]  # external panel + Mode B server; superstore generates the orders + chart series
+examples = ["pydantic>=2", "transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "spaday-webawesome>=0.1.0", "spaday-lightweight-charts>=0.1.0"]
+cluster = ["pydantic>=2", "transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
+perspective = ["pydantic>=2", "transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6", "spaday-perspective>=0.1.0", "superstore>=0.3.1"]  # external panel + Mode B server; superstore generates the orders + chart series
 aiohttp = ["aiohttp"]  # the aiohttp backend (spaday.backends.aiohttp)
 flask = ["flask"]  # the Flask backend (spaday.backends.flask)
 tornado = ["tornado"]  # the Tornado backend (spaday.backends.tornado)
@@ -53,7 +53,7 @@ develop = [
     "codespell",
     "flask",  # the Flask backend — covered by test_backend_flask
     "hatch-js",
-    "hatch-rs",
+    "hatch-rs>=0.3.0",
     "hatchling",
     "httpx",  # starlette TestClient backend (for test_backend_starlette)
     "mdformat",
@@ -70,7 +70,7 @@ develop = [
     "starlette",  # the Starlette backend — covered by test_backend_starlette (import spaday stays starlette-free)
     "superstore>=0.3.1",  # the omnibus example's data generator (orders + chart series)
     "tornado",  # the Tornado backend — covered by test_backend_tornado
-    "transports>=0.6,<0.7",  # reactive, form, cluster, embed, gateway, and omnibus example tests
+    "transports>=0.7,<0.8",  # reactive, form, cluster, embed, gateway, and omnibus example tests
     "twine",
     "ty",
     "uv",
@@ -149,6 +149,13 @@ archs = "arm64"
 environment = {PATH="$UserProfile\\.cargo\bin;$PATH", CARGO_TERM_COLOR="always"}
 skip = "*win32 *arm_64"
 
+[tool.cibuildwheel.pyodide]
+environment = {SKIP_HATCH_JS="1"}
+test-command = "python -m pytest {project}/spaday/tests/test_pyodide.py -v"
+test-extras = []
+test-requires = ["pytest", "transports==0.7.0"]
+xbuild-tools = ["cargo", "rustc", "rustup"]
+
 [tool.coverage.run]
 branch = true
 omit = [
@@ -168,9 +175,6 @@ fail_under = 50
 
 [tool.hatch.build]
 artifacts = [
-    "spaday/*.dll",
-    "spaday/*.dylib",
-    "spaday/*.so",
     "spaday/extension",
 ]
 
@@ -278,6 +282,7 @@ pages = [
     "docs/src/serving.md",
     "docs/src/transports.md",
     "docs/src/notebook.md",
+    "docs/src/pyodide.md",
     "docs/src/wrappers.md",
     "docs/src/cem.md",
     "docs/src/api.md",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,4 +18,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # spaday's prop/state `Value` IS transports' core `Value`, and its tree/patch ride transports' `Frame` +
 # codecs (see rust/src/value.rs, rust/src/wire.rs). Tracks the published transports release.
-transports = "0.6"
+transports = "0.7"

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -35,6 +35,7 @@ from .render import render_html
 from .spaday import apply, decode_frame, diff, encode_frame, parse_cem  # compiled Rust extension (rust/python)
 from .theme import SHELL_TOKENS
 from .validate import ValidationError, validate
+from .worker import WorkerApp
 
 __version__ = "0.5.0"
 
@@ -58,6 +59,7 @@ __all__ = [
     "Toggle",
     "ToggleField",
     "ValidationError",
+    "WorkerApp",
     # anywidget host (optional; requires the `widget` extra)
     "Widget",
     # a typed transports wire spec for a multi-model page (serve/bootstrap wire=[…])

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -29,6 +29,10 @@ Notebook examples need:
 pip install -e ".[widget]"
 ```
 
+The [Pyodide example](../../js/examples/pyodide.html) runs
+[`pyodide.py`](./pyodide.py) inside a Web Worker. Follow
+[Run a spaday app in Pyodide](../../docs/src/pyodide.md) to build its wheel and browser runtime.
+
 ## Omnibus: the complete application
 
 [`__main__.py`](./__main__.py) combines the major spaday features in one Python-authored application:

--- a/spaday/examples/pyodide.py
+++ b/spaday/examples/pyodide.py
@@ -1,0 +1,52 @@
+"""Python half of the Pyodide Web Worker example."""
+
+from pydantic import BaseModel
+from transports import Client, Server, Session, to_value
+
+from spaday import SendPatch, WorkerApp, element, lit
+
+
+class Counter(BaseModel):
+    count: int = 0
+
+
+session = Session()
+authoritative = Counter()
+model_id = session.host(authoritative)
+server = Server(session, default_codec="msgpack")
+client = Client(codec="msgpack")
+for frame in server.open("browser", "msgpack"):
+    client.recv(frame)
+
+
+def build_page():
+    return (
+        element("section", id="counter-card")
+        .child(element("p").classes("eyebrow").text("PYTHON · RUST · WEBASSEMBLY"))
+        .child(element("h1").text("spaday in a Web Worker"))
+        .child(
+            element("p")
+            .classes("intro")
+            .text("Python and transports own this model. The browser stays responsive and applies only the component-tree patch returned by Python.")
+        )
+        .child(
+            element("div")
+            .classes("counter")
+            .child(element("span").classes("label").text("Worker count"))
+            .child(element("strong", id="count").text(str(client.model(model_id, Counter).count)))
+        )
+        .child(element("button", id="increment", type="button").text("Increment in Python").on("click", SendPatch("counter", "increment", lit(1))))
+    )
+
+
+def on_intent(intent: dict) -> None:
+    detail = intent["detail"]
+    if detail["model"] == "counter" and detail["field"] == "increment":
+        proposal = client.model(model_id, Counter).model_copy()
+        proposal.count += int(detail["value"])
+        outbound = client.edit(model_id, to_value(proposal))
+        for frame in server.recv("browser", outbound)["browser"]:
+            client.recv(frame)
+
+
+app = WorkerApp(build_page, on_intent)

--- a/spaday/tests/test_examples.py
+++ b/spaday/tests/test_examples.py
@@ -104,6 +104,19 @@ def test_ssr_ships_server_rendered_markup_to_hydrate():
         assert client.get("/js/cdn/index.js").status_code == 200
 
 
+def test_pyodide_example_round_trips_a_transports_edit_into_a_tree_patch():
+    pyodide = pytest.importorskip("spaday.examples.pyodide", reason="needs transports")
+
+    snapshot = pyodide.app.start()
+    assert snapshot["type"] == "snapshot"
+    assert pyodide.authoritative.count == 0
+
+    message = pyodide.app.dispatch({"type": "spaday:patch", "detail": {"model": "counter", "field": "increment", "value": 1}})
+
+    assert pyodide.authoritative.count == 1
+    assert message["patch"]["ops"]
+
+
 # ── Notebook / anywidget: a reusable component builder + a demo wrapper ────────────────────────────
 
 

--- a/spaday/tests/test_pyodide.py
+++ b/spaday/tests/test_pyodide.py
@@ -1,0 +1,39 @@
+import sys
+
+import pytest
+from pydantic import BaseModel
+from transports import Client, Server, Session, to_value
+
+from spaday import SendPatch, WorkerApp, element, lit
+
+pytestmark = pytest.mark.skipif(sys.platform != "emscripten", reason="requires Pyodide")
+
+
+def test_worker_round_trip_uses_compiled_diff() -> None:
+    class Counter(BaseModel):
+        count: int = 0
+
+    session = Session()
+    authoritative = Counter()
+    model_id = session.host(authoritative)
+    server = Server(session, default_codec="msgpack")
+    client = Client(codec="msgpack")
+    for frame in server.open("browser", "msgpack"):
+        client.recv(frame)
+
+    def render():
+        return element("button").text(str(client.model(model_id, Counter).count)).on("click", SendPatch("counter", "increment", lit(1)))
+
+    def handle(intent: dict) -> None:
+        proposal = client.model(model_id, Counter).model_copy()
+        proposal.count += intent["detail"]["value"]
+        outbound = client.edit(model_id, to_value(proposal))
+        for frame in server.recv("browser", outbound)["browser"]:
+            client.recv(frame)
+
+    app = WorkerApp(render, handle)
+    app.start()
+    message = app.dispatch({"type": "spaday:patch", "detail": {"value": 1}})
+
+    assert authoritative.count == 1
+    assert message["patch"]["ops"] == [{"SetProp": {"path": [], "name": "textContent", "value": {"Str": "1"}}}]

--- a/spaday/tests/test_widget.py
+++ b/spaday/tests/test_widget.py
@@ -60,6 +60,7 @@ def test_extension_assets_are_present():
     # the widget loads goes missing and it fails to render. (The wasm core is inlined into the _esm
     # bundle at build time, so there is no separate wasm file to load at runtime.)
     assert widget_mod._ESM.exists()
+    assert not list(widget_mod._EXT.rglob("*.whl"))
 
 
 def test_widget_is_lazily_exported_from_the_package():

--- a/spaday/tests/test_worker.py
+++ b/spaday/tests/test_worker.py
@@ -1,0 +1,46 @@
+import json
+
+import pytest
+
+from spaday import SendPatch, WorkerApp, element, lit
+
+
+def test_worker_app_snapshots_then_patches_after_an_intent() -> None:
+    state = {"count": 0}
+
+    def render():
+        return element("button").text(str(state["count"])).on("click", SendPatch("counter", "increment", lit(1)))
+
+    def handle(intent: dict) -> None:
+        state["count"] += intent["detail"]["value"]
+
+    app = WorkerApp(render, handle)
+    snapshot = app.start()
+    message = app.dispatch({"type": "spaday:patch", "detail": {"model": "counter", "field": "increment", "value": 1}})
+
+    assert snapshot["type"] == "snapshot"
+    assert snapshot["tree"]["props"]["textContent"] == {"Str": "0"}
+    assert message == {
+        "type": "patch",
+        "patch": {"ops": [{"SetProp": {"path": [], "name": "textContent", "value": {"Str": "1"}}}]},
+    }
+
+
+def test_worker_app_json_boundary() -> None:
+    state = {"label": "before"}
+    app = WorkerApp(lambda: element("p").text(state["label"]), lambda _intent: state.update(label="after"))
+
+    assert json.loads(app.start_json())["tree"]["props"]["textContent"] == {"Str": "before"}
+    result = json.loads(app.dispatch_json('{"type":"spaday:patch","detail":{}}'))
+    assert result["patch"]["ops"][0]["SetProp"]["value"] == {"Str": "after"}
+
+
+def test_worker_app_rejects_invalid_order_and_intents() -> None:
+    app = WorkerApp(lambda: element("p"), lambda _intent: None)
+
+    with pytest.raises(RuntimeError, match=r"start\(\)"):
+        app.dispatch({"type": "spaday:patch"})
+
+    app.start()
+    with pytest.raises(ValueError, match="unsupported worker intent"):
+        app.dispatch({"type": "other"})

--- a/spaday/worker.py
+++ b/spaday/worker.py
@@ -1,0 +1,54 @@
+"""Run a Python-owned component tree behind a browser Web Worker.
+
+The worker transports snapshots and intents; the browser runtime owns the DOM. ``WorkerApp`` keeps
+the last rendered tree and returns core-generated incremental patches after Python handles an intent.
+"""
+
+import json
+from collections.abc import Callable
+
+from .component import Component
+from .spaday import diff
+
+Tree = Component | dict
+Intent = dict
+
+
+def _node(tree: Tree) -> dict:
+    return tree.to_node() if isinstance(tree, Component) else tree
+
+
+class WorkerApp:
+    """Adapt a render function and intent handler to spaday's worker message protocol."""
+
+    def __init__(self, render: Callable[[], Tree], on_intent: Callable[[Intent], None]) -> None:
+        self._render = render
+        self._on_intent = on_intent
+        self._tree: str | None = None
+
+    def start(self) -> dict:
+        """Render and return the initial tree snapshot message."""
+        tree = _node(self._render())
+        self._tree = json.dumps(tree)
+        return {"type": "snapshot", "tree": tree}
+
+    def dispatch(self, intent: Intent) -> dict:
+        """Handle one browser intent and return its incremental tree patch message."""
+        if self._tree is None:
+            raise RuntimeError("start() must be called before dispatch()")
+        if intent.get("type") != "spaday:patch":
+            raise ValueError(f"unsupported worker intent: {intent.get('type')!r}")
+
+        old = self._tree
+        self._on_intent(intent)
+        self._tree = json.dumps(_node(self._render()))
+        patch = json.loads(diff(old, self._tree))
+        return {"type": "patch", "patch": patch}
+
+    def start_json(self) -> str:
+        """Return :meth:`start` as JSON for a JavaScript worker boundary."""
+        return json.dumps(self.start())
+
+    def dispatch_json(self, intent: str) -> str:
+        """Decode a JSON intent and return :meth:`dispatch` as JSON."""
+        return json.dumps(self.dispatch(json.loads(intent)))


### PR DESCRIPTION
## Description

Add a Pyodide Web Worker host that keeps Python rendering and state work off the main thread while the browser runtime mounts and incrementally patches the DOM.

The example routes a Python-authored `SendPatch` action through a transports 0.7 client proposal and authoritative session, then renders the accepted state and applies the resulting component-tree diff without replacing live elements. The existing build matrix now produces and tests a Python 3.14 Pyodide wheel, including a real Playwright round trip.

This also updates Python, JavaScript, and Rust transports dependencies to 0.7 and prevents generated Pyodide wheels from being copied recursively into browser assets.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [x] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)
