### PR TITLE
Add snake_case prop aliases, unknown-prop validation, and Toast

### DIFF
--- a/docs/src/behavior.md
+++ b/docs/src/behavior.md
@@ -139,6 +139,21 @@ WaButton().text("Send").on("click", CallEndpoint("POST", "/api/order", obj({"sym
 Show(WaCallout().compute("textContent", field("sent.body")), when=not_(field("sent.ok")))
 ```
 
+For transient notices, the shell's `Toast` (`spa-toast`) is the canonical error-reporting surface: a
+fixed corner stack of notifications with `info` / `success` / `danger` tones that auto-dismiss
+(`timeout` ms, default 5000; `0` keeps a toast until its close × is clicked). `Invoke` its `notify`
+method from any action chain — `Invoke(by_id("toasts"), "notify", obj({"message": lit("Saved"), "tone": lit("success")}))` — or drive its bindable `message` prop from state: every non-empty write
+enqueues a toast, with the `tone` prop read at enqueue time, so a `result=` failure surfaces with no
+handler:
+
+```python
+from spaday import cond, field, lit
+from spaday.components.shell import Toast
+
+toasts = Toast(tone="danger", id="toasts")
+toasts.compute("message", cond(field("sent.ok"), lit(""), field("sent.body")))
+```
+
 `SendPatch` is usually unnecessary once you use a two-way binding (above) — the binding carries the
 control→model edit declaratively. Reach for `SendPatch` for an imperative edit that
 isn't a simple control value. When several models share a page, a `SendPatch("ns", field, value)` is
@@ -248,3 +263,13 @@ a `TypeError` naming the component tag, the prop, and the offending value, inste
 as an opaque component error in the browser. Two limits: reactive bindings and computed values are
 dynamic and stay unvalidated, and `json`-kind props (lists, objects, mixed unions, untyped props all
 map to that kind) are type-opaque, so no literal shape can be ruled out for them.
+
+Prop *names* are checked too. A schema-carrying component's constructor accepts the snake_case
+spelling of each camelCase CEM prop and normalizes it to the canonical name —
+`Dagre(max_label_width=180)` sets `maxLabelWidth`; passing both spellings at once raises. And
+`spaday.validate` checks every node that still knows its catalog schema for unknown prop and binding
+names: a typo raises a `ValidationError` naming the tag and prop, with a "did you mean" hint when the
+unknown name is the snake_case spelling of a real prop. Generic globals (`id`, `class`, `style`,
+`slot`, `data-*` / `aria-*`, …) always pass; nodes without a schema — `element(...)` escape hatches
+and serialized dict trees — stay unvalidated, as do two-way binding names, which target live
+form-control properties a manifest routinely omits.

--- a/js/src/ts/shell.ts
+++ b/js/src/ts/shell.ts
@@ -24,13 +24,24 @@ const THEME_CSS = `:where(.wa-dark) {
   --spa-surface-2: #1d232b;
   --spa-border: #333b45;
   --spa-muted: #9aa3ad;
+  --spa-info: #5b9dd9;
+  --spa-success: #58a765;
+  --spa-danger: #d9636a;
 }
 :where(.wa-light) {
   --spa-surface: #fff;
   --spa-surface-2: #fafafa;
   --spa-border: #e6e6e6;
   --spa-muted: #666;
+  --spa-info: #1565c0;
+  --spa-success: #2e7d32;
+  --spa-danger: #c62828;
 }`;
+
+// Tone accents for notification surfaces (light defaults; the dark palette overrides above).
+const INFO = "var(--spa-info, #1565c0)";
+const SUCCESS = "var(--spa-success, #2e7d32)";
+const DANGER = "var(--spa-danger, #c62828)";
 
 /** tag → the element's `:host` layout style. Each gets a shadow root with this style + a default slot. */
 const SHELL: Record<string, string> = {
@@ -428,6 +439,85 @@ if (typeof customElements !== "undefined" && !customElements.get("spa-popup")) {
       #undismiss(): void {
         document.removeEventListener("pointerdown", this.#onPointerDown, true);
         document.removeEventListener("keydown", this.#onKeyDown, true);
+      }
+    },
+  );
+}
+
+// Transient notifications (`spa-toast`): a fixed corner stack of notices, the shell's canonical
+// surface for reporting action outcomes (e.g. a `CallEndpoint` failure). Enqueue imperatively via
+// the `notify` method — from Python, `Invoke(by_id("toasts"), "notify", obj({...}))` — or
+// reactively by setting the bindable `message` property (each non-empty write enqueues a toast,
+// with the `tone` property read at enqueue time). A toast auto-dismisses after `timeout` ms
+// (default 5000); `timeout: 0` keeps it until its close button is clicked.
+const TOAST_CSS = `:host{position:fixed;right:1rem;bottom:1rem;z-index:1100;display:flex;flex-direction:column;align-items:flex-end;gap:.5rem;pointer-events:none}
+.toast{display:flex;align-items:center;gap:.6rem;padding:.55rem .8rem;max-width:24rem;border:1px solid ${BORDER};border-left:3px solid ${INFO};border-radius:8px;background:${SURFACE};color:inherit;font-size:.9rem;box-shadow:0 2px 10px rgba(0,0,0,.18);pointer-events:auto}
+.toast.success{border-left-color:${SUCCESS}}
+.toast.danger{border-left-color:${DANGER}}
+.toast button{all:unset;cursor:pointer;color:${MUTED};font-size:1rem;line-height:1;padding:0 .1rem}`;
+
+type ToastTone = "info" | "success" | "danger";
+
+function toastTone(value: unknown): ToastTone {
+  return value === "success" || value === "danger" ? value : "info";
+}
+
+if (typeof customElements !== "undefined" && !customElements.get("spa-toast")) {
+  customElements.define(
+    "spa-toast",
+    class extends HTMLElement {
+      #root: ShadowRoot;
+      #tone: ToastTone = "info";
+
+      constructor() {
+        super();
+        this.#root = this.attachShadow({ mode: "open" });
+        const style = document.createElement("style");
+        style.textContent = TOAST_CSS;
+        this.#root.append(style);
+      }
+
+      get tone(): ToastTone {
+        return this.#tone;
+      }
+
+      set tone(value: unknown) {
+        this.#tone = toastTone(value);
+      }
+
+      // The store-driven pattern: a bound/computed `message` enqueues on every non-empty write
+      // (clearing to ""/null enqueues nothing, so a computed failure message stays quiet on success).
+      get message(): string {
+        return "";
+      }
+
+      set message(value: unknown) {
+        if (value == null || value === "") return;
+        this.notify({ message: value, tone: this.#tone });
+      }
+
+      notify(
+        options: { message?: unknown; tone?: unknown; timeout?: unknown } = {},
+      ): void {
+        const toast = document.createElement("div");
+        toast.className = `toast ${toastTone(options.tone)}`;
+        const text = document.createElement("span");
+        text.textContent =
+          options.message == null ? "" : String(options.message);
+        toast.append(text);
+        const timeout = Number(options.timeout ?? 5000);
+        if (timeout > 0) {
+          setTimeout(() => toast.remove(), timeout);
+        } else {
+          // sticky: stays until its close button is clicked
+          const close = document.createElement("button");
+          close.type = "button";
+          close.setAttribute("aria-label", "close");
+          close.textContent = "×";
+          close.addEventListener("click", () => toast.remove());
+          toast.append(close);
+        }
+        this.#root.append(toast);
       }
     },
   );

--- a/js/tests/shell.spec.js
+++ b/js/tests/shell.spec.js
@@ -405,6 +405,98 @@ test("spa-popup clamps into the viewport and closes on Escape", async ({
   ).toBe(false);
 });
 
+test("spa-toast notify() renders a toned toast and auto-dismisses after its timeout", async ({
+  page,
+}) => {
+  const r = await page.evaluate(async () => {
+    const el = window.__spaday.mount(document.body, { tag: "spa-toast" });
+    el.notify({ message: "saved", tone: "success", timeout: 200 });
+    el.notify({ message: "fyi" }); // default tone info, default (long) timeout
+    const toasts = [...el.shadowRoot.querySelectorAll(".toast")];
+    const before = toasts.map((t) => ({
+      text: t.textContent,
+      classes: [...t.classList],
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    return {
+      before,
+      after: [...el.shadowRoot.querySelectorAll(".toast")].map(
+        (t) => t.textContent,
+      ),
+    };
+  });
+  expect(r.before).toEqual([
+    { text: "saved", classes: ["toast", "success"] },
+    { text: "fyi", classes: ["toast", "info"] },
+  ]);
+  // the 200ms toast is gone; the default-timeout toast is still up
+  expect(r.after).toEqual(["fyi"]);
+});
+
+test("spa-toast keeps a timeout-0 toast until its close button is clicked", async ({
+  page,
+}) => {
+  const r = await page.evaluate(async () => {
+    const el = window.__spaday.mount(document.body, { tag: "spa-toast" });
+    el.notify({ message: "boom", tone: "danger", timeout: 0 });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const toast = el.shadowRoot.querySelector(".toast");
+    const close = toast.querySelector("button");
+    const sticky = {
+      stillUp: !!toast.isConnected,
+      danger: toast.classList.contains("danger"),
+      text: toast.querySelector("span").textContent,
+      closeLabel: close.getAttribute("aria-label"),
+    };
+    close.click();
+    return {
+      sticky,
+      afterClose: el.shadowRoot.querySelectorAll(".toast").length,
+    };
+  });
+  expect(r.sticky).toEqual({
+    stillUp: true,
+    danger: true,
+    text: "boom",
+    closeLabel: "close",
+  });
+  expect(r.afterClose).toBe(0);
+});
+
+test("spa-toast enqueues from a bound message field, reading tone at enqueue time", async ({
+  page,
+}) => {
+  const r = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ error: "" });
+    const el = mount(
+      document.body,
+      {
+        tag: "spa-toast",
+        props: { tone: { Str: "danger" } },
+        bindings: { message: { field: "error", mode: "one-way" } },
+      },
+      store,
+    );
+    const count = () => el.shadowRoot.querySelectorAll(".toast").length;
+    const initial = count(); // the empty initial field value enqueues nothing
+    store.set("error", "request failed");
+    const toast = el.shadowRoot.querySelector(".toast");
+    return {
+      initial,
+      after: count(),
+      text: toast.textContent,
+      danger: toast.classList.contains("danger"),
+    };
+  });
+  expect(r).toEqual({
+    initial: 0,
+    after: 1,
+    text: "request failed",
+    danger: true,
+  });
+});
+
 test("spa-popup falls back to the last-known pointer position when x/y are not finite", async ({
   page,
 }) => {

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -13,6 +13,8 @@ the runtime interprets the action in the browser on the DOM event, with no round
 from __future__ import annotations
 
 import json
+import re
+from functools import lru_cache
 from typing import Any, ClassVar, Union
 
 from .actions import Action, Expr
@@ -29,6 +31,23 @@ def _attr_name(name: str) -> str:
     """A Python kwarg → its attribute name: drop one trailing underscore so reserved words work
     (``class_`` → ``class``, ``for_`` → ``for``)."""
     return name.removesuffix("_")
+
+
+def _snake_name(name: str) -> str:
+    """A camelCase prop name → its snake_case spelling (``maxLabelWidth`` → ``max_label_width``)."""
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", "_", name).lower()
+
+
+@lru_cache(maxsize=None)
+def _prop_aliases(schema: ComponentSchema) -> dict[str, str]:
+    """snake_case spelling → canonical prop name, for schema props where the two spellings differ."""
+    names = {prop.name for prop in schema.props}
+    aliases: dict[str, str] = {}
+    for prop in schema.props:
+        snake = _snake_name(prop.name)
+        if snake != prop.name and snake not in names:
+            aliases.setdefault(snake, prop.name)
+    return aliases
 
 
 def _tag(value: Any) -> Any:
@@ -88,7 +107,17 @@ class Component:
     def __init__(self, *children: Child, key: str | None = None, props: dict[str, Any] | None = None, **attrs: Any) -> None:
         self._key = key
         merged = dict(props or {})  # typed props (from a subclass) + generic keyword props (id, style, …)
-        merged.update({_attr_name(k): v for k, v in attrs.items()})
+        generic = {_attr_name(k): v for k, v in attrs.items()}
+        if type(self).schema is not None and generic:
+            # a schema-carrying class also accepts the snake_case spelling of each camelCase prop
+            # (`max_label_width=` lands as prop `maxLabelWidth`); both spellings at once is ambiguous
+            aliases = _prop_aliases(type(self).schema)
+            for name in [n for n in generic if n in aliases and generic[n] is not None]:
+                canonical = aliases[name]
+                if generic.get(canonical) is not None or merged.get(canonical) is not None:
+                    raise TypeError(f"<{self.tag}> prop {canonical!r} passed under both spellings ({name!r} and {canonical!r})")
+                generic[canonical] = generic.pop(name)
+        merged.update(generic)
         self._props: dict[str, Any] = {k: v for k, v in merged.items() if v is not None}
         if type(self).schema is not None:
             self._check_prop_kinds()

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -41,6 +41,7 @@ __all__ = [
     "Switch",
     "Stack",
     "Table",
+    "Toast",
     "Toolbar",
 ]
 
@@ -308,6 +309,33 @@ class Lazy(Component):
             if not isinstance(when, Expr):
                 raise TypeError(f"Lazy when must be an Expr, got {type(when).__name__}")
             self._bindings["when"] = {"compute": when.to_dict(), "mode": "one-way"}
+
+
+class Toast(Component):
+    """Transient corner notifications (``spa-toast``) — the shell's surface for reporting action
+    outcomes, most usefully failures.
+
+    Notices stack in the viewport corner with a tone accent (``"info"`` / ``"success"`` /
+    ``"danger"``) and auto-dismiss after ``timeout`` ms (default 5000; ``0`` keeps a toast until its
+    close × is clicked). Trigger one two ways. Imperatively, :class:`~spaday.actions.Invoke` the
+    element's ``notify`` method from any action chain::
+
+        toasts = Toast(id="toasts")
+        save.on("click", Invoke(by_id("toasts"), "notify", obj({"message": lit("Saved"), "tone": lit("success")})))
+
+    Reactively, drive the bindable ``message`` prop from state — every non-empty write enqueues a
+    toast, with the optional ``tone`` prop read at enqueue time (an empty message enqueues nothing).
+    This is the canonical way to surface a ``CallEndpoint`` failure from its ``result=`` field::
+
+        toasts = Toast(tone="danger", id="toasts")
+        submit.on("click", CallEndpoint("POST", "/api/thing", body=..., result="submit_result"))
+        # surface failures from the result field …
+        toasts.compute("message", cond(field("submit_result.ok"), lit(""), field("submit_result.body")))
+        # … or drive any reactive fallback UI from the same field
+        page.add(Show(..., when=not_(field("submit_result.ok"))))
+    """
+
+    tag = "spa-toast"
 
 
 class Show(Component):

--- a/spaday/tests/test_cem.py
+++ b/spaday/tests/test_cem.py
@@ -139,6 +139,59 @@ def test_prop_kind_validation_covers_number_and_leaves_json_dynamic():
     assert element("div", count="3").to_node()["props"]["count"] == {"Str": "3"}
 
 
+def _camel_demo() -> type[Component]:
+    class Demo(Component):
+        tag = "demo-graph"
+        schema = ComponentSchema.from_cem(
+            {
+                "tag_name": "demo-graph",
+                "class_name": "DemoGraph",
+                "props": [{"name": "maxLabelWidth", "ty": "Number"}, {"name": "size", "ty": "Str"}],
+            }
+        )
+
+    return Demo
+
+
+def test_schema_component_accepts_snake_case_prop_aliases():
+    Demo = _camel_demo()
+    # the snake_case spelling normalizes to the canonical CEM name instead of inventing a new prop
+    assert Demo(max_label_width=180).to_node()["props"] == {"maxLabelWidth": {"Int": 180}}
+    # the canonical spelling still works; names whose spellings coincide need no alias
+    assert Demo(maxLabelWidth=180).to_node()["props"] == {"maxLabelWidth": {"Int": 180}}
+    assert Demo(size="s").to_node()["props"] == {"size": {"Str": "s"}}
+    # an aliased value is kind-checked under the canonical name
+    with pytest.raises(TypeError, match=r"<demo-graph> prop 'maxLabelWidth' expects kind 'number'"):
+        Demo(max_label_width="wide")
+
+
+def test_schema_component_rejects_both_prop_spellings_at_once():
+    Demo = _camel_demo()
+    with pytest.raises(TypeError, match=r"<demo-graph> prop 'maxLabelWidth' passed under both spellings"):
+        Demo(maxLabelWidth=100, max_label_width=180)
+    # an explicit None means "unset", so it doesn't count as the other spelling
+    assert Demo(maxLabelWidth=None, max_label_width=180).to_node()["props"] == {"maxLabelWidth": {"Int": 180}}
+
+
+def test_generated_module_aliases_snake_case_kwargs():
+    # the aliasing lives in the shared Component base, so generated module text is unchanged —
+    # a class exec'd from rendered code picks it up with no regeneration
+    from spaday.cem import render
+
+    ns: dict = {}
+    exec(render([{"tag_name": "x-graph", "class_name": "XGraph", "props": [{"name": "maxLabelWidth", "ty": "Number"}]}]), ns)  # noqa: S102
+    assert ns["XGraph"](max_label_width=180).to_node()["props"]["maxLabelWidth"] == {"Int": 180}
+    with pytest.raises(TypeError, match="both spellings"):
+        ns["XGraph"](maxLabelWidth=100, max_label_width=180)
+
+
+def test_schema_free_components_keep_snake_case_props_verbatim():
+    from spaday import element
+
+    # element() carries no schema: arbitrary attribute names pass through untouched
+    assert element("div", max_label_width=1).to_node()["props"] == {"max_label_width": {"Int": 1}}
+
+
 def test_typed_signatures_rendered():
     code = generate(FIXTURE)
     assert 'size: Literal["small", "medium", "large"] | None = None' in code

--- a/spaday/tests/test_shell.py
+++ b/spaday/tests/test_shell.py
@@ -4,7 +4,7 @@ import pytest
 
 from spaday import Paragraph, Strong, Text, apply, diff, element
 from spaday.actions import NamedJs, field, item, not_
-from spaday.components.shell import App, AppShell, Body, Column, Each, Footer, Gutter, Main, Nav, Region, Row, Show, Stack, Table, Toolbar
+from spaday.components.shell import App, AppShell, Body, Column, Each, Footer, Gutter, Main, Nav, Region, Row, Show, Stack, Table, Toast, Toolbar
 
 
 def test_shell_classes_emit_spa_tags():
@@ -243,6 +243,21 @@ def test_each_validates_its_source_key_and_scope(kwargs, message):
 def test_each_requires_one_component_template():
     with pytest.raises(TypeError, match="one Component"):
         Each("text", field="rows", key="id")
+
+
+def test_toast_authors_a_spa_toast_with_both_trigger_patterns():
+    # imperative target: an id for Invoke(by_id("toasts"), "notify", ...)
+    node = Toast(id="toasts").to_node()
+    assert node["tag"] == "spa-toast"
+    assert node["props"]["id"] == {"Str": "toasts"}
+    # store-driven: a bound message enqueues, with the tone prop read at enqueue time
+    node = Toast(tone="danger").bind("message", "submit_error").to_node()
+    assert node["props"]["tone"] == {"Str": "danger"}
+    assert node["bindings"]["message"] == {"field": "submit_error", "mode": "one-way"}
+    # exported alongside the other shell components
+    from spaday import components
+
+    assert components.Toast is Toast
 
 
 def test_table_authors_a_spa_table():

--- a/spaday/tests/test_validate.py
+++ b/spaday/tests/test_validate.py
@@ -3,6 +3,8 @@ import pytest
 import spaday
 from spaday import (
     CallEndpoint,
+    Component,
+    ComponentSchema,
     Emit,
     If,
     Sequence,
@@ -16,6 +18,19 @@ from spaday import (
     this,
     validate,
 )
+
+
+class Dagre(Component):
+    """A stand-in for a CEM-generated component: carries a catalog schema."""
+
+    tag = "spa-dagre"
+    schema = ComponentSchema.from_cem(
+        {
+            "tag_name": "spa-dagre",
+            "class_name": "Dagre",
+            "props": [{"name": "maxLabelWidth", "ty": "Number"}, {"name": "layout", "ty": "Str"}],
+        }
+    )
 
 
 def test_resolved_by_id_passes():
@@ -70,6 +85,34 @@ def test_validate_accepts_a_serialized_node_dict():
     node = element("button").on("click", Toggle(by_id("x"), "hidden")).to_node()
     with pytest.raises(ValidationError):
         validate(node)
+
+
+def test_unknown_prop_on_a_schema_component_raises_with_a_snake_case_hint():
+    tree = element("div").child(Dagre().prop("max_label_width", 180))
+    with pytest.raises(ValidationError) as exc:
+        validate(tree)
+    assert "<spa-dagre> unknown prop 'max_label_width' (did you mean 'maxLabelWidth'?)" in str(exc.value)
+
+
+def test_unknown_binding_without_a_snake_case_match_gets_no_hint():
+    with pytest.raises(ValidationError) as exc:
+        validate(Dagre().bind("maxLabelWdith", "width"))
+    msg = str(exc.value)
+    assert "<spa-dagre> unknown prop 'maxLabelWdith'" in msg
+    assert "did you mean" not in msg
+
+
+def test_schema_props_globals_and_schema_free_nodes_pass_the_prop_check():
+    validate(Dagre(maxLabelWidth=180, id="graph", class_="card").prop("data-x", "1").prop("aria-label", "graph"))
+    validate(Dagre().bind("layout", "layout_field").compute("textContent", spaday.field("title")))
+    validate(element("div", max_label_width=1))  # element() carries no schema — stays unvalidated
+    # two-way bindings target live form-control properties a manifest routinely omits — unchecked
+    validate(Dagre().bind("value", "selection", mode="two-way"))
+
+
+def test_serialized_dict_trees_skip_the_prop_check():
+    # a plain node dict no longer knows its schema, so only by_id resolution runs on it
+    validate(Dagre().prop("mystery", 1).to_node())
 
 
 def test_exported_from_package():

--- a/spaday/validate.py
+++ b/spaday/validate.py
@@ -5,15 +5,18 @@ id — a silent, easy-to-miss bug. :func:`validate` walks the tree and raises :c
 listing every ``by_id`` reference (in an action or a ``prop(...)`` expression, however deeply nested)
 that doesn't resolve to a node's id in the same tree.
 
-Reactive ``bind`` targets a state *field*, not a node, so it has nothing to resolve here; and prop
-*names* aren't checked (the typed component constructors already validate those, and the string escape
-hatches legitimately allow custom attributes).
+Reactive ``bind`` targets a state *field*, not a node, so it has nothing to resolve here. Prop and
+binding *names* are checked too, wherever a catalog schema is known — see :func:`validate`.
 """
 
 from collections.abc import Iterator
 from typing import Any
 
-from .component import Component
+from .component import Component, _snake_name
+
+#: Generic props the runtime sets on any element, so they pass the unknown-prop check everywhere.
+_GLOBAL_PROPS = {"id", "class", "style", "slot", "part", "title", "role", "hidden", "tabindex", "textContent"}
+_GLOBAL_PREFIXES = ("data-", "aria-")
 
 
 class ValidationError(ValueError):
@@ -68,10 +71,38 @@ def _collect_refs(node: dict, refs: list[str]) -> None:
             _collect_refs(child, refs)
 
 
+def _collect_unknown_props(component: Component, problems: list[str]) -> None:
+    schema = type(component).schema
+    if schema is not None:
+        known = {prop.name for prop in schema.props}
+        # two-way bindings target live form-control properties (a composed control's `value` is
+        # routinely absent from its manifest), so their names stay unchecked
+        bound = [n for n, b in component._bindings.items() if b.get("mode") != "two-way" and not n.startswith("root-class:")]
+        names = list(component._props) + bound
+        for name in names:
+            if name in known or name in _GLOBAL_PROPS or name.startswith(_GLOBAL_PREFIXES):
+                continue
+            hint = next((p for p in sorted(known) if _snake_name(p) == name), None)
+            problems.append(f"<{component.tag}> unknown prop {name!r}" + (f" (did you mean {hint!r}?)" if hint else ""))
+    for children in component._slots.values():
+        for child in children:
+            if isinstance(child, Component):
+                _collect_unknown_props(child, problems)
+
+
 def validate(tree: Component | dict) -> None:
-    """Raise :class:`ValidationError` if any ``by_id(...)`` reference in the tree's actions is unresolved.
+    """Raise :class:`ValidationError` if the tree has unresolved ``by_id(...)`` references or unknown props.
 
     Pass a :class:`~spaday.component.Component` (or its serialized node dict). Returns ``None`` on success.
+
+    Two checks run. Every ``by_id`` reference (in an action or a ``prop(...)`` expression) must resolve
+    to a node's id in the same tree. And on each node that carries a catalog ``schema`` (CEM-generated
+    components retain one), every prop and binding name must be a schema prop or a generic global
+    (``id``, ``class``, ``style``, ``slot``, …, plus ``data-*``/``aria-*``); an unknown name is reported
+    with the tag and — when it is the snake_case spelling of a real prop — a "did you mean" hint. The
+    prop check only reaches what still knows its schema: nodes built by ``element(...)`` and serialized
+    dict trees carry none, so they stay unvalidated — as do two-way binding names, which target live
+    form-control properties a manifest routinely omits.
     """
     node = tree.to_node() if isinstance(tree, Component) else tree
     ids: set[str] = set()
@@ -82,3 +113,8 @@ def validate(tree: Component | dict) -> None:
     if missing:
         known = sorted(ids)
         raise ValidationError("unresolved by_id reference(s): " + ", ".join(repr(m) for m in missing) + f" (known ids: {known})")
+    if isinstance(tree, Component):
+        problems: list[str] = []
+        _collect_unknown_props(tree, problems)
+        if problems:
+            raise ValidationError("unknown prop(s): " + "; ".join(problems))


### PR DESCRIPTION
Round-2 feedback, items 1 and 5. Both are additive (patch-level); no version bump. Stacked on `tree-scale` (which stacks on async-actions, #156) — only the last commit here is new.

**Unknown props are accepted silently / no snake_case spellings (item 1)**

- Schema-carrying component constructors (CEM-generated classes, `classes()`-built classes, hand-authored classes with a catalog `schema`) accept the snake_case spelling of each camelCase prop and normalize it to the canonical name: `Dagre(max_label_width=180)` now sets `maxLabelWidth` instead of silently inventing a `max_label_width` prop. Passing both spellings at once raises. The aliasing lives in the shared `Component` base (`spaday/component.py`), not in emitted code, so `generate()` output is byte-identical and peer catalogs need no regeneration (the drift checks stay green).
- `spaday.validate()` additionally checks prop and binding names on every node that still knows its catalog schema: an unknown name raises `ValidationError` naming the tag and the prop, with a `did you mean 'maxLabelWidth'?` hint when the unknown name is the snake_case spelling of a real prop. Generic globals (`id`, `class`, `style`, `slot`, `data-*`/`aria-*`, ...) always pass. Unvalidated by design, and documented in the docstring: `element()` nodes and serialized dict trees (no schema attached), and two-way binding names, which target live form-control properties a manifest routinely omits (e.g. `value` on `wa-checkbox-group` in the gallery examples).

**No notification primitive for action failures (item 5)**

- `spa-toast` (`js/src/ts/shell.ts`, following the `spa-popup` precedent): a fixed corner stack of transient notices themed on `--spa-*` tokens with `wa-dark`/`wa-light` variants, tones `info`/`success`/`danger`. `notify({message, tone?, timeout?})` is a method, so `Invoke(by_id("toasts"), "notify", obj({...}))` is the declarative trigger; `timeout` defaults to 5000 ms and `0` keeps a toast until its close × is clicked. The bindable `message` prop enqueues on every non-empty write (with `tone` read at enqueue time) for the store-driven pattern.
- Python `Toast` (`spaday/components/shell.py`, tag `spa-toast`), exported via the shell `__all__` and `spaday.components`, with a docstring showing both trigger patterns including the `CallEndpoint(result=...)` failure case. Documented in `docs/src/behavior.md` next to the `result=` section as the canonical error-reporting pattern.

Tests: alias normalization, spelling collision, generated-module pass-through, unknown-prop/binding errors with and without hints, schema-free and dict-tree boundaries, and the Toast authoring shape on the Python side; `notify()` tone + auto-dismiss, sticky `timeout: 0` with close button, and bound-message enqueueing in the Playwright shell suite.
