### PR TITLE
Add component catalog contract

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -76,6 +76,16 @@ state bindings prefer `Component.bind` / `Component.compute` (above).
 .. autofunction:: spaday.classes
 ```
 
+### Component catalog schemas
+
+```{eval-rst}
+.. autoclass:: spaday.ComponentSchema
+   :members:
+
+.. autoclass:: spaday.PropertySchema
+   :members:
+```
+
 ## Serving
 
 Generate a page and deliver it on any backend; see [Serve and embed](serving.md) and
@@ -98,6 +108,7 @@ Generate a page and deliver it on any backend; see [Serve and embed](serving.md)
 .. autoclass:: spaday.ComponentPackage
 .. autofunction:: spaday.resolve_component_packages
 .. autofunction:: spaday.discover_component_packages
+.. autofunction:: spaday.discover_component_package_names
 ```
 
 ## Server-side rendering

--- a/docs/src/cem.md
+++ b/docs/src/cem.md
@@ -21,6 +21,8 @@ code = spaday.generate("custom-elements.json")   # returns the module source (ty
 
 Peer packages use this workflow for committed catalogs. For example, `spaday-webawesome` generates
 `spaday_webawesome/components.py` from its committed manifest and checks AST drift in its test suite.
+Generated classes expose their normalized CEM metadata through `Component.schema`, ready for inclusion
+in a [`ComponentPackage` catalog](serving.md).
 
 ## Build classes at runtime
 
@@ -34,6 +36,8 @@ ns = spaday.classes("custom-elements.json")                    # {"WaSwitch": <c
 WaSwitch = spaday.classes("custom-elements.json", "WaSwitch")  # or one class by name
 WaSwitch(checked=True).to_node()
 ```
+
+Runtime-generated classes expose the same `Component.schema` metadata as committed classes.
 
 ## One manifest, both bindings
 

--- a/docs/src/serving.md
+++ b/docs/src/serving.md
@@ -65,12 +65,32 @@ An integration package defines that descriptor beside its built assets:
 from pathlib import Path
 
 from spaday import ComponentPackage
+from .components import SpadayTree
 
 package = ComponentPackage(
     name="trees",
     assets_dir=Path(__file__).parent / "extension",
     assets=(("css", "trees.css"), ("js", "trees.js")),
+    components=(SpadayTree,),
 )
+```
+
+Classes generated with `spaday-cem` already contain property, event, and slot schemas. Add the public
+classes to `components` so editors and other tools can read `package.catalog` without constructing them.
+For a hand-authored component, define the same metadata explicitly:
+
+```python
+from spaday import Component, ComponentSchema, PropertySchema
+
+class DemoGauge(Component):
+    tag = "demo-gauge"
+    schema = ComponentSchema(
+        tag=tag,
+        class_name="DemoGauge",
+        props=(PropertySchema(name="value", kind="number"),),
+        events=("change",),
+        slots=("",),
+    )
 ```
 
 To make the short form `packages=["trees"]` available, publish the same object as a Python packaging
@@ -86,6 +106,9 @@ installed integration. All four backends serve each selected descriptor's `asset
 `{prefix}/components/{name}/`; `bootstrap` emits its CSS and module-script URLs from the same `assets`
 list. This registration is host-side only: component tags and props already cross the generic spaday
 tree, so an integration needs no Rust plugin.
+
+Use `discover_component_package_names()` when listing installed integrations without importing them.
+Use `resolve_component_packages()` for explicitly selected names and read each descriptor's `catalog`.
 
 ## Embed in an existing app
 

--- a/docs/src/serving.md
+++ b/docs/src/serving.md
@@ -77,6 +77,9 @@ package = ComponentPackage(
 
 Classes generated with `spaday-cem` already contain property, event, and slot schemas. Add the public
 classes to `components` so editors and other tools can read `package.catalog` without constructing them.
+`ComponentSchema` and `PropertySchema` are frozen Pydantic models, so catalog consumers can validate
+external data with `model_validate()`, serialize it with `model_dump()`, and generate JSON Schema with
+`model_json_schema()`.
 For a hand-authored component, define the same metadata explicitly:
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,15 +31,15 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 
-dependencies = []
+dependencies = ["pydantic>=2"]
 
 [project.optional-dependencies]
 widget = ["anywidget"]
 webawesome = ["spaday-webawesome>=0.1.0"]
 lightweight-charts = ["spaday-lightweight-charts>=0.1.0"]
-examples = ["pydantic>=2", "transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "spaday-webawesome>=0.1.0", "spaday-lightweight-charts>=0.1.0"]
-cluster = ["pydantic>=2", "transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
-perspective = ["pydantic>=2", "transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6", "spaday-perspective>=0.1.0", "superstore>=0.3.1"]  # external panel + Mode B server; superstore generates the orders + chart series
+examples = ["transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "spaday-webawesome>=0.1.0", "spaday-lightweight-charts>=0.1.0"]
+cluster = ["transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
+perspective = ["transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6", "spaday-perspective>=0.1.0", "superstore>=0.3.1"]  # external panel + Mode B server; superstore generates the orders + chart series
 aiohttp = ["aiohttp"]  # the aiohttp backend (spaday.backends.aiohttp)
 flask = ["flask"]  # the Flask backend (spaday.backends.flask)
 tornado = ["tornado"]  # the Tornado backend (spaday.backends.tornado)
@@ -59,7 +59,6 @@ develop = [
     "mdformat",
     "mdformat-tables>=1",
     "perspective-python>=4.5,<4.6",  # gateway + omnibus browser example tests
-    "pydantic>=2",  # example/test models
     "pyzmq",  # clustered chart browser example test
     "pytest",
     "pytest-cov",

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -28,9 +28,10 @@ from .actions import (
     this,
 )
 from .bootstrap import Wire
+from .catalog import ComponentSchema, PropertyKind, PropertySchema
 from .cem import classes, generate
 from .component import Component, Paragraph, Strong, Text, element
-from .packages import ComponentPackage, discover_component_packages, resolve_component_packages
+from .packages import ComponentPackage, discover_component_package_names, discover_component_packages, resolve_component_packages
 from .render import render_html
 from .spaday import apply, decode_frame, diff, encode_frame, parse_cem  # compiled Rust extension (rust/python)
 from .theme import SHELL_TOKENS
@@ -46,10 +47,13 @@ __all__ = [
     "Component",
     # external component-package assets (direct descriptor, Python path, or entry point)
     "ComponentPackage",
+    "ComponentSchema",
     "Emit",
     "If",
     "NamedJs",
     "Paragraph",
+    "PropertyKind",
+    "PropertySchema",
     "SendPatch",
     "Sequence",
     "SetField",
@@ -79,6 +83,7 @@ __all__ = [
     # component-tree diff/patch (compiled core)
     "diff",
     "discover_component_packages",
+    "discover_component_package_names",
     "element",
     # framed wire (tree/patch over transports' Frame + JSON/msgpack codecs)
     "encode_frame",

--- a/spaday/catalog.py
+++ b/spaday/catalog.py
@@ -1,0 +1,104 @@
+"""Serializable metadata for component catalogs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping
+
+PropertyKind = Literal["string", "boolean", "number", "enum", "json"]
+
+
+@dataclass(frozen=True)
+class PropertySchema:
+    """One editable DOM property exposed by a component."""
+
+    name: str
+    kind: PropertyKind
+    choices: tuple[str, ...] = ()
+    default: str | None = None
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "choices", tuple(self.choices))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable catalog data."""
+        value: dict[str, Any] = {"name": self.name, "kind": self.kind}
+        if self.choices:
+            value["choices"] = list(self.choices)
+        if self.default is not None:
+            value["default"] = self.default
+        if self.description is not None:
+            value["description"] = self.description
+        return value
+
+
+@dataclass(frozen=True)
+class ComponentSchema:
+    """Catalog metadata for one component class and custom-element tag."""
+
+    tag: str
+    class_name: str
+    summary: str | None = None
+    props: tuple[PropertySchema, ...] = ()
+    events: tuple[str, ...] = ()
+    slots: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "props", tuple(self.props))
+        object.__setattr__(self, "events", tuple(self.events))
+        object.__setattr__(self, "slots", tuple(self.slots))
+
+    @classmethod
+    def from_cem(cls, schema: Mapping[str, Any]) -> ComponentSchema:
+        """Build catalog metadata from spaday's normalized CEM schema."""
+        return cls(
+            tag=schema["tag_name"],
+            class_name=schema["class_name"],
+            summary=schema.get("summary"),
+            props=tuple(_property_from_cem(prop) for prop in schema.get("props", ())),
+            events=tuple(schema.get("events", ())),
+            slots=tuple(schema.get("slots", ())),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable catalog data."""
+        value: dict[str, Any] = {
+            "tag": self.tag,
+            "class_name": self.class_name,
+            "props": [prop.to_dict() for prop in self.props],
+            "events": list(self.events),
+            "slots": list(self.slots),
+        }
+        if self.summary is not None:
+            value["summary"] = self.summary
+        return value
+
+
+def _property_from_cem(prop: Mapping[str, Any]) -> PropertySchema:
+    kind, choices = _property_type(prop.get("ty"))
+    return PropertySchema(
+        name=prop["name"],
+        kind=kind,
+        choices=choices,
+        default=prop.get("default"),
+        description=prop.get("doc"),
+    )
+
+
+def _property_type(value: Any) -> tuple[PropertyKind, tuple[str, ...]]:
+    if isinstance(value, dict):
+        if "Optional" in value:
+            return _property_type(value["Optional"])
+        if "Enum" in value:
+            return "enum", tuple(value["Enum"])
+    if value == "Bool":
+        return "boolean", ()
+    if value == "Str":
+        return "string", ()
+    if value == "Number":
+        return "number", ()
+    return "json", ()
+
+
+__all__ = ["ComponentSchema", "PropertyKind", "PropertySchema"]

--- a/spaday/catalog.py
+++ b/spaday/catalog.py
@@ -2,24 +2,23 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict
 
 PropertyKind = Literal["string", "boolean", "number", "enum", "json"]
 
 
-@dataclass(frozen=True)
-class PropertySchema:
+class PropertySchema(BaseModel):
     """One editable DOM property exposed by a component."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     name: str
     kind: PropertyKind
     choices: tuple[str, ...] = ()
     default: str | None = None
     description: str | None = None
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "choices", tuple(self.choices))
 
     def to_dict(self) -> dict[str, Any]:
         """Return JSON-serializable catalog data."""
@@ -33,9 +32,10 @@ class PropertySchema:
         return value
 
 
-@dataclass(frozen=True)
-class ComponentSchema:
+class ComponentSchema(BaseModel):
     """Catalog metadata for one component class and custom-element tag."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     tag: str
     class_name: str
@@ -43,11 +43,6 @@ class ComponentSchema:
     props: tuple[PropertySchema, ...] = ()
     events: tuple[str, ...] = ()
     slots: tuple[str, ...] = ()
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "props", tuple(self.props))
-        object.__setattr__(self, "events", tuple(self.events))
-        object.__setattr__(self, "slots", tuple(self.slots))
 
     @classmethod
     def from_cem(cls, schema: Mapping[str, Any]) -> ComponentSchema:

--- a/spaday/cem.py
+++ b/spaday/cem.py
@@ -17,6 +17,7 @@ import keyword
 from pathlib import Path
 from typing import Any, overload
 
+from .catalog import ComponentSchema
 from .component import Child, Component
 from .spaday import parse_cem as _parse_cem
 
@@ -64,7 +65,16 @@ def _make_class(schema: dict) -> type[Component]:
         typed = {attr_of[p]: props.pop(p) for p in list(props) if p in attr_of}
         Component.__init__(self, *children, key=key, props=typed, **props)
 
-    return type(name, (Component,), {"tag": tag, "__doc__": schema.get("summary"), "__init__": __init__})
+    return type(
+        name,
+        (Component,),
+        {
+            "tag": tag,
+            "schema": ComponentSchema.from_cem(schema),
+            "__doc__": schema.get("summary"),
+            "__init__": __init__,
+        },
+    )
 
 
 def generate(manifest_path: str, out_path: str | None = None, *, source: str | None = None) -> str:
@@ -89,6 +99,7 @@ def render(component_schemas: list[dict], *, source: str = "a manifest") -> str:
     if typing_imports:
         lines.append(f"from typing import {', '.join(typing_imports)}")
         lines.append("")
+    lines.append("from spaday.catalog import ComponentSchema, PropertySchema")
     lines.append("from spaday.component import Child, Component")
     lines.append("")
     names = ", ".join(repr(name) for name in sorted(b.name for b in bodies))
@@ -129,6 +140,7 @@ def _render_class(schema: dict) -> _ClassBody:
     if doc:
         head.append(f'    """{doc}"""')
     head.append(f"    tag = {json.dumps(schema['tag_name'])}")
+    head.append(f"    schema = {ComponentSchema.from_cem(schema)!r}")
     head.append("")
     params.append("**props: Any")
     sig = ",\n        ".join(params)

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -10,10 +10,13 @@ Behavior is attached with :meth:`Component.on` — the declarative action DSL (s
 the runtime interprets the action in the browser on the DOM event, with no round-trip to Python.
 """
 
+from __future__ import annotations
+
 import json
-from typing import Any, Union
+from typing import Any, ClassVar, Union
 
 from .actions import Expr
+from .catalog import ComponentSchema
 
 #: The conventional name of a component's unnamed (default) slot (matches the Rust core).
 DEFAULT_SLOT = "default"
@@ -64,10 +67,12 @@ class Component:
     props as keywords — ``App(Nav("title"), Body(...), id="root")`` — or build it up fluently with
     ``.child()`` / ``.prop()``. A string child becomes a text node. Subclasses set the class attribute
     ``tag`` and forward their typed props via ``props=`` (only the ones the author set — ``None`` means
-    "leave the element's own default").
+    "leave the element's own default"). CEM-generated subclasses also set the class-level ``schema``
+    used by component catalogs; hand-authored catalog components may set it explicitly.
     """
 
     tag: str = ""
+    schema: ClassVar[ComponentSchema | None] = None
 
     def __init__(self, *children: Child, key: str | None = None, props: dict[str, Any] | None = None, **attrs: Any) -> None:
         self._key = key

--- a/spaday/packages.py
+++ b/spaday/packages.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from importlib import import_module
 from importlib.metadata import entry_points
 from pathlib import Path, PurePosixPath
+
+from .catalog import ComponentSchema
+from .component import Component
 
 ENTRY_POINT_GROUP = "spaday.component_packages"
 _PACKAGE_NAME = re.compile(r"[a-z0-9][a-z0-9._-]*\Z")
@@ -15,17 +18,21 @@ _PACKAGE_NAME = re.compile(r"[a-z0-9][a-z0-9._-]*\Z")
 
 @dataclass(frozen=True)
 class ComponentPackage:
-    """Assets that register one external component library in the browser.
+    """Assets and catalog metadata for one external component library.
 
     ``assets`` contains ``("css" | "js", relative_path)`` pairs under
     ``assets_dir``. Backends serve that directory at
     ``{prefix}/components/{name}``; :func:`spaday.bootstrap.bootstrap` emits
-    the matching tags.
+    the matching tags. ``components`` contains the package's public
+    :class:`~spaday.component.Component` subclasses. Generated CEM classes
+    already carry schemas; hand-authored classes set ``Component.schema``.
+    ``catalog`` returns those schemas without constructing components.
     """
 
     name: str
     assets_dir: Path
     assets: Sequence[tuple[str, str]]
+    components: Sequence[type[Component]] = ()
 
     def __post_init__(self) -> None:
         if not _PACKAGE_NAME.fullmatch(self.name):
@@ -40,6 +47,24 @@ class ComponentPackage:
             normalized.append((kind, asset_path.as_posix()))
         object.__setattr__(self, "assets_dir", Path(self.assets_dir))
         object.__setattr__(self, "assets", tuple(normalized))
+        components = tuple(self.components)
+        seen: set[str] = set()
+        for component in components:
+            if not isinstance(component, type) or not issubclass(component, Component):
+                raise TypeError("component package components must be Component subclasses")
+            if component.schema is None:
+                raise ValueError(f"component {component.__name__!r} does not define catalog schema")
+            if component.schema.tag != component.tag:
+                raise ValueError(f"component {component.__name__!r} schema tag does not match {component.tag!r}")
+            if component.tag in seen:
+                raise ValueError(f"component package contains duplicate tag {component.tag!r}")
+            seen.add(component.tag)
+        object.__setattr__(self, "components", components)
+
+    @property
+    def catalog(self) -> tuple[ComponentSchema, ...]:
+        """Schemas for the package's public component classes."""
+        return tuple(replace(component.schema, class_name=component.__name__) for component in self.components if component.schema is not None)
 
 
 PackageRef = ComponentPackage | str
@@ -101,3 +126,8 @@ def discover_component_packages() -> tuple[ComponentPackage, ...]:
         _require_package(candidate.load(), f"component package entry point {candidate.name!r}")
         for candidate in sorted(_installed_entry_points(), key=lambda candidate: candidate.name)
     )
+
+
+def discover_component_package_names() -> tuple[str, ...]:
+    """Return installed component-package entry-point names without loading them."""
+    return tuple(sorted({candidate.name for candidate in _installed_entry_points()}))

--- a/spaday/packages.py
+++ b/spaday/packages.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from importlib import import_module
 from importlib.metadata import entry_points
 from pathlib import Path, PurePosixPath
@@ -64,7 +64,9 @@ class ComponentPackage:
     @property
     def catalog(self) -> tuple[ComponentSchema, ...]:
         """Schemas for the package's public component classes."""
-        return tuple(replace(component.schema, class_name=component.__name__) for component in self.components if component.schema is not None)
+        return tuple(
+            component.schema.model_copy(update={"class_name": component.__name__}) for component in self.components if component.schema is not None
+        )
 
 
 PackageRef = ComponentPackage | str

--- a/spaday/tests/test_cem.py
+++ b/spaday/tests/test_cem.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from spaday import Component, apply, classes, diff, generate, parse_cem
+from spaday import Component, ComponentSchema, apply, classes, diff, generate, parse_cem
 
 FIXTURES = Path(__file__).parent / "fixtures"
 FIXTURE = str(FIXTURES / "webawesome.cem.json")
@@ -34,6 +34,45 @@ def test_generated_class_builds_a_node():
     assert node["props"]["size"] == {"Str": "large"}
     # unset props are omitted so the element keeps its own defaults
     assert "name" not in node["props"]
+
+
+def test_generated_class_exposes_catalog_schema():
+    schema = _module()["WaSwitch"].schema
+    assert isinstance(schema, ComponentSchema)
+    assert schema.tag == "wa-switch"
+    assert schema.class_name == "WaSwitch"
+    assert schema.summary == "Switches allow the user to toggle an option on or off."
+    assert schema.events == ("change", "input")
+    assert schema.slots == ("", "hint")
+
+    props = {prop.name: prop for prop in schema.props}
+    assert props["checked"].kind == "boolean"
+    assert props["checked"].default == "false"
+    assert props["checked"].description == "Draws the switch in a checked state."
+    assert props["size"].kind == "enum"
+    assert props["size"].choices == ("small", "medium", "large")
+    assert props["name"].kind == "string"
+    assert schema.to_dict()["props"][2]["choices"] == ["small", "medium", "large"]
+
+
+def test_catalog_schema_maps_all_normalized_property_kinds():
+    schema = ComponentSchema.from_cem(
+        {
+            "tag_name": "demo-values",
+            "class_name": "DemoValues",
+            "props": [
+                {"name": "count", "ty": "Number"},
+                {"name": "config", "ty": "Any"},
+                {"name": "optional", "ty": {"Optional": "Bool"}},
+            ],
+        }
+    )
+
+    assert [(prop.name, prop.kind) for prop in schema.props] == [
+        ("count", "number"),
+        ("config", "json"),
+        ("optional", "boolean"),
+    ]
 
 
 def test_typed_signatures_rendered():
@@ -72,6 +111,8 @@ def test_classes_builds_components_at_runtime():
     klasses = classes(FIXTURE)
     assert set(klasses) == {"WaSwitch", "WaButton", "WaCard"}
     assert issubclass(klasses["WaSwitch"], Component)
+    schema = klasses["WaSwitch"].schema
+    assert schema is not None and schema.tag == "wa-switch"
 
     node = klasses["WaSwitch"](checked=True, size="large").to_node()
     assert node["tag"] == "wa-switch"

--- a/spaday/tests/test_cem.py
+++ b/spaday/tests/test_cem.py
@@ -2,8 +2,9 @@ import json
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
-from spaday import Component, ComponentSchema, apply, classes, diff, generate, parse_cem
+from spaday import Component, ComponentSchema, PropertySchema, apply, classes, diff, generate, parse_cem
 
 FIXTURES = Path(__file__).parent / "fixtures"
 FIXTURE = str(FIXTURES / "webawesome.cem.json")
@@ -73,6 +74,27 @@ def test_catalog_schema_maps_all_normalized_property_kinds():
         ("config", "json"),
         ("optional", "boolean"),
     ]
+
+
+def test_catalog_schema_validates_and_serializes_with_pydantic():
+    schema = ComponentSchema.model_validate(
+        {
+            "tag": "demo-card",
+            "class_name": "DemoCard",
+            "props": [{"name": "appearance", "kind": "enum", "choices": ["filled", "outlined"]}],
+            "events": ["change"],
+            "slots": [""],
+        }
+    )
+
+    assert schema.props[0].choices == ("filled", "outlined")
+    assert schema.model_dump(mode="json")["props"][0]["choices"] == ["filled", "outlined"]
+    assert ComponentSchema.model_json_schema()["properties"]["props"]["type"] == "array"
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        PropertySchema.model_validate({"name": "value", "kind": "number", "unknown": True})
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        schema.tag = "changed"  # type: ignore[misc]
 
 
 def test_typed_signatures_rendered():

--- a/spaday/tests/test_packages.py
+++ b/spaday/tests/test_packages.py
@@ -4,16 +4,19 @@ from types import ModuleType
 import pytest
 
 import spaday.packages as package_registry
+from spaday import Component, ComponentSchema, PropertySchema
 from spaday.bootstrap import bootstrap
-from spaday.packages import ComponentPackage, discover_component_packages, resolve_component_packages
+from spaday.packages import ComponentPackage, discover_component_package_names, discover_component_packages, resolve_component_packages
 
 
 class EntryPoint:
     def __init__(self, name, package):
         self.name = name
         self.package = package
+        self.loaded = False
 
     def load(self):
+        self.loaded = True
         return self.package
 
 
@@ -40,6 +43,55 @@ def test_resolves_and_discovers_installed_entry_points(monkeypatch):
 
     assert resolve_component_packages("z-second") == (second,)
     assert discover_component_packages() == (first, second)
+
+
+def test_discovers_installed_names_without_loading_entry_points(monkeypatch):
+    candidates = [EntryPoint("z-second", object()), EntryPoint("a-first", object()), EntryPoint("a-first", object())]
+    monkeypatch.setattr(package_registry, "entry_points", lambda **_kwargs: candidates)
+
+    assert discover_component_package_names() == ("a-first", "z-second")
+    assert not any(candidate.loaded for candidate in candidates)
+
+
+def test_package_exposes_component_catalog():
+    class GeneratedCard(Component):
+        tag = "demo-card"
+        schema = ComponentSchema(
+            tag="demo-card",
+            class_name="GeneratedCard",
+            props=(PropertySchema(name="appearance", kind="enum", choices=("filled", "outlined")),),
+            slots=("", "header"),
+        )
+
+    class Card(GeneratedCard):
+        def __init__(self):
+            raise AssertionError("catalog discovery must not construct components")
+
+    package = ComponentPackage("demo", ".", (("js", "index.js"),), components=(Card,))
+
+    assert package.components == (Card,)
+    assert package.catalog[0].class_name == "Card"
+    assert package.catalog[0].to_dict() == {
+        "tag": "demo-card",
+        "class_name": "Card",
+        "props": [{"name": "appearance", "kind": "enum", "choices": ["filled", "outlined"]}],
+        "events": [],
+        "slots": ["", "header"],
+    }
+
+
+def test_package_rejects_components_without_matching_schema():
+    class MissingSchema(Component):
+        tag = "missing-schema"
+
+    class WrongSchema(Component):
+        tag = "wrong-schema"
+        schema = ComponentSchema(tag="another-tag", class_name="WrongSchema")
+
+    with pytest.raises(ValueError, match="does not define catalog schema"):
+        ComponentPackage("missing", ".", (), components=(MissingSchema,))
+    with pytest.raises(ValueError, match="schema tag does not match"):
+        ComponentPackage("wrong", ".", (), components=(WrongSchema,))
 
 
 def test_bootstrap_uses_the_same_descriptor_for_package_asset_urls(python_path_package):


### PR DESCRIPTION
## Description

Add a public component catalog contract for editors and other tooling. CEM-generated and runtime-generated component classes now retain normalized property, event, and slot schemas, while hand-authored classes can declare the same metadata directly.

Make `PropertySchema` and `ComponentSchema` frozen Pydantic models with unknown-field rejection, nested validation, standard serialization, and JSON Schema generation. Pydantic is now a core dependency; runtime-only `ComponentPackage` descriptors remain dataclasses.

Extend `ComponentPackage` with explicit public component classes and a catalog that can be read without constructing them. Add metadata-only installed-package name discovery so tools can list integrations without importing unselected packages.

Existing asset-only package descriptors remain valid because the component list defaults to empty. Existing `to_dict()` catalog output is unchanged, and Pyodide wheel installation and execution remain supported.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [ ] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)
