### PR TITLE
Propagate transport collection deltas

### DIFF
--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -631,7 +631,7 @@ function wireEach(
     for (const dependency of exprScopes(source.compute, parentScope))
       subs.push(dependency.subscribe(scheduleReconcile));
   } else if (source?.field && store) {
-    subs.push(store.subscribeCollection(source.field, scheduleDelta));
+    subs.push(store.subscribeCollection(source.field, itemKey, scheduleDelta));
   }
   let map = bindings.get(el);
   if (!map) bindings.set(el, (map = new Map()));

--- a/js/src/ts/signals.ts
+++ b/js/src/ts/signals.ts
@@ -23,6 +23,10 @@ export type CollectionDelta<Item = unknown> =
 
 type Subscriber = (value: unknown) => void;
 type CollectionSubscriber = (delta: CollectionDelta) => void;
+interface CollectionSubscription {
+  key: string;
+  subscriber: CollectionSubscriber;
+}
 type SubscriberIndex = {
   field?: Field;
   children: Map<string, SubscriberIndex>;
@@ -99,7 +103,7 @@ function setPath(
 export class Store {
   private values: Map<Field, unknown>;
   private subscribers: Map<Field, Set<Subscriber>> = new Map();
-  private collectionSubscribers: Map<Field, Set<CollectionSubscriber>> =
+  private collectionSubscribers: Map<Field, Set<CollectionSubscription>> =
     new Map();
   private subscriberIndex: SubscriberIndex = { children: new Map() };
 
@@ -212,7 +216,8 @@ export class Store {
           ? deltas
           : [{ kind: "reset", items: Array.isArray(now) ? now : [] } as const];
       for (const delta of changes) {
-        for (const cb of [...collectionSubscribers]) cb(delta);
+        for (const subscription of [...collectionSubscribers])
+          subscription.subscriber(delta);
       }
     }
   }
@@ -259,20 +264,34 @@ export class Store {
     };
   }
 
+  /** Return the shared item key for a field's structural subscribers, if they agree on one. */
+  collectionKey(field: Field): string | undefined {
+    const subscriptions = this.collectionSubscribers.get(field);
+    if (!subscriptions?.size) return undefined;
+    let key: string | undefined;
+    for (const subscription of subscriptions) {
+      if (key !== undefined && key !== subscription.key) return undefined;
+      key = subscription.key;
+    }
+    return key;
+  }
+
   /** Subscribe to keyed structural changes; ordinary `set` calls arrive as a reset. */
   subscribeCollection<Item>(
     field: Field,
+    key: string,
     cb: (delta: CollectionDelta<Item>) => void,
   ): () => void {
     const subscriber = cb as CollectionSubscriber;
+    const subscription = { key, subscriber };
     let subs = this.collectionSubscribers.get(field);
     if (!subs) {
       this.collectionSubscribers.set(field, (subs = new Set()));
       this.index(field);
     }
-    subs.add(subscriber);
+    subs.add(subscription);
     return () => {
-      subs!.delete(subscriber);
+      subs!.delete(subscription);
       if (!subs!.size && this.collectionSubscribers.get(field) === subs) {
         this.collectionSubscribers.delete(field);
         if (!this.hasSubscribers(field)) this.unindex(field);

--- a/js/src/ts/store-sync.ts
+++ b/js/src/ts/store-sync.ts
@@ -11,7 +11,12 @@
 // model and inbound patches flow model → fields → bound props, while a two-way control's change becomes
 // a server-authoritative `edit`. Swap in any object satisfying `ModelClient` and spaday is none the wiser.
 
-import { Store } from "./signals";
+import {
+  type CollectionDelta,
+  type CollectionKey,
+  type CollectionPathSegment,
+  Store,
+} from "./signals";
 
 /** Spaday's whole view of a transports `Client`: receive a frame, find the model, read it, edit it. */
 type PathSeg = { Key: string } | { Index: number };
@@ -149,6 +154,86 @@ function applyPlainOp(
   });
 }
 
+function readSegments(value: unknown, path: readonly PathSeg[]): unknown {
+  let current = value;
+  for (const segment of path) {
+    if ("Key" in segment) {
+      if (!isObj(current)) return undefined;
+      current = current[segment.Key];
+    } else {
+      if (!Array.isArray(current)) return undefined;
+      current = current[segment.Index];
+    }
+  }
+  return current;
+}
+
+function readCollectionKey(
+  item: unknown,
+  field: string,
+): CollectionKey | undefined {
+  let current = item;
+  for (const part of field.split(".")) {
+    if (Array.isArray(current)) {
+      const index = Number(part);
+      if (!Number.isSafeInteger(index) || index < 0 || index >= current.length)
+        return undefined;
+      current = current[index];
+    } else if (isObj(current)) {
+      current = current[part];
+    } else {
+      return undefined;
+    }
+  }
+  return typeof current === "string" ||
+    (typeof current === "number" && Number.isFinite(current))
+    ? current
+    : undefined;
+}
+
+function collectionPath(path: readonly PathSeg[]): CollectionPathSegment[] {
+  return path.map((segment) =>
+    "Key" in segment ? segment.Key : segment.Index,
+  );
+}
+
+function collectionDelta(
+  current: unknown,
+  next: unknown,
+  path: PathSeg[],
+  op: PatchOp,
+  itemKey: string,
+): CollectionDelta | undefined {
+  if (!Array.isArray(current) || !Array.isArray(next)) return undefined;
+  if ("Insert" in op && path.length === 0) {
+    const item = next[op.Insert.index];
+    const key = readCollectionKey(item, itemKey);
+    return key === undefined
+      ? undefined
+      : { kind: "insert", key, index: op.Insert.index, item };
+  }
+  if ("RemoveAt" in op && path.length === 0) {
+    const key = readCollectionKey(current[op.RemoveAt.index], itemKey);
+    return key === undefined ? undefined : { kind: "remove", key };
+  }
+  const [row, ...itemPath] = path;
+  if (!row || !("Index" in row)) return undefined;
+  const oldItem = current[row.Index];
+  const newItem = next[row.Index];
+  const key = readCollectionKey(oldItem, itemKey);
+  if (key === undefined || !Object.is(key, readCollectionKey(newItem, itemKey)))
+    return undefined;
+
+  let changedPath = itemPath;
+  if ("Remove" in op) changedPath = itemPath.slice(0, -1);
+  return {
+    kind: "update",
+    key,
+    path: collectionPath(changedPath),
+    value: readSegments(newItem, changedPath),
+  };
+}
+
 /**
  * Bidirectionally sync a `Store` with a transports-mirrored model. Model fields map by name to store
  * fields — and a nested sub-model flattens to dotted `parent.child` fields: inbound frames pull them
@@ -213,7 +298,14 @@ export function connectStore(
   };
 
   const receivePatch = (change: Extract<ReceiveChange, { t: "patch" }>) => {
-    const staged = new Map<string, { field: string; value: unknown }>();
+    const staged = new Map<
+      string,
+      {
+        field: string;
+        value: unknown;
+        deltas?: CollectionDelta[];
+      }
+    >();
     try {
       for (const op of change.patch.ops) {
         const body =
@@ -236,9 +328,22 @@ export function connectStore(
         const current = staged.has(key)
           ? staged.get(key)!.value
           : store.get(key);
+        const value = applyPlainOp(current, rest, op, codec);
+        const itemKey = store.collectionKey(key);
+        let deltas = staged.has(key)
+          ? staged.get(key)!.deltas
+          : itemKey
+            ? []
+            : undefined;
+        if (deltas && itemKey) {
+          const delta = collectionDelta(current, value, rest, op, itemKey);
+          if (delta) deltas.push(delta);
+          else deltas = undefined;
+        }
         staged.set(key, {
           field,
-          value: applyPlainOp(current, rest, op, codec),
+          value,
+          deltas,
         });
       }
     } catch {
@@ -246,7 +351,9 @@ export function connectStore(
       return;
     }
     for (const [key, update] of staged) {
-      store.set(key, update.value);
+      if (update.deltas && Array.isArray(update.value))
+        store.setCollection(key, update.value, update.deltas);
+      else store.set(key, update.value);
       wireField(update.field);
     }
   };

--- a/js/tests/signals.spec.js
+++ b/js/tests/signals.spec.js
@@ -401,7 +401,7 @@ test("collection subscribers receive resets while ordinary subscribers keep valu
     const values = [];
     const deltas = [];
     store.subscribe("rows", (value) => values.push(value));
-    store.subscribeCollection("rows", (delta) => deltas.push(delta));
+    store.subscribeCollection("rows", "id", (delta) => deltas.push(delta));
 
     const rows = [{ id: 1 }, { id: 2 }];
     store.set("rows", rows);
@@ -424,7 +424,7 @@ test("setCollection publishes exact deltas after storing the final collection", 
     const values = [];
     const changes = [];
     store.subscribe("rows", (value) => values.push(value));
-    store.subscribeCollection("rows", (delta) => {
+    store.subscribeCollection("rows", "id", (delta) => {
       changes.push({ delta, visible: store.get("rows") });
     });
 
@@ -463,7 +463,7 @@ test("collection-only dotted subscriptions stay indexed until unsubscribe", asyn
     const { Store } = window.__spaday;
     const store = new Store({ model: { rows: [] } });
     const deltas = [];
-    const unsubscribe = store.subscribeCollection("model.rows", (delta) =>
+    const unsubscribe = store.subscribeCollection("model.rows", "id", (delta) =>
       deltas.push(delta),
     );
     store.set("model", { rows: [{ id: 1 }] });
@@ -473,6 +473,31 @@ test("collection-only dotted subscriptions stay indexed until unsubscribe", asyn
   });
 
   expect(result).toEqual([{ kind: "reset", items: [{ id: 1 }] }]);
+});
+
+test("collection subscribers expose a key only while all repeaters agree", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { Store } = window.__spaday;
+    const store = new Store();
+    const first = store.subscribeCollection("rows", "id", () => {});
+    const shared = store.collectionKey("rows");
+    const second = store.subscribeCollection("rows", "slug", () => {});
+    const conflicted = store.collectionKey("rows") ?? null;
+    second();
+    const restored = store.collectionKey("rows");
+    first();
+    const absent = store.collectionKey("rows") ?? null;
+    return { shared, conflicted, restored, absent };
+  });
+
+  expect(result).toEqual({
+    shared: "id",
+    conflicted: null,
+    restored: "id",
+    absent: null,
+  });
 });
 
 test("subscriber paths retain ancestor and descendant notifications after index pruning", async ({

--- a/js/tests/store-sync.spec.js
+++ b/js/tests/store-sync.spec.js
@@ -298,6 +298,110 @@ test("inbound patch applies list insertion and removal without a model read", as
   });
 });
 
+test("inbound list patches reach Each as keyed collection deltas", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async (makeFake) => {
+    const { client, codec } = eval(`(${makeFake})()`);
+    const { mount, Store, connectStore } = window.__spaday;
+    class SyncProbe extends HTMLElement {
+      set label(value) {
+        this.updates = (this.updates ?? 0) + 1;
+        this.textContent = value;
+      }
+    }
+    if (!customElements.get("sync-probe"))
+      customElements.define("sync-probe", SyncProbe);
+    const store = new Store({ rows: [] });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: { itemKey: { Str: "id" } },
+        bindings: { items: { field: "rows", mode: "one-way" } },
+        slots: {
+          default: [
+            {
+              tag: "sync-probe",
+              bindings: {
+                label: {
+                  compute: { expr: "item", path: "name" },
+                  mode: "one-way",
+                },
+              },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    const link = connectStore(store, client, () => {}, codec);
+    link.receive(
+      JSON.stringify({
+        t: "snapshot",
+        id: 1,
+        value: {
+          rows: [
+            { id: 1, name: "A" },
+            { id: 2, name: "B" },
+          ],
+        },
+      }),
+    );
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    const retained = root.children[1];
+    client.valueCalls = 0;
+    codec.fromCalls = 0;
+
+    link.receive(
+      JSON.stringify({
+        t: "patch",
+        id: 1,
+        patch: {
+          rev: 1,
+          ops: [
+            {
+              Set: {
+                path: [{ Key: "rows" }, { Index: 1 }, { Key: "name" }],
+                value: "Bee",
+              },
+            },
+            {
+              Insert: {
+                path: [{ Key: "rows" }],
+                index: 2,
+                value: { id: 3, name: "C" },
+              },
+            },
+            { RemoveAt: { path: [{ Key: "rows" }], index: 0 } },
+          ],
+        },
+      }),
+    );
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    return {
+      rows: store.get("rows"),
+      values: [...root.children].map((element) => element.textContent),
+      updates: [...root.children].map((element) => element.updates),
+      retained: root.children[0] === retained,
+      valueCalls: client.valueCalls,
+      decodedValues: codec.fromCalls,
+    };
+  }, PATCH_FAKE.toString());
+
+  expect(result).toEqual({
+    rows: [
+      { id: 2, name: "Bee" },
+      { id: 3, name: "C" },
+    ],
+    values: ["Bee", "C"],
+    updates: [2, 1],
+    retained: true,
+    valueCalls: 0,
+    decodedValues: 2,
+  });
+});
+
 test("onChange drives accepted updates and ignores non-change frames", async ({
   page,
 }) => {


### PR DESCRIPTION
Let structural Store subscribers declare their item key, allowing the transport adapter to derive keyed collection changes without duplicate application configuration.

Accepted item updates, inserts, and removals now reach direct-field Each bindings as granular deltas. Ambiguous keys and unsupported positional replacements retain safe reset behavior.

Browser tests cover key agreement, transport-to-Each identity preservation, incremental scope updates, and fallback behavior.