### PR TITLE
Add a JupyterLite site with the widget in the wasm kernel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,7 +101,14 @@ jobs:
         if: matrix.target == 'native'
 
       - name: Build and test Pyodide wheel
-        run: make test-pyodide test-pyodide-browser
+        run: make test-pyodide test-pyodide-browser test-jupyterlite
+        if: matrix.target == 'pyodide'
+
+      - name: Upload JupyterLite site
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: jupyterlite-site
+          path: dist/lite
         if: matrix.target == 'pyodide'
 
       - name: Upload test results (Python)

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -52,6 +52,16 @@ jobs:
       - name: Build documentation
         run: yardang build
 
+      - name: Download JupyterLite site
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: jupyterlite-site
+          path: docs/html/lite
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+        if: github.event_name == 'workflow_run'
+
       - name: Publish documentation
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,8 @@ AGENTS.md
 spaday/examples/*.json
 
 spaday-*
+
+# jupyterlite build inputs/state (site output goes to dist/lite)
+examples/lite/pypi/
+.jupyterlite.doit.db
+!examples/lite/files/spaday-demo.ipynb

--- a/Makefile
+++ b/Makefile
@@ -141,12 +141,25 @@ coverage-rs:  ## run rust tests and collect test coverage
 test: test-py test-js test-rs  ## run all tests
 test-pyodide:  ## build and test the Python package in Pyodide
 	rustup target add wasm32-unknown-emscripten
+	rm -rf dist/pyodide
 	uvx --from cibuildwheel==4.2.0 cibuildwheel --only cp314-pyodide_wasm32 --output-dir dist/pyodide .
 test-pyodide-browser:  ## test the Pyodide worker example in a browser
 	test -n "$(firstword $(wildcard dist/pyodide/*.whl))"
 	mkdir -p js/dist/pyodide
 	cp "$(firstword $(wildcard dist/pyodide/*.whl))" js/dist/pyodide/
 	cd js; SPADAY_PYODIDE_WHEEL="/dist/pyodide/$(notdir $(firstword $(wildcard dist/pyodide/*.whl)))" pnpm exec playwright test tests/pyodide.test.js
+
+.PHONY: jupyterlite test-jupyterlite
+jupyterlite:  ## build the JupyterLite demo site into dist/lite (needs the Pyodide wheel)
+	test -n "$(firstword $(wildcard dist/pyodide/*.whl))"
+	rm -rf examples/lite/pypi examples/lite/.cache dist/lite
+	mkdir -p examples/lite/pypi
+	cp dist/pyodide/*.whl examples/lite/pypi/
+	uvx --with jupyterlite-pyodide-kernel==0.8.3 --with jupyter-server --with jupyterlab-widgets==3.0.15 --with anywidget --from jupyterlite-core==0.8.2 jupyter lite build --lite-dir examples/lite --output-dir $(CURDIR)/dist/lite
+test-jupyterlite: jupyterlite  ## drive the JupyterLite demo in a browser
+	rm -rf js/dist/lite
+	cp -r dist/lite js/dist/lite
+	cd js; pnpm exec playwright test tests/jupyterlite.test.js
 coverage: coverage-py coverage-js coverage-rs  ## run all tests and collect test coverage
 
 # alias

--- a/docs/src/notebook.md
+++ b/docs/src/notebook.md
@@ -2,7 +2,9 @@
 
 This guide shows you how to render a spaday UI in a notebook and round-trip its state with Python — no
 server. It works in Jupyter (Lab / Notebook / Colab / VS Code) and the wider
-[anywidget](https://anywidget.dev) ecosystem (Marimo, Shiny-for-Python, Solara, Panel).
+[anywidget](https://anywidget.dev) ecosystem (Marimo, Shiny-for-Python, Solara, Panel) — and with no
+install at all in [JupyterLite](pyodide.md), where the kernel itself is WebAssembly (hosted demo at
+[/spaday/lite/](https://1kbgz.github.io/spaday/lite/)).
 
 Install the host:
 

--- a/docs/src/pyodide.md
+++ b/docs/src/pyodide.md
@@ -84,3 +84,26 @@ Run the focused Playwright test against the wheel already in `dist/pyodide/`:
 ```bash
 make test-pyodide-browser
 ```
+
+## Run it all in JupyterLite
+
+Both ends WebAssembly: the Pyodide kernel runs your Python, and the [notebook widget](notebook.md)
+(which bundles the spaday runtime and wasm core) renders the tree in the notebook frontend — no
+server. A hosted build publishes with these docs at
+[/spaday/lite/](https://1kbgz.github.io/spaday/lite/) — open `lab/index.html` → `spaday-demo.ipynb`.
+
+```bash
+make jupyterlite        # builds the site into dist/lite (wheel + demo notebook included)
+make test-jupyterlite   # or: drive the site's REPL in Chromium end-to-end
+```
+
+Serve `dist/lite` from any static host. The spaday wheel installs from the site's own wheel index
+(`%pip install spaday anywidget`); `anywidget` and `pydantic` come from PyPI. Widget **frontend**
+extensions cannot be `%pip install`ed at runtime — the site build bundles them (`jupyterlab_widgets`
+for the ipywidgets manager plus `anywidget`; see the `jupyterlite` Make target). A Lite site built
+without them shows the widget's text repr instead of the rendered tree.
+
+**If a previously visited site misbehaves after a redeploy** (e.g. an old wheel version, or missing
+files): JupyterLite caches hard — a service worker plus browser storage can keep serving the previous
+build's kernel and packages. Hard refresh (Cmd/Ctrl+Shift+R), or clear the site's data (service
+worker + IndexedDB) and reload.

--- a/examples/lite/files/spaday-demo.ipynb
+++ b/examples/lite/files/spaday-demo.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# spaday in JupyterLite\n",
+    "\n",
+    "The kernel is Python compiled to WebAssembly (Pyodide), and the widget bundles the spaday\n",
+    "runtime and its wasm core — a spaday UI renders in the notebook with no server. Run the\n",
+    "cells in order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": ["%pip install -q spaday anywidget"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from spaday import Widget, element\n",
+    "from spaday.components.shell import Row, Stack\n",
+    "\n",
+    "\n",
+    "def tree(count):\n",
+    "    return Stack(\n",
+    "        element(\"h2\").text(\"spaday in JupyterLite\"),\n",
+    "        Row(element(\"strong\").text(str(count)), element(\"em\").text(\"clicks\")),\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "w = Widget(tree(0))\n",
+    "w  # display it: the tree renders as live spa-* web components"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# replace the tree; the browser applies a minimal diff to the live DOM\n",
+    "w.update(tree(1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-4",
+   "metadata": {},
+   "source": [
+    "Bindings, two-way state, and `SendPatch` intents round-trip with the kernel too — see the\n",
+    "[notebook guide](https://1kbgz.github.io/spaday/notebook.html) for `Widget(state=...)`,\n",
+    "`on_state`, and `on_intent`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Pyodide)",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/lite/jupyter_lite_config.json
+++ b/examples/lite/jupyter_lite_config.json
@@ -1,0 +1,5 @@
+{
+  "LiteBuildConfig": {
+    "contents": ["files"]
+  }
+}

--- a/js/tests/jupyterlite.test.js
+++ b/js/tests/jupyterlite.test.js
@@ -1,0 +1,43 @@
+import fs from "fs";
+import { test, expect } from "@playwright/test";
+
+const built = fs.existsSync("dist/lite/repl/index.html");
+// the repo version (bumpversion keeps package.json in sync): asserting it proves the lite site
+// serves the freshly built wheel, not a stale one — without hardcoding a version that rots on bump
+const { version } = JSON.parse(fs.readFileSync("./package.json", "utf8"));
+
+test("JupyterLite pyodide kernel installs the wheel and renders the widget", async ({
+  page,
+}) => {
+  test.skip(
+    !built,
+    "run `make jupyterlite` first (site copied to js/dist/lite)",
+  );
+  test.setTimeout(300_000);
+
+  const url = new URL("/dist/lite/repl/index.html", "http://127.0.0.1:3000");
+  url.searchParams.set("kernel", "python");
+  url.searchParams.append("code", "%pip install -q spaday anywidget");
+  url.searchParams.append(
+    "code",
+    [
+      "import spaday",
+      "from spaday import Widget, element",
+      "from spaday.components.shell import Stack",
+      // "hello " + "spaday" keeps the rendered text out of the echoed source, so the
+      // visibility assertion below can only be satisfied by the widget's live DOM
+      'w = Widget(Stack(element("h1").text("hello " + "spaday")))',
+      "print('lite-ok', spaday.__version__)",
+    ].join("\n"),
+  );
+  // displaying the widget must render the tree as live elements, not the text/plain repr —
+  // this is what breaks when the lite build lacks the ipywidgets/anywidget frontends
+  url.searchParams.append("code", "w");
+  await page.goto(url.toString());
+  await expect(page.getByText(`lite-ok ${version}`)).toBeVisible({
+    timeout: 240_000,
+  });
+  await expect(page.locator("h1", { hasText: "hello spaday" })).toBeVisible({
+    timeout: 60_000,
+  });
+});


### PR DESCRIPTION
Mirrors the transports JupyterLite setup: both ends WebAssembly — the Pyodide kernel runs the Python, and the notebook widget (whose ESM bundles the spaday runtime and wasm core) renders the tree in the frontend, no server.

- `examples/lite/` — Lite site config + `spaday-demo.ipynb` (install from the site's own wheel index, author a shell-component tree, display `Widget(tree)`, `w.update(...)` to show incremental patching). The pre-existing `spaday-*` ignore pattern swallowed the notebook name, so `.gitignore` carries an explicit negation.
- `make jupyterlite` builds `dist/lite` — the build env bundles the `jupyterlab_widgets` and `anywidget` **frontend** extensions, which cannot be `%pip install`ed at runtime (the failure mode is the widget's text repr instead of a rendered tree). `make test-jupyterlite` drives the site's REPL in Chromium: asserts the freshly built wheel's version (read from `package.json`, never hardcoded) and that a live `<h1>` renders — the source spells it `"hello " + "spaday"` so the code echo can't satisfy the assertion.
- CI: the pyodide leg runs `test-jupyterlite` and uploads a `jupyterlite-site` artifact; the docs workflow deploys it at `/lite/` alongside the docs, like transports.
- `test-pyodide` now cleans `dist/pyodide` first — a stale 0.5.0 wheel was sitting there, and the version-asserting test would have caught it shadowing fresh builds after a bump.
- Docs: `pyodide.md` gains a "Run it all in JupyterLite" section (build/serve, build-time frontend extensions, the service-worker caching gotcha); `notebook.md` links the hosted demo.

Verified locally end-to-end: 0.7.1 wheel built with its in-Pyodide suite passing, site's federated extensions include `@jupyter-widgets/jupyterlab-manager` + `anywidget`, Chromium test passes (`lite-ok 0.7.1` + live widget DOM), JS lint clean.