### PR TITLE
Await async Invoke results and sequence across them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "spaday",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -405,6 +406,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/docs/src/behavior.md
+++ b/docs/src/behavior.md
@@ -210,6 +210,17 @@ save.on("click", SetStorage("my_layout", call(by_id("layout"), "save")))
 export.on("click", Download("layout.json", call(by_id("layout"), "save")))
 ```
 
+An async method composes with `Sequence`: `Invoke` awaits a returned promise (and with `result=`,
+writes the resolved value to a state field first), so "save, then persist what was saved" is plain
+data — while purely synchronous action chains still apply in the same tick:
+
+```python
+save.on("click", Sequence(
+    Invoke(by_id("workspace"), "saveClean", result="custom_layout"),
+    SetStorage("my_layout", field("custom_layout")),
+))
+```
+
 Prefer methods a component's manifest declares — they are part of its public surface. Method names
 are not yet checked against the catalog at authoring time (a mistyped name logs a console error at
 event time); catalog-backed validation is planned alongside CEM method parsing.

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -15,5 +15,6 @@ crate-type = ["cdylib"]
 spaday = { path = "../rust", version = "*" }
 wasm-bindgen = "=0.2.126"
 js-sys = "0.3"
+wasm-bindgen-futures = "0.4"
 serde = "1"
 serde-wasm-bindgen = "0.6"

--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -1,3 +1,6 @@
+use std::future::Future;
+use std::pin::Pin;
+
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
@@ -49,13 +52,25 @@ extern "C" {
 /// Behavior is data: the action is parsed + validated by the shared core, then evaluated here with no
 /// `eval`. This is the browser-side half of the action DSL — the same model the Python binding authors.
 #[wasm_bindgen]
-pub fn interpret(action: &str, host: &Host) -> Result<(), JsError> {
+pub fn interpret(action: &str, host: Host) -> Result<(), JsError> {
     let action = spaday::parse_action(action).map_err(|e| JsError::new(&e))?;
-    run(&action, host);
+    let mut fut = Box::pin(async move { run(&action, &host).await });
+    // Drive synchronously to the first pending await: purely-sync action chains apply inline
+    // (same-tick reads keep working); only a chain blocked on a real promise — an `invoke` of
+    // an async method — continues on the microtask queue, preserving `seq` ordering across it.
+    let waker = std::task::Waker::noop();
+    let mut cx = std::task::Context::from_waker(waker);
+    if fut.as_mut().poll(&mut cx).is_pending() {
+        wasm_bindgen_futures::spawn_local(fut);
+    }
     Ok(())
 }
 
-fn run(action: &spaday::Action, host: &Host) {
+fn run<'a>(action: &'a spaday::Action, host: &'a Host) -> Pin<Box<dyn Future<Output = ()> + 'a>> {
+    Box::pin(run_inner(action, host))
+}
+
+async fn run_inner(action: &spaday::Action, host: &Host) {
     use spaday::Action::{
         CallEndpoint, Download, Emit, If, Invoke, NamedJs, SendPatch, Sequence, SetField, SetProp,
         SetStorage, Toggle, ToggleField,
@@ -85,7 +100,7 @@ fn run(action: &spaday::Action, host: &Host) {
         }
         Sequence { actions } => {
             for a in actions {
-                run(a, host);
+                run(a, host).await;
             }
         }
         Emit { event, detail } => {
@@ -103,9 +118,9 @@ fn run(action: &spaday::Action, host: &Host) {
         }
         If { cond, then, els } => {
             if truthy(&eval(cond, host)) {
-                run(then, host);
+                run(then, host).await;
             } else if let Some(e) = els {
-                run(e, host);
+                run(e, host).await;
             }
         }
         CallEndpoint {
@@ -125,9 +140,24 @@ fn run(action: &spaday::Action, host: &Host) {
             target,
             method,
             args,
+            result,
         } => {
             if let Some(el) = resolve(target, host) {
-                host.call_method(&el, method, eval_args(args, host));
+                let value = host.call_method(&el, method, eval_args(args, host));
+                // await a returned promise so a `seq` continues only after the method settles;
+                // rejections were already marked handled (and logged) by the host
+                let thenable = value.is_object()
+                    && js_sys::Reflect::has(&value, &JsValue::from_str("then")).unwrap_or(false);
+                let resolved = if thenable {
+                    wasm_bindgen_futures::JsFuture::from(js_sys::Promise::resolve(&value))
+                        .await
+                        .unwrap_or(JsValue::UNDEFINED)
+                } else {
+                    value
+                };
+                if let Some(field) = result {
+                    host.set_field(field, resolved);
+                }
             }
         }
         SetStorage { key, value } => {

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -774,7 +774,7 @@ test("event expressions walk a path into a rich CustomEvent detail", async ({
 test("Invoke calls a component method with evaluated args; call reads a sync result", async ({
   page,
 }) => {
-  const r = await page.evaluate(() => {
+  const r = await page.evaluate(async () => {
     // a stand-in component: one async method (invoke) and one sync method (call)
     if (!customElements.get("x-panel-host")) {
       customElements.define(
@@ -835,6 +835,8 @@ test("Invoke calls a component method with evaluated args; call reads a sync res
       store,
     );
     root.querySelector("button").click();
+    // the seq awaits the async openPanel before the set-field step
+    await new Promise((resolve) => setTimeout(resolve, 20));
     const host = root.querySelector("x-panel-host");
     return { calls: host.calls, saved: store.get("saved") };
   });
@@ -899,4 +901,97 @@ test("SetStorage persists strings verbatim and objects as JSON; Download offers 
   expect(JSON.parse(r.b)).toEqual({ n: 1 }); // objects JSON-encoded
   expect(r.blobType).toBe("application/json");
   expect(r.anchor).toEqual({ href: "blob:stubbed", download: "layout.json" });
+});
+
+test("a Sequence awaits an async Invoke: result lands before the next step", async ({
+  page,
+}) => {
+  const r = await page.evaluate(async () => {
+    if (!customElements.get("x-async-saver")) {
+      customElements.define(
+        "x-async-saver",
+        class extends HTMLElement {
+          async saveClean() {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            return { layout: "clean" };
+          }
+          sync() {
+            return "sync-value";
+          }
+        },
+      );
+    }
+    const store = new window.__spaday.Store({
+      saved: null,
+      after: null,
+      syncImmediate: null,
+    });
+    const root = window.__spaday.mount(
+      document.body,
+      {
+        tag: "div",
+        slots: {
+          default: [
+            { tag: "x-async-saver", props: { id: { Str: "saver" } } },
+            {
+              tag: "button",
+              events: {
+                click: {
+                  kind: "seq",
+                  actions: [
+                    {
+                      kind: "invoke",
+                      target: { ref: "id", id: "saver" },
+                      method: "saveClean",
+                      result: "saved",
+                    },
+                    // runs only after the promise above settles: reads the landed result
+                    {
+                      kind: "set-field",
+                      field: "after",
+                      value: { expr: "field", name: "saved" },
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              tag: "button",
+              props: { id: { Str: "sync-btn" } },
+              events: {
+                click: {
+                  kind: "invoke",
+                  target: { ref: "id", id: "saver" },
+                  method: "sync",
+                  result: "syncImmediate",
+                },
+              },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    // a sync method with result= applies inline, same tick
+    root.querySelector("#sync-btn").click();
+    const syncImmediate = store.get("syncImmediate");
+    // the async chain: nothing lands synchronously...
+    root.querySelector("button").click();
+    const beforeSettle = {
+      saved: store.get("saved"),
+      after: store.get("after"),
+    };
+    // ...and after the promise settles, result first, then the dependent step
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    return {
+      syncImmediate,
+      beforeSettle,
+      saved: store.get("saved"),
+      after: store.get("after"),
+    };
+  });
+  expect(r.syncImmediate).toBe("sync-value"); // the sync fast path stayed same-tick
+  expect(r.beforeSettle).toEqual({ saved: null, after: null });
+  expect(r.saved).toEqual({ layout: "clean" });
+  expect(r.after).toEqual({ layout: "clean" }); // seq ordering held across the await
 });

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -194,6 +194,11 @@ pub enum Action {
         method: String,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         args: Vec<Expr>,
+        /// With `result`, the interpreter awaits an async method and writes the resolved value to
+        /// this signal-store field — and a `Sequence` waits for it before its next step, so
+        /// "save, then persist what was saved" is expressible as data.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        result: Option<String>,
     },
     /// Persist an evaluated value under `key` in the browser's localStorage — strings verbatim,
     /// other values JSON-encoded — e.g. saving a layout so a reload restores it.
@@ -337,6 +342,7 @@ mod tests {
                 args: vec![Expr::EventProp {
                     path: "currentTarget.dataset.tab".into(),
                 }],
+                result: None,
             },
             json!({
                 "kind": "invoke",
@@ -380,6 +386,26 @@ mod tests {
                 "kind": "download",
                 "filename": {"expr": "lit", "value": "layout.json"},
                 "value": {"expr": "call", "target": {"ref": "id", "id": "layout"}, "method": "save"},
+            }),
+        );
+    }
+
+    #[test]
+    fn invoke_with_result_field() {
+        round(
+            &Action::Invoke {
+                target: Ref::Id {
+                    id: "workspace".into(),
+                },
+                method: "saveClean".into(),
+                args: vec![],
+                result: Some("custom_layout".into()),
+            },
+            json!({
+                "kind": "invoke",
+                "target": {"ref": "id", "id": "workspace"},
+                "method": "saveClean",
+                "result": "custom_layout",
             }),
         );
     }

--- a/spaday/actions.py
+++ b/spaday/actions.py
@@ -489,16 +489,26 @@ class Invoke(Action):
         button.on("click", Invoke(by_id("layout"), "openPanel", event_prop("currentTarget.dataset.tab")))
 
     Prefer a component's declared methods (its CEM documents them); for a synchronous method whose
-    *result* you need, use the :func:`call` expression instead.
+    *result* you need inline, use the :func:`call` expression instead. With ``result=`` the
+    interpreter awaits an async method and writes the resolved value to that signal-store field —
+    and a :class:`Sequence` waits before its next step, so "save, then persist what was saved" is
+    expressible as data::
+
+        Sequence(
+            Invoke(by_id("workspace"), "saveClean", result="custom_layout"),
+            SetStorage("my_layout", field("custom_layout")),
+        )
     """
 
-    def __init__(self, target: Ref, method: str, *args: Any) -> None:
-        self.target, self.method, self.args = target, method, args
+    def __init__(self, target: Ref, method: str, *args: Any, result: str | None = None) -> None:
+        self.target, self.method, self.args, self.result = target, method, args, result
 
     def to_dict(self) -> dict[str, Any]:
         out: dict[str, Any] = {"kind": "invoke", "target": self.target.to_dict(), "method": self.method}
         if self.args:
             out["args"] = [_expr(a).to_dict() for a in self.args]
+        if self.result is not None:
+            out["result"] = self.result
         return out
 
 


### PR DESCRIPTION
The async half of #155, needed for csp-gateway's save/download-layout flows (which await `workspace.save()` before persisting):

- **`Invoke(..., result="field")`** awaits the method's returned promise and writes the resolved value to that signal-store field — the `CallEndpoint result=` precedent applied to component methods.
- **`Sequence` and `If` await each step**, so a chain like *save → persist what was saved → switch the selector* is plain data:

```python
Sequence(
    Invoke(by_id("workspace"), "saveClean", result="custom_layout"),
    SetStorage("my_layout", field("custom_layout")),
    SetField("layout_view", "Custom Layout"),
)
```

- **Same-tick semantics preserved**: `interpret` drives the action future one poll synchronously (`Waker::noop`) and only spawns the remainder onto the microtask queue when a real await is pending — purely synchronous chains apply inline exactly as before (a new browser test pins both: sync `result=` lands same-tick; an async chain lands nothing synchronously, then result-before-dependent-step ordering holds). The one existing test that assumed an async `Invoke` completed same-tick was updated — that assumption is exactly what this PR makes correct.

rust 58 / python 185 / playwright 122. Additive — patch release.