### PR TITLE
Clean stale in-tree extensions before Linux dist builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,10 +145,7 @@ jobs:
 
       - name: Build distributions (Linux x86_64)
         run: |
-          # stale host-built extensions (spaday/transports/superstore .abi3.so from the develop and
-          # coverage steps) must not leak into the container-built wheel — auditwheel rejects their
-          # host-glibc symbols
-          rm -rf dist target spaday/*.abi3.so
+          rm -rf dist
           make dist-rs
           make dist-py-sdist
           make dist-py-wheel
@@ -160,7 +157,7 @@ jobs:
 
       - name: Build distributions (Linux ARM64)
         run: |
-          rm -rf dist target spaday/*.abi3.so
+          rm -rf dist
           make dist-py-wheel
           make dist-check
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,7 +145,10 @@ jobs:
 
       - name: Build distributions (Linux x86_64)
         run: |
-          rm -rf dist
+          # stale host-built extensions (spaday/transports/superstore .abi3.so from the develop and
+          # coverage steps) must not leak into the container-built wheel — auditwheel rejects their
+          # host-glibc symbols
+          rm -rf dist target spaday/*.abi3.so
           make dist-rs
           make dist-py-sdist
           make dist-py-wheel
@@ -157,7 +160,7 @@ jobs:
 
       - name: Build distributions (Linux ARM64)
         run: |
-          rm -rf dist
+          rm -rf dist target spaday/*.abi3.so
           make dist-py-wheel
           make dist-check
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,7 +145,9 @@ jobs:
 
       - name: Build distributions (Linux x86_64)
         run: |
-          rm -rf dist
+          # drop host-built cargo artifacts: the manylinux container mounts the project and cargo
+          # reuses them (same rustc), linking host-glibc symbols that auditwheel rejects
+          rm -rf dist target
           make dist-rs
           make dist-py-sdist
           make dist-py-wheel
@@ -157,7 +159,7 @@ jobs:
 
       - name: Build distributions (Linux ARM64)
         run: |
-          rm -rf dist
+          rm -rf dist target
           make dist-py-wheel
           make dist-check
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,13 @@ exclude = [
     "js",
     "rust",
     "spaday/tests",
+    # stale in-tree builds (develop/coverage leave host-glibc extensions in the package dir, which
+    # auditwheel rejects); hatch-rs force-includes its fresh artifacts past these filters
+    "spaday/*.so",
+    "spaday/*.abi3.so",
+    "spaday/*.dylib",
+    "spaday/*.dll",
+    "spaday/*.pyd",
 ]
 # The JS build (hatch-js hook) emits the runtime/widget assets under spaday/extension, which is
 # git-ignored; include them as build artifacts so installed wheels ship the widget's _esm / _css /


### PR DESCRIPTION
Fixes the `build (ubuntu-24.04-arm)` dist failure that #147 merged with: the develop and coverage steps leave host-built `spaday/{spaday,transports,superstore}.abi3.so` inside the package dir, the container wheel build picks them up, and auditwheel rejects their host-glibc symbols (`too-recent versioned symbols`) on the new native ARM leg. Removes them (and `target/`) before cibuildwheel in both Linux dist steps, per cibuildwheel's own clean-checkout advice. The x86 leg gets the same treatment — it was only surviving by cancellation ordering. (transports needed no equivalent: its ARM leg is green.)