### PR TITLE
List spaday-dagre and spaday-studio in the component ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ registers its browser assets with spaday:
 - [spaday-perspective](https://github.com/1kbgz/spaday-perspective) — live [Perspective](https://perspective-dev.github.io) workspaces and datagrids.
 - [spaday-webawesome](https://github.com/1kbgz/spaday-webawesome) — typed [WebAwesome](https://webawesome.com) catalog, forms, and tabs.
 - [spaday-lightweight-charts](https://github.com/1kbgz/spaday-lightweight-charts) — reactive TradingView Lightweight Charts.
+- [spaday-dagre](https://github.com/1kbgz/spaday-dagre) — interactive directed-graph rendering with [dagre](https://github.com/dagrejs/dagre) layout.
 - [spaday-regular-layout](https://github.com/1kbgz/spaday-regular-layout) — serializable resizable panel layouts.
 - [spaday-regular-table](https://github.com/1kbgz/spaday-regular-table) — viewport-virtualized high-performance data tables.
+- [spaday-studio](https://github.com/1kbgz/spaday-studio) — AI-native visual development environment.
 
 Select an installed integration by its entry-point name, for example `serve(page, packages=["trees"])`.
 


### PR DESCRIPTION
Adds the two missing peers to the README's component ecosystem listing:

- [spaday-dagre](https://github.com/1kbgz/spaday-dagre) — interactive directed-graph rendering with dagre layout
- [spaday-studio](https://github.com/1kbgz/spaday-studio) — AI-native visual development environment

The docs landing page (`index.md`) is generated from the README, so it picks this up on the next docs build.