### PR TITLE
Fix dagre contextmenu event name in open_popup docs

### DIFF
--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -442,7 +442,7 @@ def open_popup(target: Ref, *, x: Any = None, y: Any = None, context_field: str 
     context into reactive state first — the context-menu opener::
 
         graph.on(
-            "spaday-dagre-node-contextmenu",
+            "dagre-node-contextmenu",
             open_popup(by_id("node-menu"), context_field="menu_ctx", context=event_value("detail")),
         )
 


### PR DESCRIPTION
The `open_popup` docstring's context-menu example cited a `spaday-dagre-node-contextmenu` event; the event `spaday-dagre` actually dispatches is `dagre-node-contextmenu`. Docs-only; `docs/src/behavior.md` was checked and does not repeat the mistake. Follow-up remnant from the ccflow registry-browser consumer report (the contextmenu events themselves shipped in spaday-dagre 0.1.2).