### PR TITLE
Detect the source checkout by package.json, not a bare js dir

### DIFF
--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -100,7 +100,10 @@ _SESSION_ID = "globalThis.crypto?.randomUUID?.() ?? (Date.now().toString(36) + M
 def _layout(layout: AssetLayout | None = None) -> AssetLayout:
     if layout is not None and layout not in _ASSETS:
         raise ValueError("layout must be 'source' or 'installed'")
-    return layout or ("source" if _SOURCE_DIR.is_dir() else "installed")
+    # package.json distinguishes spaday's own js/ checkout from an unrelated sibling `js` dir —
+    # notably plotly's labextension data, which lands at top-level site-packages/js next to an
+    # installed spaday and would otherwise force source-layout URLs that 404
+    return layout or ("source" if (_SOURCE_DIR / "package.json").is_file() else "installed")
 
 
 def bundles_dir(layout: AssetLayout | None = None) -> Path:

--- a/spaday/tests/test_bootstrap.py
+++ b/spaday/tests/test_bootstrap.py
@@ -100,6 +100,19 @@ def test_invalid_asset_layout_raises():
         bootstrap(layout="other")
 
 
+def test_bare_js_dir_is_not_mistaken_for_a_source_checkout(tmp_path, monkeypatch):
+    # plotly installs its labextension data at top-level site-packages/js — a `js` dir next to an
+    # installed spaday must not flip layout detection to source (its URLs would 404)
+    import spaday.bootstrap as bs
+
+    monkeypatch.setattr(bs, "_SOURCE_DIR", tmp_path / "js")
+    (tmp_path / "js").mkdir()
+    (tmp_path / "js" / "install.json").write_text("{}", encoding="utf-8")
+    assert bundles_dir().name == "extension"
+    (tmp_path / "js" / "package.json").write_text("{}", encoding="utf-8")  # a real checkout marker
+    assert bundles_dir() == tmp_path / "js"
+
+
 def test_base_prefixes_the_tree_js_and_ws_urls():
     html = bootstrap(base="/dash", wire="transports", layout="source")
     assert 'fetch("/dash/tree.json")' in html  # tree


### PR DESCRIPTION
plotly installs its jupyter labextension data at top-level `site-packages/js` — exactly where spaday's source-layout heuristic looks (`Path(spaday/__file__).parent.parent / "js"`). In any environment with plotly installed, an installed-wheel spaday app therefore generated source-checkout asset URLs (`/js/dist/esm/index.js`, `node_modules` transports paths) that 404, breaking every served page.

Detect the source checkout by `js/package.json` instead of the bare directory (plotly's dir contains only `install.json`). New test covers both sides of the heuristic.

This turned out to be the cause of the long-standing local example-test failures in spaday-perspective / spaday-regular-table / spaday-regular-layout — with this fix (validated by patching an installed spaday), the spaday-perspective live example test passes again ([spaday-perspective#22](https://github.com/1kbgz/spaday-perspective/pull/22)).