### PR TITLE
Benchmark granular collection updates

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -104,32 +104,45 @@ _INSTALL_BENCHMARK = """
       mountPrepared();
       return metrics(started);
     },
-    async update(workload) {
+    async update(workload, granular = false) {
       const started = performance.now();
       const size = state.rows.length;
       const middle = Math.floor(size / 2);
+      const publish = (rows, deltas) => {
+        state.rows = rows;
+        if (granular) state.store.setCollection("rows", rows, deltas);
+        else state.store.set("rows", rows);
+      };
       if (workload === "append") {
-        state.rows = [...state.rows, { id: size, label: `row-${size}`, value: size }];
-        state.store.set("rows", state.rows);
+        const item = { id: size, label: `row-${size}`, value: size };
+        publish([...state.rows, item], [
+          { kind: "insert", key: size, index: size, item },
+        ]);
       } else if (workload === "front-insert") {
-        state.rows = [{ id: -1, label: "row--1", value: -1 }, ...state.rows];
-        state.store.set("rows", state.rows);
+        const item = { id: -1, label: "row--1", value: -1 };
+        publish([item, ...state.rows], [
+          { kind: "insert", key: -1, index: 0, item },
+        ]);
       } else if (workload === "random-update") {
-        state.rows = state.rows.with(middle, {
+        const item = {
           ...state.rows[middle],
           label: `updated-${middle}`,
-        });
-        state.store.set("rows", state.rows);
+        };
+        publish(state.rows.with(middle, item), [
+          { kind: "update", key: middle, path: ["label"], value: item.label },
+        ]);
       } else if (workload === "reorder") {
-        state.rows = state.rows.toReversed();
-        state.store.set("rows", state.rows);
+        if (granular) throw new Error("reorder has no granular transport operation");
+        publish(state.rows.toReversed(), []);
       } else if (workload === "burst") {
         for (let revision = 0; revision < 10; revision += 1) {
-          state.rows = state.rows.with(middle, {
+          const item = {
             ...state.rows[middle],
             label: `burst-${revision}`,
-          });
-          state.store.set("rows", state.rows);
+          };
+          publish(state.rows.with(middle, item), [
+            { kind: "update", key: middle, path: ["label"], value: item.label },
+          ]);
         }
       } else {
         throw new Error(`unknown workload: ${workload}`);

--- a/benchmarks/test_each.py
+++ b/benchmarks/test_each.py
@@ -8,13 +8,22 @@ from playwright.sync_api import Page
 SIZES = (1_000, 10_000, 100_000)
 ROUNDS = {1_000: 10, 10_000: 5, 100_000: 3}
 WORKLOADS = ("append", "front-insert", "random-update", "reorder", "burst")
+DELTA_WORKLOADS = ("append", "front-insert", "random-update", "burst")
 
 
-def _record_browser_metrics(benchmark: Any, result: dict[str, int | float | None], *, size: int, workload: str) -> None:
+def _record_browser_metrics(
+    benchmark: Any,
+    result: dict[str, int | float | None],
+    *,
+    size: int,
+    workload: str,
+    delivery: str = "reset",
+) -> None:
     benchmark.extra_info.update(
         {
             "records": size,
             "workload": workload,
+            "delivery": delivery,
             "browser_duration_ms": result["durationMs"],
             "dom_nodes": result["domNodes"],
             "heap_used_bytes": result["heapUsedBytes"],
@@ -58,3 +67,28 @@ def test_each_reconcile(benchmark: Any, runtime_page: Page, size: int, workload:
     expected_rows = size + 1 if workload in {"append", "front-insert"} else size
     assert result["rows"] == expected_rows
     _record_browser_metrics(benchmark, result, size=size, workload=workload)
+
+
+@pytest.mark.parametrize("size", SIZES, ids=lambda size: f"{size // 1_000}k")
+@pytest.mark.parametrize("workload", DELTA_WORKLOADS)
+def test_each_delta(benchmark: Any, runtime_page: Page, size: int, workload: str) -> None:
+    benchmark.group = f"each-delta-{workload}"
+
+    def setup() -> None:
+        runtime_page.evaluate("size => window.__eachBenchmark.prepareUpdate(size)", size)
+        runtime_page.request_gc()
+
+    def run() -> dict[str, int | float | None]:
+        return runtime_page.evaluate("workload => window.__eachBenchmark.update(workload, true)", workload)
+
+    result = benchmark.pedantic(run, setup=setup, rounds=ROUNDS[size], iterations=1)
+
+    expected_rows = size + 1 if workload in {"append", "front-insert"} else size
+    assert result["rows"] == expected_rows
+    _record_browser_metrics(
+        benchmark,
+        result,
+        size=size,
+        workload=workload,
+        delivery="delta",
+    )


### PR DESCRIPTION
Extend the browser-backed pytest-benchmark suite to compare keyed collection deltas with full Each reconciliation at 1k, 10k, and 100k records.

Cover append, front insert, random update, and burst workloads while retaining full-reset coverage for reorder. Record delivery mode alongside browser duration, DOM node count, and heap usage.

A local 100k random-update sample measured 65.9 ms mean for full reconciliation and 3.25 ms for the granular path.