### PR TITLE
Ship shell dark palette and CSP-clean stylesheet options

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -150,5 +150,19 @@ The `spa-*` shell components are re-themed by setting their `--spa-*` CSS custom
 `Component.css` (e.g. `App().css(spa_surface="#111", spa_border="#333")`, which cascades to the whole
 shell). `spaday.SHELL_TOKENS` maps each `css()` keyword to the CSS custom property it drives and what it
 controls — `spa_surface`, `spa_surface_2`, `spa_border`, `spa_muted`, `spa_gap`, `spa_align`,
-`spa_justify`, `spa_gutter_width`. Shell elements use neutral defaults unless an application or component
-package maps its theme tokens onto those variables.
+`spa_justify`, `spa_gutter_width`. The shell ships neutral light and dark defaults — the dark palette is
+keyed off WebAwesome's `wa-dark` class (`wa-light` flips a nested island back), so
+`App(...).bind_root_class("wa-dark", "dark")` alone re-themes the whole page. Both palettes are emitted
+at zero specificity, so an application or component package overrides them by mapping its own theme
+tokens onto those variables.
+
+`wa-dark`/`wa-light` on the root is spaday's page-mode convention, and component packages join it
+through whichever channel themes them:
+
+- a package themed by **CSS tokens** ships mode-keyed rules in its own package stylesheet (its `css`
+  assets land in `<head>` via `packages=`, and custom properties cascade into its shadow roots) — key
+  them off the same classes, at low specificity (`:where(.wa-dark) { --my-token: … }`), exactly as the
+  shell does;
+- a package themed by a **prop or constructor options** (Perspective's `theme`, Lightweight Charts)
+  binds that prop to the same field that drives the root class:
+  `component.compute("theme", cond(field("dark"), "dark", "light"))`.

--- a/docs/src/serving.md
+++ b/docs/src/serving.md
@@ -31,7 +31,7 @@ from spaday_webawesome import WaButton
 app = serve(
     lambda: WaButton(variant="brand").text("Hi"),
     packages=["webawesome"],          # pull WebAwesome's styles + catalog into <head>
-    head="<style>body{margin:2rem}</style>",
+    styles=["body{margin:2rem}"],     # inline <style> blocks; stylesheets=[...] adds <link> URLs
     title="my app",
 )
 
@@ -158,7 +158,9 @@ routes = [
 ```
 
 The mounting script is inline, so a host with a strict `script-src` Content-Security-Policy passes a
-per-request **`nonce`** — it stamps the generated `<script>`/`<link>` tags so the policy can allow them:
+per-request **`nonce`** — it stamps the generated `<script>`/`<link>`/`<style>` tags so the policy can
+allow them. Application CSS belongs in `stylesheets=` (URLs) or `styles=` (inline blocks), which are
+stamped like every generated tag; raw `head=` markup is concatenated verbatim and is *not* stamped:
 
 ```python
 fragment = bootstrap(fragment=True, target="#spaday-root", packages=[webawesome], nonce=request_nonce)

--- a/js/package.json
+++ b/js/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "spaday",
+  "name": "@1kbgz/spaday",
   "version": "0.7.0",
   "description": "",
   "repository": "git@github.com:1kbgz/spaday.git",
   "author": "1kbgz <dev@1kbgz.com>",
   "license": "Apache-2.0",
-  "private": true,
   "type": "module",
   "unpkg": "dist/cdn/index.js",
   "jsdelivr": "dist/cdn/index.js",

--- a/js/src/ts/shell.ts
+++ b/js/src/ts/shell.ts
@@ -14,6 +14,24 @@ const SURFACE = "var(--spa-surface, #fff)";
 const SURFACE_2 = "var(--spa-surface-2, #fafafa)";
 const MUTED = "var(--spa-muted, #666)";
 
+// The shell's own two palettes, keyed off WebAwesome's mode classes so
+// `App(...).bind_root_class("wa-dark", "dark")` alone re-themes the whole page. Custom properties
+// inherit through shadow boundaries, so one document-level rule reaches every `:host` style above.
+// `:where()` keeps specificity at zero: any application rule (or inline `.css(...)`) wins. The
+// explicit `.wa-light` values make a nested light island inside a dark page flip back.
+const THEME_CSS = `:where(.wa-dark) {
+  --spa-surface: #15191e;
+  --spa-surface-2: #1d232b;
+  --spa-border: #333b45;
+  --spa-muted: #9aa3ad;
+}
+:where(.wa-light) {
+  --spa-surface: #fff;
+  --spa-surface-2: #fafafa;
+  --spa-border: #e6e6e6;
+  --spa-muted: #666;
+}`;
+
 /** tag → the element's `:host` layout style. Each gets a shadow root with this style + a default slot. */
 const SHELL: Record<string, string> = {
   // page frame: nav (top) / body (fills) / footer (bottom), stacked
@@ -55,6 +73,12 @@ const ATTR_VARS: Record<string, string> = {
 // Guard so importing the runtime in a non-DOM context (e.g. the test runner / SSR in node) is a no-op
 // rather than touching `customElements`/`HTMLElement`, which only exist in the browser.
 if (typeof customElements !== "undefined") {
+  if (!document.querySelector("style[data-spaday-shell-theme]")) {
+    const theme = document.createElement("style");
+    theme.setAttribute("data-spaday-shell-theme", "");
+    theme.textContent = THEME_CSS;
+    document.head.append(theme);
+  }
   for (const [tag, css] of Object.entries(SHELL)) {
     if (customElements.get(tag)) continue;
     customElements.define(

--- a/js/tests/shell.spec.js
+++ b/js/tests/shell.spec.js
@@ -55,6 +55,29 @@ test("layout primitives carry their own encapsulated layout CSS", async ({
   expect(r.row.alignItems).toBe("center"); // Row centers its items
 });
 
+test("the shell ships a dark palette keyed off wa-dark, with wa-light flipping a nested island back", async ({
+  page,
+}) => {
+  const r = await page.evaluate(() => {
+    const nav = window.__spaday.mount(document.body, { tag: "spa-nav" });
+    const bg = () => getComputedStyle(nav).backgroundColor;
+    const light = bg();
+    document.documentElement.classList.add("wa-dark"); // what bind_root_class("wa-dark", ...) toggles
+    const dark = bg();
+    const island = document.createElement("div");
+    island.className = "wa-light";
+    document.body.append(island);
+    const islandNav = window.__spaday.mount(island, { tag: "spa-nav" });
+    const islandBg = getComputedStyle(islandNav).backgroundColor;
+    document.documentElement.classList.remove("wa-dark");
+    return { light, dark, islandBg, back: bg() };
+  });
+  expect(r.light).toBe("rgb(255, 255, 255)"); // the light default
+  expect(r.dark).toBe("rgb(21, 25, 30)"); // --spa-surface under .wa-dark
+  expect(r.islandBg).toBe("rgb(255, 255, 255)"); // a light island inside a dark page
+  expect(r.back).toBe("rgb(255, 255, 255)"); // removing the class restores the light palette
+});
+
 test("spa-table renders rows under columns and re-renders when the bound field changes", async ({
   page,
 }) => {

--- a/spaday/backends/aiohttp.py
+++ b/spaday/backends/aiohttp.py
@@ -39,6 +39,8 @@ def mount(
     tree: str = "json",
     reconnect: bool = False,
     scripts: Sequence[str] = (),
+    stylesheets: Sequence[str] = (),
+    styles: Sequence[str] = (),
     head: str = "",
 ) -> web.Application:
     """Add spaday's routes to an existing aiohttp ``app`` under ``prefix``. ``routes`` is a list of
@@ -56,6 +58,8 @@ def mount(
         tree=tree,
         reconnect=reconnect,
         scripts=scripts,
+        stylesheets=stylesheets,
+        styles=styles,
         head=head,
         title=title,
         layout=asset_layout,

--- a/spaday/backends/flask.py
+++ b/spaday/backends/flask.py
@@ -37,6 +37,8 @@ def mount(
     tree: str = "json",
     reconnect: bool = False,
     scripts: Sequence[str] = (),
+    stylesheets: Sequence[str] = (),
+    styles: Sequence[str] = (),
     head: str = "",
 ) -> Flask:
     """Add spaday's routes to an existing Flask ``app`` under ``prefix``. ``routes`` is a list of
@@ -54,6 +56,8 @@ def mount(
         tree=tree,
         reconnect=reconnect,
         scripts=scripts,
+        stylesheets=stylesheets,
+        styles=styles,
         head=head,
         title=title,
         layout=asset_layout,

--- a/spaday/backends/starlette.py
+++ b/spaday/backends/starlette.py
@@ -60,6 +60,8 @@ def mount(
     tree: str = "json",
     reconnect: bool = False,
     scripts: Sequence[str] = (),
+    stylesheets: Sequence[str] = (),
+    styles: Sequence[str] = (),
     head: str = "",
     store: dict | None = None,
     nonce: str | None = None,
@@ -86,6 +88,8 @@ def mount(
         tree=tree,
         reconnect=reconnect,
         scripts=scripts,
+        stylesheets=stylesheets,
+        styles=styles,
         head=head,
         title=title,
         store=store,
@@ -121,7 +125,8 @@ def serve(page: Page, *, background: Sequence[Awaitable] = (), lifespan: Callabl
     """Create a Starlette app and :func:`mount` ``page`` onto it. ``background`` coroutines run for the
     app's lifetime (or pass a custom ``lifespan`` for ordered startup, e.g. a clustering relay); all other
     keyword options are :func:`mount`'s (``prefix``/``routes``/``html``/``js``/``title``/``packages``/
-    ``wire``/``ws``/``tree``/``reconnect``/``scripts``/``head``/``store``/``nonce``)."""
+    ``wire``/``ws``/``tree``/``reconnect``/``scripts``/``stylesheets``/``styles``/``head``/``store``/
+    ``nonce``)."""
     from starlette.applications import Starlette
 
     @asynccontextmanager

--- a/spaday/backends/tornado.py
+++ b/spaday/backends/tornado.py
@@ -40,6 +40,8 @@ def mount(
     tree: str = "json",
     reconnect: bool = False,
     scripts: Sequence[str] = (),
+    stylesheets: Sequence[str] = (),
+    styles: Sequence[str] = (),
     head: str = "",
 ) -> Application:
     """Add spaday's handlers to an existing Tornado ``app`` under ``prefix``. ``routes`` is a list of
@@ -57,6 +59,8 @@ def mount(
         tree=tree,
         reconnect=reconnect,
         scripts=scripts,
+        stylesheets=stylesheets,
+        styles=styles,
         head=head,
         title=title,
         layout=asset_layout,

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -12,6 +12,8 @@ What an app would otherwise hand-write in HTML is declared in Python:
   one wire), decoded in the browser, instead of JSON at ``…/tree.json``.
 - ``reconnect=True`` — re-open the websocket on drop, re-syncing from the server snapshot.
 - ``scripts=[…]`` — extra ES-module URLs to load (e.g. ``NamedJs`` handlers).
+- ``stylesheets=[…]`` / ``styles=[…]`` — extra ``<link rel="stylesheet">`` URLs / inline ``<style>``
+  blocks in ``<head>``, stamped with ``nonce`` like every generated tag (unlike raw ``head`` markup).
 - ``base="/dashboard"`` — mount the app under a path prefix, so it coexists with the host's other routes
   (the tree / ``/js`` / ws URLs are all prefixed). Default ``""`` = served at the root.
 - ``fragment=True`` + ``target="#widget"`` — return just the package tags + the module ``<script>`` (not a
@@ -280,6 +282,8 @@ def bootstrap(
     tree: str = "json",
     reconnect: bool = False,
     scripts: Sequence[str] = (),
+    stylesheets: Sequence[str] = (),
+    styles: Sequence[str] = (),
     head: str = "",
     title: str = "spaday",
     store: dict | None = None,
@@ -300,14 +304,18 @@ def bootstrap(
     module ``<script>`` — a snippet to **drop into a host page's template** (Jinja/Django/…), so spaday is
     one component among many rather than the whole page. Pass ``target`` (a CSS selector) to mount into a
     specific element (e.g. ``"#widget"``) instead of ``document.body``; the host provides that element.
-    ``nonce`` stamps the generated ``<script>``/``<link>`` tags with a CSP nonce, so a host with a strict
-    ``script-src``/``style-src`` policy can allow the snippet. See the module docstring for the rest of the
-    options and the route contract. ``packages`` selects external :class:`~spaday.packages.ComponentPackage`
+    ``nonce`` stamps the generated ``<script>``/``<link>``/``<style>`` tags with a CSP nonce, so a host
+    with a strict ``script-src``/``style-src`` policy can allow the snippet. ``stylesheets`` adds
+    ``<link rel="stylesheet">`` URLs and ``styles`` inline ``<style>`` blocks to ``<head>`` — both
+    nonce-stamped, unlike raw ``head`` markup, which is concatenated verbatim. See the module docstring
+    for the rest of the options and the route contract. ``packages`` selects external :class:`~spaday.packages.ComponentPackage`
     descriptors directly, by ``module:attribute`` path, or by installed entry-point name. ``layout``
     selects source-checkout or installed-wheel asset URLs; by default it follows :func:`bundles_dir`."""
     n = f' nonce="{nonce}"' if nonce else ""
     component_packages = resolve_component_packages(packages)
-    head_markup = "\n    ".join(p for p in (_package_head(component_packages, base, nonce), head) if p)
+    style_tags = [f'<link rel="stylesheet"{n} href="{url}" />' for url in stylesheets]
+    style_tags += [f"<style{n}>{css}</style>" for css in styles]
+    head_markup = "\n    ".join(p for p in (_package_head(component_packages, base, nonce), *style_tags, head) if p)
     script = _script(base, wire, scripts, ws, tree, reconnect, store, target, layout)
     if fragment:
         head_block = f"{head_markup}\n" if head_markup else ""

--- a/spaday/tests/test_backend_starlette.py
+++ b/spaday/tests/test_backend_starlette.py
@@ -109,6 +109,16 @@ def test_mount_stamps_a_csp_nonce_on_generated_tags(tmp_path):
     assert 'nonce="abc123"' in page and "/components/fixture/fixture.js" in page
 
 
+def test_mount_threads_stylesheets_and_styles(tmp_path):
+    from starlette.applications import Starlette
+
+    app = Starlette()
+    mount(app, Main("hi"), prefix="/dash", js=tmp_path, stylesheets=["/static/theme.css"], styles=["body{margin:0}"], nonce="abc123")
+    page = TestClient(app).get("/dash/").text
+    assert '<link rel="stylesheet" nonce="abc123" href="/static/theme.css" />' in page
+    assert '<style nonce="abc123">body{margin:0}</style>' in page
+
+
 def test_serve_custom_html_and_background(tmp_path):
     html_file = tmp_path / "page.html"
     html_file.write_text("<!doctype html><title>custom</title>", encoding="utf-8")

--- a/spaday/tests/test_bootstrap.py
+++ b/spaday/tests/test_bootstrap.py
@@ -45,6 +45,23 @@ def test_scripts_are_injected():
     assert 'import "/static/handlers.js";' in bootstrap(scripts=["/static/handlers.js"])
 
 
+def test_stylesheets_and_styles_are_injected_with_the_nonce():
+    html = bootstrap(stylesheets=["/static/a.css", "/static/b.css"], styles=["body{margin:0}"], nonce="abc123")
+    assert '<link rel="stylesheet" nonce="abc123" href="/static/a.css" />' in html
+    assert '<link rel="stylesheet" nonce="abc123" href="/static/b.css" />' in html
+    assert '<style nonce="abc123">body{margin:0}</style>' in html
+    # without a nonce the tags are plain
+    plain = bootstrap(stylesheets=["/static/a.css"], styles=["body{margin:0}"])
+    assert '<link rel="stylesheet" href="/static/a.css" />' in plain
+    assert "<style>body{margin:0}</style>" in plain
+
+
+def test_stylesheets_land_in_fragment_snippets_too():
+    f = bootstrap(fragment=True, target="#widget", stylesheets=["/static/a.css"], nonce="abc123")
+    assert '<link rel="stylesheet" nonce="abc123" href="/static/a.css" />' in f
+    assert "<!doctype html>" not in f
+
+
 def test_tree_json_serializes_and_recomputes_per_call():
     page = Main("hi")
     assert json.loads(tree_json(page)) == page.to_node()

--- a/spaday/theme.py
+++ b/spaday/theme.py
@@ -7,8 +7,11 @@ a custom property set on a container cascades, so an **app-level** theme is just
 ``App`` root.
 
 ``SHELL_TOKENS`` documents the ``spa-*`` shell's own override tokens (the ``css()`` kwarg → the CSS
-custom property it drives and what it controls). Shell elements use neutral defaults until an
-application or component package maps its theme onto these variables::
+custom property it drives and what it controls). The shell ships neutral **light and dark** defaults —
+the dark palette is keyed off WebAwesome's ``wa-dark`` class (with ``wa-light`` flipping a nested
+island back), so ``App(...).bind_root_class("wa-dark", "dark")`` alone re-themes the whole page. Both
+palettes are emitted at zero specificity, so an application or component package overrides them by
+mapping its own theme onto these variables::
 
     from spaday.components.shell import App
     App().css(spa_surface="#111", spa_border="#333", spa_muted="#999")  # retheme the whole shell


### PR DESCRIPTION
Two gaps found while white-labeling csp-gateway's spaday UI, both about getting styling into the page declaratively.

**Shell dark palette.** The `spa-*` shell had light-only token fallbacks, so an app wiring WebAwesome's dark mode the documented way still rendered a light nav/footer, and every app had to hand-write a stylesheet redefining the `--spa-*` tokens under `wa-dark` (~60 lines in csp-gateway). The runtime now injects one document-level stylesheet — dark values under `:where(.wa-dark)`, explicit light values under `:where(.wa-light)` so a nested light island flips back. Custom properties inherit through shadow boundaries, so `App(...).bind_root_class("wa-dark", "dark")` alone re-themes the whole page (making that docstring true), and `:where()`'s zero specificity keeps every application/package rule winning. Docs establish `wa-dark`/`wa-light` as the page-mode convention component packages key off — mode-keyed rules in package CSS for token-themed packages, `cond(field(...))` into a theme prop for imperative renderers (the pattern the Perspective and Lightweight Charts examples already use).

**`stylesheets=` / `styles=`.** `mount()` took `scripts=` but no CSS equivalent, and raw `head=` markup bypasses the CSP nonce — operator stylesheets meant hand-building `<link>` strings that a strict `style-src` policy then blocked. `bootstrap()` and all four backend `mount()`s now accept `stylesheets=` (`<link rel="stylesheet">") and `styles=` (inline `<style>` blocks), both nonce-stamped like every generated tag, in document and fragment modes. `head=` stays the unstamped verbatim escape hatch, documented as such.
