### PR TITLE
Walk a path into the event value

### DIFF
--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -125,7 +125,19 @@ fn eval(expr: &spaday::Expr, host: &Host) -> JsValue {
         Lit { value } => value
             .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
             .unwrap_or(JsValue::UNDEFINED),
-        Event => host.event_value(),
+        Event { path } => {
+            let mut value = host.event_value();
+            if let Some(path) = path {
+                for key in path.split('.').filter(|part| !part.is_empty()) {
+                    if value.is_null() || value.is_undefined() {
+                        break;
+                    }
+                    value = js_sys::Reflect::get(&value, &JsValue::from_str(key))
+                        .unwrap_or(JsValue::UNDEFINED);
+                }
+            }
+            value
+        }
         Field { name } => host.get_field(name),
         Item { path } => host.get_item(path),
         Scope { name, path } => host.get_scope(name, path),

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -659,3 +659,35 @@ test("NamedJs invokes a pre-registered handler (the no-eval escape hatch)", asyn
   });
   expect(ran).toBe(2);
 });
+
+test("event expressions walk a path into a rich CustomEvent detail", async ({
+  page,
+}) => {
+  await page.goto("/tests/runtime.html");
+  await page.waitForFunction(() => window.__spaday);
+  const value = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ selected: "" });
+    const root = mount(
+      document.body,
+      {
+        tag: "div",
+        events: {
+          "edge-click": {
+            kind: "set-field",
+            field: "selected",
+            value: { expr: "event", path: "meta.label" },
+          },
+        },
+      },
+      store,
+    );
+    root.dispatchEvent(
+      new CustomEvent("edge-click", {
+        detail: { meta: { label: "rows" }, other: 1 },
+      }),
+    );
+    return store.get("selected");
+  });
+  expect(value).toBe("rows");
+});

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -45,7 +45,11 @@ pub enum Expr {
     /// A literal (plain JSON) value.
     Lit { value: serde_json::Value },
     /// The triggering event's value — a control's `checked` (bool), else `value`, else `detail`.
-    Event,
+    /// A dot `path` walks into the value (e.g. `label` from a rich CustomEvent detail).
+    Event {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+    },
     /// Boolean negation of an expression.
     Not { of: Box<Expr> },
     /// The current value of a `name` prop on `target` (reads live element state).
@@ -192,13 +196,32 @@ mod tests {
     }
 
     #[test]
+    fn event_with_path() {
+        round(
+            &Action::SetProp {
+                target: Ref::This,
+                prop: "textContent".into(),
+                value: Expr::Event {
+                    path: Some("label".into()),
+                },
+            },
+            json!({
+                "kind": "set",
+                "target": {"ref": "this"},
+                "prop": "textContent",
+                "value": {"expr": "event", "path": "label"},
+            }),
+        );
+    }
+
+    #[test]
     fn setprop_by_id_with_not_event() {
         round(
             &Action::SetProp {
                 target: Ref::Id { id: "panel".into() },
                 prop: "hidden".into(),
                 value: Expr::Not {
-                    of: Box::new(Expr::Event),
+                    of: Box::new(Expr::Event { path: None }),
                 },
             },
             json!({
@@ -255,7 +278,7 @@ mod tests {
             &Action::SendPatch {
                 model: "global".into(),
                 field: "type".into(),
-                value: Expr::Event,
+                value: Expr::Event { path: None },
             },
             json!({"kind": "patch", "model": "global", "field": "type", "value": {"expr": "event"}}),
         );
@@ -291,7 +314,7 @@ mod tests {
     fn if_without_else_serializes_null() {
         round(
             &Action::If {
-                cond: Expr::Event,
+                cond: Expr::Event { path: None },
                 then: Box::new(Action::Toggle {
                     target: Ref::This,
                     prop: "hidden".into(),
@@ -308,7 +331,7 @@ mod tests {
             &Action::CallEndpoint {
                 method: "POST".into(),
                 url: "/api/order".into(),
-                body: Some(Expr::Event),
+                body: Some(Expr::Event { path: None }),
                 result: None,
             },
             json!({"kind": "call", "method": "POST", "url": "/api/order", "body": {"expr": "event"}, "result": null}),
@@ -360,7 +383,7 @@ mod tests {
             &Action::CallEndpoint {
                 method: "POST".into(),
                 url: "/api/order".into(),
-                body: Some(Expr::Event),
+                body: Some(Expr::Event { path: None }),
                 result: Some("order_result".into()),
             },
             json!({"kind": "call", "method": "POST", "url": "/api/order", "body": {"expr": "event"}, "result": "order_result"}),
@@ -389,7 +412,7 @@ mod tests {
         round(
             &Action::SetField {
                 field: "qty".into(),
-                value: Expr::Event,
+                value: Expr::Event { path: None },
             },
             json!({"kind": "set-field", "field": "qty", "value": {"expr": "event"}}),
         );

--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -43,8 +43,11 @@ class _Lit(Expr):
 
 
 class _EventValue(Expr):
+    def __init__(self, path: str = "") -> None:
+        self.path = path
+
     def to_dict(self) -> dict[str, Any]:
-        return {"expr": "event"}
+        return {"expr": "event", "path": self.path} if self.path else {"expr": "event"}
 
 
 class _Not(Expr):
@@ -60,9 +63,11 @@ def lit(value: Any) -> Expr:
     return _Lit(value)
 
 
-def event_value() -> Expr:
-    """The triggering event's value — a control's ``checked`` (booleans) else ``value`` else ``detail``."""
-    return _EventValue()
+def event_value(path: str = "") -> Expr:
+    """The triggering event's value — a control's ``checked`` (booleans) else ``value`` else ``detail``.
+    A dot ``path`` walks into the value: ``event_value("label")`` reads ``detail.label`` from a rich
+    CustomEvent, so one field of a structured detail can land in the store or an endpoint body."""
+    return _EventValue(path)
 
 
 def not_(of: Any) -> Expr:

--- a/spaday/tests/test_actions.py
+++ b/spaday/tests/test_actions.py
@@ -247,3 +247,9 @@ def test_every_action_kind_round_trips_through_core():
     )
     tree = node.to_json()
     assert json.loads(apply(tree, diff(tree, tree))) == json.loads(tree)
+
+
+def test_event_value_path_reads_into_a_rich_detail():
+    assert event_value().to_dict() == {"expr": "event"}
+    assert event_value("label").to_dict() == {"expr": "event", "path": "label"}
+    assert event_value("a.b").to_dict() == {"expr": "event", "path": "a.b"}


### PR DESCRIPTION
`event_value("label")` reads `detail.label` from a rich CustomEvent detail — previously the DSL could only take the whole detail, so a component emitting structured details (spaday-dagre's edge clicks: `{source, target, label}`) couldn't land one field in the store: `SetField("selected", event_value())` displayed `[object Object]`.

The `Event` expr gains an optional dot `path` (`{"expr":"event","path":"a.b"}`), omitted from the wire when empty so existing trees serialize identically; the wasm evaluator walks it with `Reflect`, stopping at null/undefined. Covered at all three layers: Rust round-trip, Python serializer test, and a Playwright runtime test dispatching a nested detail through `set-field`. Suites: cargo 53, pytest full, Playwright full, lint clean.