### PR TITLE
Apply transport sequence reorders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "transports"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37cd628dace67d7abeab8ae56fc9131dd4f839420759eec6a06f1c4a06c455a"
+checksum = "28acbb451675126a0a6b71bed13d0a7ea68ad14eee2e14710c14b0d6fd195699"
 dependencies = [
  "ciborium",
  "rmp-serde",

--- a/js/examples/pyodide-worker.js
+++ b/js/examples/pyodide-worker.js
@@ -12,7 +12,7 @@ const ready = (async () => {
   pyodide.globals.set("wheel", wheel);
   await pyodide.runPythonAsync(`
 import micropip
-await micropip.install([wheel, "transports==0.7.0"])
+await micropip.install([wheel, "transports==0.8.0"])
 
 from spaday.examples.pyodide import app
 `);

--- a/js/package.json
+++ b/js/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@1kbgz/transports": "^0.7.0",
+    "@1kbgz/transports": "^0.8.0",
     "@playwright/test": "^1.62.0",
     "cpy": "^13.2.2",
     "esbuild": "^0.28.0",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@1kbgz/transports':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.8.0
+        version: 0.8.0
       '@playwright/test':
         specifier: ^1.62.0
         version: 1.62.0
@@ -44,8 +44,8 @@ importers:
 
 packages:
 
-  '@1kbgz/transports@0.7.0':
-    resolution: {integrity: sha512-y5LMt2/jVBGZvLYGaoNIAyK0UyAzxNuFwfAI0UmTU3R2VThF8KNtqBZBM6+pROwCa93tBTIZ2QrKpxJb1O4YHQ==}
+  '@1kbgz/transports@0.8.0':
+    resolution: {integrity: sha512-A7/eR7KYgKRoACjPLkdspH/Jw6RbrjExrh7yAyQbsFU1RNklCW1BXyYk7dYA4v5WseQE4Hl3AKKLaFx/NWlGGA==}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -1522,7 +1522,7 @@ packages:
 
 snapshots:
 
-  '@1kbgz/transports@0.7.0': {}
+  '@1kbgz/transports@0.8.0': {}
 
   '@esbuild/aix-ppc64@0.28.0':
     optional: true

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -368,6 +368,7 @@ type PreparedEachDelta =
   | { kind: "insert"; identity: string; index: number; item: unknown }
   | { kind: "update"; identity: string; item: unknown }
   | { kind: "move"; identity: string; index: number }
+  | { kind: "reorder"; order: string[] }
   | { kind: "remove"; identity: string };
 
 function prepareEachDeltas(
@@ -390,6 +391,22 @@ function prepareEachDeltas(
       nextOrder = items.map(([identity]) => identity);
       values = new Map(items);
       prepared.push({ kind: "reset", items });
+      continue;
+    }
+    if (delta.kind === "reorder") {
+      const sequence = currentOrder();
+      const reordered = delta.keys.map((key) => eachKeyIdentity(key, itemKey));
+      const identities = new Set(reordered);
+      if (
+        reordered.length !== sequence.length ||
+        identities.size !== reordered.length ||
+        sequence.some((identity) => !identities.has(identity))
+      )
+        throw new Error(
+          "spa-each collection reorder must contain every current key exactly once",
+        );
+      nextOrder = reordered;
+      prepared.push({ kind: "reorder", order: [...reordered] });
       continue;
     }
     const identity = eachKeyIdentity(delta.key, itemKey);
@@ -455,15 +472,18 @@ function preserveEachFocus(el: Element, mutate: () => void): void {
     el.contains(document.activeElement)
       ? document.activeElement
       : undefined;
-  const selection =
-    focused instanceof HTMLInputElement ||
-    focused instanceof HTMLTextAreaElement
-      ? ([
-          focused.selectionStart,
-          focused.selectionEnd,
-          focused.selectionDirection,
-        ] as const)
-      : undefined;
+  let selection: readonly [number, number, string | null] | undefined;
+  if (
+    (focused instanceof HTMLInputElement ||
+      focused instanceof HTMLTextAreaElement) &&
+    focused.selectionStart !== null &&
+    focused.selectionEnd !== null
+  )
+    selection = [
+      focused.selectionStart,
+      focused.selectionEnd,
+      focused.selectionDirection,
+    ];
   mutate();
   if (focused) {
     focused.focus({ preventScroll: true });
@@ -589,6 +609,10 @@ function wireEach(
           order.splice(index, 1);
           order.splice(delta.index, 0, delta.identity);
           placeAt(instances.get(delta.identity)!, delta.index, index);
+        } else if (delta.kind === "reorder") {
+          for (const [index, identity] of delta.order.entries())
+            placeAt(instances.get(identity)!, index);
+          order = [...delta.order];
         } else {
           const instance = instances.get(delta.identity)!;
           teardownTree(instance.element);

--- a/js/src/ts/signals.ts
+++ b/js/src/ts/signals.ts
@@ -19,6 +19,7 @@ export type CollectionDelta<Item = unknown> =
       value: unknown;
     }
   | { kind: "move"; key: CollectionKey; index: number }
+  | { kind: "reorder"; keys: readonly CollectionKey[] }
   | { kind: "remove"; key: CollectionKey };
 
 type Subscriber = (value: unknown) => void;

--- a/js/src/ts/store-sync.ts
+++ b/js/src/ts/store-sync.ts
@@ -24,7 +24,9 @@ type PatchOp =
   | { Set: { path: PathSeg[]; value: unknown } }
   | { Remove: { path: PathSeg[] } }
   | { Insert: { path: PathSeg[]; index: number; value: unknown } }
-  | { RemoveAt: { path: PathSeg[]; index: number } };
+  | { RemoveAt: { path: PathSeg[]; index: number } }
+  | { Move: { path: PathSeg[]; from: number; to: number } }
+  | { Reorder: { path: PathSeg[]; order: number[] } };
 type ReceiveChange =
   | { t: "snapshot"; id: number }
   | { t: "patch"; id: number; patch: { rev: number; ops: PatchOp[] } };
@@ -99,7 +101,11 @@ function updatePath(
     };
   }
   if (!Array.isArray(value)) throw new Error("patch path expected an array");
-  if (segment.Index < 0 || segment.Index >= value.length)
+  if (
+    !Number.isSafeInteger(segment.Index) ||
+    segment.Index < 0 ||
+    segment.Index >= value.length
+  )
     throw new Error(
       `patch path index ${segment.Index} out of bounds (len ${value.length})`,
     );
@@ -132,7 +138,11 @@ function applyPlainOp(
     return updatePath(current, path, (container) => {
       if (!Array.isArray(container))
         throw new Error("insert path expected an array");
-      if (op.Insert.index < 0 || op.Insert.index > container.length)
+      if (
+        !Number.isSafeInteger(op.Insert.index) ||
+        op.Insert.index < 0 ||
+        op.Insert.index > container.length
+      )
         throw new Error(
           `insert index ${op.Insert.index} out of bounds (len ${container.length})`,
         );
@@ -141,10 +151,58 @@ function applyPlainOp(
       return next;
     });
   }
+  if ("Move" in op) {
+    return updatePath(current, path, (container) => {
+      if (!Array.isArray(container))
+        throw new Error("move path expected an array");
+      if (
+        !Number.isSafeInteger(op.Move.from) ||
+        op.Move.from < 0 ||
+        op.Move.from >= container.length
+      )
+        throw new Error(
+          `move source ${op.Move.from} out of bounds (len ${container.length})`,
+        );
+      if (
+        !Number.isSafeInteger(op.Move.to) ||
+        op.Move.to < 0 ||
+        op.Move.to >= container.length
+      )
+        throw new Error(
+          `move destination ${op.Move.to} out of bounds (len ${container.length})`,
+        );
+      const next = [...container];
+      const [item] = next.splice(op.Move.from, 1);
+      next.splice(op.Move.to, 0, item);
+      return next;
+    });
+  }
+  if ("Reorder" in op) {
+    return updatePath(current, path, (container) => {
+      if (!Array.isArray(container))
+        throw new Error("reorder path expected an array");
+      if (
+        op.Reorder.order.length !== container.length ||
+        op.Reorder.order.some(
+          (index) =>
+            !Number.isSafeInteger(index) ||
+            index < 0 ||
+            index >= container.length,
+        ) ||
+        new Set(op.Reorder.order).size !== container.length
+      )
+        throw new Error("reorder order must be a complete array permutation");
+      return op.Reorder.order.map((index) => container[index]);
+    });
+  }
   return updatePath(current, path, (container) => {
     if (!Array.isArray(container))
       throw new Error("remove path expected an array");
-    if (op.RemoveAt.index < 0 || op.RemoveAt.index >= container.length)
+    if (
+      !Number.isSafeInteger(op.RemoveAt.index) ||
+      op.RemoveAt.index < 0 ||
+      op.RemoveAt.index >= container.length
+    )
       throw new Error(
         `remove index ${op.RemoveAt.index} out of bounds (len ${container.length})`,
       );
@@ -191,6 +249,74 @@ function readCollectionKey(
     : undefined;
 }
 
+function collectionDeltasMatch(
+  current: readonly unknown[],
+  next: readonly unknown[],
+  deltas: readonly CollectionDelta[],
+  itemKey: string,
+): boolean {
+  const identity = (item: unknown): string | undefined => {
+    const key = readCollectionKey(item, itemKey);
+    return key === undefined ? undefined : `${typeof key}:${key}`;
+  };
+  const order = current.map(identity);
+  const target = next.map(identity);
+  if (
+    order.includes(undefined) ||
+    target.includes(undefined) ||
+    new Set(order).size !== order.length ||
+    new Set(target).size !== target.length
+  )
+    return false;
+  for (const delta of deltas) {
+    if (delta.kind === "reset") return false;
+    if (delta.kind === "reorder") {
+      const reordered = delta.keys.map((key) => `${typeof key}:${key}`);
+      const currentKeys = new Set(order);
+      if (
+        reordered.length !== order.length ||
+        new Set(reordered).size !== reordered.length ||
+        reordered.some((key) => !currentKeys.has(key))
+      )
+        return false;
+      order.splice(0, order.length, ...reordered);
+      continue;
+    }
+    const key = `${typeof delta.key}:${delta.key}`;
+    const index = order.indexOf(key);
+    if (delta.kind === "insert") {
+      if (
+        index !== -1 ||
+        !Number.isSafeInteger(delta.index) ||
+        delta.index < 0 ||
+        delta.index > order.length ||
+        identity(delta.item) !== key
+      )
+        return false;
+      order.splice(delta.index, 0, key);
+    } else if (delta.kind === "update") {
+      if (index === -1) return false;
+    } else if (delta.kind === "move") {
+      if (
+        index === -1 ||
+        !Number.isSafeInteger(delta.index) ||
+        delta.index < 0 ||
+        delta.index >= order.length
+      )
+        return false;
+      order.splice(index, 1);
+      order.splice(delta.index, 0, key);
+    } else {
+      if (index === -1) return false;
+      order.splice(index, 1);
+    }
+  }
+  return (
+    order.length === target.length &&
+    order.every((key, index) => key === target[index])
+  );
+}
+
 function collectionPath(path: readonly PathSeg[]): CollectionPathSegment[] {
   return path.map((segment) =>
     "Key" in segment ? segment.Key : segment.Index,
@@ -215,6 +341,19 @@ function collectionDelta(
   if ("RemoveAt" in op && path.length === 0) {
     const key = readCollectionKey(current[op.RemoveAt.index], itemKey);
     return key === undefined ? undefined : { kind: "remove", key };
+  }
+  if ("Move" in op && path.length === 0) {
+    const key = readCollectionKey(current[op.Move.from], itemKey);
+    return key === undefined ||
+      !Object.is(key, readCollectionKey(next[op.Move.to], itemKey))
+      ? undefined
+      : { kind: "move", key, index: op.Move.to };
+  }
+  if ("Reorder" in op && path.length === 0) {
+    const keys = next.map((item) => readCollectionKey(item, itemKey));
+    return keys.includes(undefined)
+      ? undefined
+      : { kind: "reorder", keys: keys as CollectionKey[] };
   }
   const [row, ...itemPath] = path;
   if (!row || !("Index" in row)) return undefined;
@@ -315,7 +454,11 @@ export function connectStore(
               ? op.Remove
               : "Insert" in op
                 ? op.Insert
-                : op.RemoveAt;
+                : "RemoveAt" in op
+                  ? op.RemoveAt
+                  : "Move" in op
+                    ? op.Move
+                    : op.Reorder;
         const [head, ...rest] = body.path;
         if (!head) {
           receiveSnapshot();
@@ -351,7 +494,19 @@ export function connectStore(
       return;
     }
     for (const [key, update] of staged) {
-      if (update.deltas && Array.isArray(update.value))
+      const itemKey = store.collectionKey(key);
+      if (
+        update.deltas &&
+        itemKey &&
+        Array.isArray(update.value) &&
+        Array.isArray(store.get(key)) &&
+        collectionDeltasMatch(
+          store.get(key),
+          update.value,
+          update.deltas,
+          itemKey,
+        )
+      )
         store.setCollection(key, update.value, update.deltas);
       else store.set(key, update.value);
       wireField(update.field);

--- a/js/tests/each.spec.js
+++ b/js/tests/each.spec.js
@@ -80,6 +80,37 @@ test("spa-each reconciles keyed instances without losing live state", async ({
   });
 });
 
+test("spa-each preserves focus on non-text inputs during a move", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async () => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ rows: [{ id: 1 }, { id: 2 }] });
+    const root = mount(
+      document.body,
+      {
+        tag: "spa-each",
+        props: { itemKey: { Str: "id" } },
+        bindings: { items: { field: "rows", mode: "one-way" } },
+        slots: {
+          default: [{ tag: "input", props: { type: { Str: "number" } } }],
+        },
+      },
+      store,
+    );
+    const focused = root.children[0];
+    focused.focus();
+    store.set("rows", [{ id: 2 }, { id: 1 }]);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    return {
+      moved: root.children[1] === focused,
+      focused: document.activeElement === focused,
+    };
+  });
+
+  expect(result).toEqual({ moved: true, focused: true });
+});
+
 test("spa-each applies granular collection changes without resetting unchanged scopes", async ({
   page,
 }) => {
@@ -127,7 +158,7 @@ test("spa-each applies granular collection changes without resetting unchanged s
       [three, updatedOne, four],
       [
         { kind: "update", key: 1, path: ["label"], value: "AA" },
-        { kind: "move", key: 1, index: 2 },
+        { kind: "reorder", keys: [3, 1, 2] },
         { kind: "remove", key: 2 },
         { kind: "insert", key: 4, index: 2, item: four },
       ],

--- a/js/tests/store-sync.spec.js
+++ b/js/tests/store-sync.spec.js
@@ -245,7 +245,7 @@ test("inbound patch updates only its changed store branch", async ({
   });
 });
 
-test("inbound patch applies list insertion and removal without a model read", async ({
+test("inbound patch applies list insertion, removal, and moves without a model read", async ({
   page,
 }) => {
   const result = await page.evaluate((makeFake) => {
@@ -277,6 +277,7 @@ test("inbound patch applies list insertion and removal without a model read", as
               },
             },
             { RemoveAt: { path: [{ Key: "rows" }], index: 0 } },
+            { Move: { path: [{ Key: "rows" }], from: 0, to: 1 } },
             { Remove: { path: [{ Key: "status" }] } },
           ],
         },
@@ -291,7 +292,7 @@ test("inbound patch applies list insertion and removal without a model read", as
   }, PATCH_FAKE.toString());
 
   expect(result).toEqual({
-    rows: [5, 2],
+    rows: [2, 5],
     status: null,
     valueCalls: 0,
     decodedValues: 1,
@@ -373,7 +374,34 @@ test("inbound list patches reach Each as keyed collection deltas", async ({
                 value: { id: 3, name: "C" },
               },
             },
-            { RemoveAt: { path: [{ Key: "rows" }], index: 0 } },
+            {
+              Reorder: {
+                path: [{ Key: "rows" }],
+                order: [1, 0, 2],
+              },
+            },
+            { RemoveAt: { path: [{ Key: "rows" }], index: 1 } },
+          ],
+        },
+      }),
+    );
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    const inserted = root.children[1];
+    link.receive(
+      JSON.stringify({
+        t: "patch",
+        id: 1,
+        patch: {
+          rev: 2,
+          ops: [
+            {
+              Insert: {
+                path: [{ Key: "rows" }],
+                index: 0,
+                value: { id: 3, name: "See" },
+              },
+            },
+            { RemoveAt: { path: [{ Key: "rows" }], index: 2 } },
           ],
         },
       }),
@@ -382,8 +410,8 @@ test("inbound list patches reach Each as keyed collection deltas", async ({
     return {
       rows: store.get("rows"),
       values: [...root.children].map((element) => element.textContent),
-      updates: [...root.children].map((element) => element.updates),
-      retained: root.children[0] === retained,
+      retained: root.children[1] === retained,
+      changedMoveRetained: root.children[0] === inserted,
       valueCalls: client.valueCalls,
       decodedValues: codec.fromCalls,
     };
@@ -391,14 +419,14 @@ test("inbound list patches reach Each as keyed collection deltas", async ({
 
   expect(result).toEqual({
     rows: [
+      { id: 3, name: "See" },
       { id: 2, name: "Bee" },
-      { id: 3, name: "C" },
     ],
-    values: ["Bee", "C"],
-    updates: [2, 1],
+    values: ["See", "Bee"],
     retained: true,
+    changedMoveRetained: true,
     valueCalls: 0,
-    decodedValues: 2,
+    decodedValues: 3,
   });
 });
 
@@ -485,60 +513,75 @@ test("onChange drives accepted updates and ignores non-change frames", async ({
   });
 });
 
-test("an invalid patch falls back atomically to the client snapshot", async ({
-  page,
-}) => {
-  const result = await page.evaluate((makeFake) => {
-    const { client, codec } = eval(`(${makeFake})()`);
-    const { Store, connectStore } = window.__spaday;
-    const store = new Store();
-    const link = connectStore(store, client, () => {}, codec, undefined, false);
-    link.receive(
-      JSON.stringify({
-        t: "snapshot",
-        id: 1,
-        value: { profile: { name: "old" }, rows: [1] },
-      }),
-    );
-    let profileNotifications = 0;
-    store.subscribe("profile", () => {
-      profileNotifications += 1;
-    });
-    client.model = { profile: { name: "server" }, rows: [9] };
-    client.valueCalls = 0;
-    link.receive(
-      JSON.stringify({
-        t: "patch",
-        id: 1,
-        patch: {
-          rev: 1,
-          ops: [
-            {
-              Set: {
-                path: [{ Key: "profile" }, { Key: "name" }],
-                value: "transient",
-              },
+for (const [name, invalidOp] of [
+  ["fractional move", { Move: { path: [{ Key: "rows" }], from: 0.5, to: 0 } }],
+  ["invalid reorder", { Reorder: { path: [{ Key: "rows" }], order: [0, 0] } }],
+]) {
+  test(`${name} falls back atomically to the client snapshot`, async ({
+    page,
+  }) => {
+    const result = await page.evaluate(
+      ({ makeFake, invalidOp }) => {
+        const { client, codec } = eval(`(${makeFake})()`);
+        const { Store, connectStore } = window.__spaday;
+        const store = new Store();
+        const link = connectStore(
+          store,
+          client,
+          () => {},
+          codec,
+          undefined,
+          false,
+        );
+        link.receive(
+          JSON.stringify({
+            t: "snapshot",
+            id: 1,
+            value: { profile: { name: "old" }, rows: [1] },
+          }),
+        );
+        let profileNotifications = 0;
+        store.subscribe("profile", () => {
+          profileNotifications += 1;
+        });
+        client.model = { profile: { name: "server" }, rows: [9] };
+        client.valueCalls = 0;
+        link.receive(
+          JSON.stringify({
+            t: "patch",
+            id: 1,
+            patch: {
+              rev: 1,
+              ops: [
+                {
+                  Set: {
+                    path: [{ Key: "profile" }, { Key: "name" }],
+                    value: "transient",
+                  },
+                },
+                invalidOp,
+              ],
             },
-            { RemoveAt: { path: [{ Key: "rows" }], index: 5 } },
-          ],
-        },
-      }),
+          }),
+        );
+        return {
+          profile: store.get("profile"),
+          rows: store.get("rows"),
+          profileNotifications,
+          valueCalls: client.valueCalls,
+        };
+      },
+      { makeFake: PATCH_FAKE.toString(), invalidOp },
     );
-    return {
-      profile: store.get("profile"),
-      rows: store.get("rows"),
-      profileNotifications,
-      valueCalls: client.valueCalls,
-    };
-  }, PATCH_FAKE.toString());
 
-  expect(result).toEqual({
-    profile: { name: "server" },
-    rows: [9],
-    profileNotifications: 1,
-    valueCalls: 1,
+    expect(result).toEqual({
+      profile: { name: "server" },
+      rows: [9],
+      profileNotifications: 1,
+      valueCalls: 1,
+    });
   });
-});
+}
 
 test("inbound: a nested sub-model field flows to a dotted-path binding", async ({
   page,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dependencies = ["pydantic>=2"]
 widget = ["anywidget"]
 webawesome = ["spaday-webawesome>=0.1.0"]
 lightweight-charts = ["spaday-lightweight-charts>=0.1.0"]
-examples = ["transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "spaday-webawesome>=0.1.0", "spaday-lightweight-charts>=0.1.0"]
-cluster = ["transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
-perspective = ["transports>=0.7,<0.8", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6", "spaday-perspective>=0.1.0", "superstore>=0.3.1"]  # external panel + Mode B server; superstore generates the orders + chart series
+examples = ["transports>=0.8,<0.9", "starlette", "uvicorn", "websockets", "spaday-webawesome>=0.1.0", "spaday-lightweight-charts>=0.1.0"]
+cluster = ["transports>=0.8,<0.9", "starlette", "uvicorn", "websockets", "pyzmq"]  # the multi-worker example (needs a transports with the clustering API)
+perspective = ["transports>=0.8,<0.9", "starlette", "uvicorn", "websockets", "perspective-python>=4.5,<4.6", "spaday-perspective>=0.1.0", "superstore>=0.3.1"]  # external panel + Mode B server; superstore generates the orders + chart series
 aiohttp = ["aiohttp"]  # the aiohttp backend (spaday.backends.aiohttp)
 flask = ["flask"]  # the Flask backend (spaday.backends.flask)
 tornado = ["tornado"]  # the Tornado backend (spaday.backends.tornado)
@@ -71,7 +71,7 @@ develop = [
     "starlette",  # the Starlette backend — covered by test_backend_starlette (import spaday stays starlette-free)
     "superstore>=0.3.1",  # the omnibus example's data generator (orders + chart series)
     "tornado",  # the Tornado backend — covered by test_backend_tornado
-    "transports>=0.7,<0.8",  # reactive, form, cluster, embed, gateway, and omnibus example tests
+    "transports>=0.8,<0.9",  # reactive, form, cluster, embed, gateway, and omnibus example tests
     "twine",
     "ty",
     "uv",
@@ -154,7 +154,7 @@ skip = "*win32 *arm_64"
 environment = {SKIP_HATCH_JS="1"}
 test-command = "python -m pytest {project}/spaday/tests/test_pyodide.py -v"
 test-extras = []
-test-requires = ["pytest", "transports==0.7.0"]
+test-requires = ["pytest", "transports==0.8.0"]
 xbuild-tools = ["cargo", "rustc", "rustup"]
 
 [tool.coverage.run]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,4 +18,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # spaday's prop/state `Value` IS transports' core `Value`, and its tree/patch ride transports' `Frame` +
 # codecs (see rust/src/value.rs, rust/src/wire.rs). Tracks the published transports release.
-transports = "0.7"
+transports = "0.8"

--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -328,6 +328,9 @@ class Sequence(Action):
     """Run several actions in order."""
 
     def __init__(self, *actions: Action) -> None:
+        for action in actions:
+            if not isinstance(action, Action):
+                raise TypeError(f"Sequence entries must be Actions, got {type(action).__name__}")
         self.actions: list[Action] = list(actions)
 
     def to_dict(self) -> dict[str, Any]:
@@ -365,6 +368,10 @@ class If(Action):
     ``If(prop(by_id("sw"), "checked"), SetProp(...), SetProp(...))``."""
 
     def __init__(self, cond: Any, then: Action, els: Action | None = None) -> None:
+        if not isinstance(then, Action):
+            raise TypeError(f"If then branch must be an Action, got {type(then).__name__}")
+        if els is not None and not isinstance(els, Action):
+            raise TypeError(f"If else branch must be an Action or None, got {type(els).__name__}")
         self.cond, self.then, self.els = cond, then, els
 
     def to_dict(self) -> dict[str, Any]:

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 from typing import Any, ClassVar, Union
 
-from .actions import Expr
+from .actions import Action, Expr
 from .catalog import ComponentSchema
 
 #: The conventional name of a component's unnamed (default) slot (matches the Rust core).
@@ -99,6 +99,8 @@ class Component:
 
     def child_in(self, slot: str, node: Child) -> "Component":
         """Append a child to a named slot (a string becomes a ``<span>`` text node)."""
+        if not isinstance(node, (Component, dict, str)):
+            raise TypeError(f"child must be a Component, node dict, or string, got {type(node).__name__}")
         self._slots.setdefault(slot, []).append(element("span", textContent=node) if isinstance(node, str) else node)
         return self
 
@@ -144,12 +146,14 @@ class Component:
         self._classes.extend(n for n in names if n)
         return self
 
-    def on(self, event: str, action: Any) -> "Component":
+    def on(self, event: str, action: Action) -> "Component":
         """Bind a declarative :class:`~spaday.actions.Action` to a DOM event (e.g. ``"click"``).
 
         The action is serialized as data and interpreted in the browser when the event fires — no
         round-trip to Python.
         """
+        if not isinstance(action, Action):
+            raise TypeError(f"event action must be an Action, got {type(action).__name__}")
         self._events[event] = action.to_dict()
         return self
 
@@ -165,13 +169,15 @@ class Component:
         self._bindings[prop] = {"field": field, "mode": mode}
         return self
 
-    def compute(self, prop: str, expr: Any) -> "Component":
+    def compute(self, prop: str, expr: Expr) -> "Component":
         """Reactively set ``prop`` to a value *computed* from state fields (one-way).
 
         ``expr`` is a field expression (:func:`~spaday.actions.field` / ``eq`` / ``not_`` / ``all_`` /
         ``any_`` / ``lit`` / ``item`` / ``scope``) evaluated in the browser and recomputed whenever any
         global field or repeater scope it reads changes, e.g. ``compute("disabled", not_(field("enabled")))``.
         """
+        if not isinstance(expr, Expr):
+            raise TypeError(f"computed binding must use an Expr, got {type(expr).__name__}")
         self._bindings[prop] = {"compute": expr.to_dict(), "mode": "one-way"}
         return self
 

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -20,6 +20,7 @@ import math
 from enum import Enum
 from typing import Any
 
+from ..actions import Expr
 from ..component import Child, Component, element
 
 __all__ = ["App", "AppShell", "Body", "Column", "Each", "Footer", "Gutter", "Main", "Nav", "Region", "Row", "Show", "Stack", "Table", "Toolbar"]
@@ -223,6 +224,8 @@ class Show(Component):
         if field is not None:
             self._bindings["when"] = {"field": field, "mode": "one-way"}
         elif when is not None:
+            if not isinstance(when, Expr):
+                raise TypeError(f"Show when must be an Expr, got {type(when).__name__}")
             self._bindings["when"] = {"compute": when.to_dict(), "mode": "one-way"}
         else:
             raise ValueError("Show requires field= (a store field) or when= (a field-expression)")

--- a/spaday/packages.py
+++ b/spaday/packages.py
@@ -87,7 +87,14 @@ def _from_python_path(spec: str) -> ComponentPackage:
     module_name, separator, attribute = spec.partition(":")
     if not separator or not module_name or not attribute:
         raise ValueError(f"invalid component package Python path {spec!r}; expected 'module:attribute'")
-    value = getattr(import_module(module_name), attribute)
+    try:
+        module = import_module(module_name)
+    except ImportError as error:
+        raise ValueError(f"could not import component package Python path {spec!r}: {error}") from error
+    try:
+        value = getattr(module, attribute)
+    except AttributeError as error:
+        raise ValueError(f"component package Python path {spec!r} does not exist") from error
     return _require_package(value, f"component package Python path {spec!r}")
 
 
@@ -96,9 +103,12 @@ def _installed_entry_points():
 
 
 def _from_entry_point(name: str) -> ComponentPackage:
-    matches = [candidate for candidate in _installed_entry_points() if candidate.name == name]
+    candidates = _installed_entry_points()
+    matches = [candidate for candidate in candidates if candidate.name == name]
     if not matches:
-        raise ValueError(f"unknown component package {name!r}; no {ENTRY_POINT_GROUP!r} entry point is installed")
+        available = sorted({candidate.name for candidate in candidates})
+        choices = f"; available packages: {', '.join(available)}" if available else "; no component packages are installed"
+        raise ValueError(f"unknown component package {name!r}{choices}")
     if len(matches) > 1:
         raise ValueError(f"multiple {ENTRY_POINT_GROUP!r} entry points are named {name!r}")
     return _require_package(matches[0].load(), f"component package entry point {name!r}")

--- a/spaday/tests/test_actions.py
+++ b/spaday/tests/test_actions.py
@@ -97,6 +97,17 @@ def test_scope_requires_a_name():
         scope("")
 
 
+def test_composite_actions_reject_non_actions_at_authoring_time():
+    with pytest.raises(TypeError, match="Sequence entries must be Actions"):
+        Sequence(Emit("ready"), 3)
+    with pytest.raises(TypeError, match="Sequence entries must be Actions"):
+        Sequence(None)
+    with pytest.raises(TypeError, match="then branch must be an Action"):
+        If(True, 3)
+    with pytest.raises(TypeError, match="else branch must be an Action"):
+        If(True, Emit("ready"), 3)
+
+
 def test_logical_combinators_coerce_values_to_expressions():
     assert all_(field("ready"), True).to_dict() == {
         "expr": "all",

--- a/spaday/tests/test_bindings.py
+++ b/spaday/tests/test_bindings.py
@@ -55,6 +55,11 @@ def test_compute_with_cond_selects_a_value_by_a_field():
     assert json.loads(spaday.apply(j, spaday.diff(j, j))) == json.loads(j)  # rides the core diff/apply
 
 
+def test_compute_rejects_non_expression_at_authoring_time():
+    with pytest.raises(TypeError, match="computed binding must use an Expr"):
+        element("span").compute("textContent", 3)
+
+
 def test_bind_root_class_targets_the_document_root():
     # page-level theming outside the tree: a field toggles a class on <html> (e.g. WebAwesome's wa-dark)
     node = element("spa-app").bind_root_class("wa-dark", "dark").to_node()

--- a/spaday/tests/test_packages.py
+++ b/spaday/tests/test_packages.py
@@ -117,8 +117,9 @@ def test_rejects_unsafe_descriptors_and_duplicate_selection():
 
 
 def test_unknown_entry_point_has_a_useful_error(monkeypatch):
-    monkeypatch.setattr(package_registry, "entry_points", lambda **_kwargs: ())
-    with pytest.raises(ValueError, match="spaday.component_packages"):
+    available = ComponentPackage("available", ".", ())
+    monkeypatch.setattr(package_registry, "entry_points", lambda **_kwargs: (EntryPoint("available", available),))
+    with pytest.raises(ValueError, match="available packages: available"):
         resolve_component_packages("missing")
 
 
@@ -128,6 +129,10 @@ def test_rejects_invalid_python_paths_and_entry_points(monkeypatch, python_path_
 
     with pytest.raises(ValueError, match="expected 'module:attribute'"):
         resolve_component_packages(":package")
+    with pytest.raises(ValueError, match="Python path 'missing_module:package'"):
+        resolve_component_packages("missing_module:package")
+    with pytest.raises(ValueError, match="Python path 'spaday_package_fixture:missing' does not exist"):
+        resolve_component_packages("spaday_package_fixture:missing")
     with pytest.raises(TypeError, match="must expose a ComponentPackage"):
         resolve_component_packages("spaday_package_fixture:invalid")
 

--- a/spaday/tests/test_shell.py
+++ b/spaday/tests/test_shell.py
@@ -65,6 +65,13 @@ def test_constructor_children_and_string_text_and_generic_props():
     assert Nav().child("Title").to_node() == nav
 
 
+def test_component_rejects_invalid_children_and_actions_at_authoring_time():
+    with pytest.raises(TypeError, match="child must be a Component, node dict, or string"):
+        element("div").child(3)
+    with pytest.raises(TypeError, match="event action must be an Action"):
+        element("button").on("click", 3)
+
+
 def test_component_keys_primitives_and_prop_validation():
     assert element("article").key("story").to_node()["key"] == "story"
     assert Text("plain").tag == "span"
@@ -188,6 +195,8 @@ def test_show_when_authors_a_compute_binding():
 def test_show_requires_a_condition():
     with pytest.raises(ValueError):
         Show()
+    with pytest.raises(TypeError, match="Show when must be an Expr"):
+        Show(when=True)
 
 
 def test_each_authors_a_keyed_collection_template():


### PR DESCRIPTION
## Description

Consumes transports `Move` and `Reorder` patches as keyed collection deltas so `spa-each` retains existing DOM elements and item scopes through sparse moves and dense arbitrary reorders. Reorder validation and preparation stay linear; malformed or transiently invalid keyed batches fall back atomically to keyed reset reconciliation.

Also fixes focus restoration for non-text inputs and tightens authoring-time errors for invalid children, actions, expressions, and component-package references found during the DevEx audit.

Depends on [transports #168](https://github.com/1kbgz/transports/pull/168). Release follow-up: align spaday's transports dependency floor/pins with the released version and add released-version cross-repository coverage.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [x] Other: developer experience

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)
