### PR TITLE
Evaluate arr in computed bindings and resolve thenable action values

### DIFF
--- a/js/src/rust/lib.rs
+++ b/js/src/rust/lib.rs
@@ -159,43 +159,43 @@ async fn run_inner(action: &spaday::Action, host: &Host) {
                 let value = host.call_method(&el, method, eval_args(args, host));
                 // await a returned promise so a `seq` continues only after the method settles;
                 // rejections were already marked handled (and logged) by the host
-                let thenable = value.is_object()
-                    && js_sys::Reflect::has(&value, &JsValue::from_str("then")).unwrap_or(false);
-                let resolved = if thenable {
-                    wasm_bindgen_futures::JsFuture::from(js_sys::Promise::resolve(&value))
-                        .await
-                        .unwrap_or(JsValue::UNDEFINED)
-                } else {
-                    value
-                };
+                let resolved = resolve_thenable(value).await;
                 if let Some(field) = result {
                     host.set_field(field, resolved);
                 }
             }
         }
         SetStorage { key, value } => {
-            host.set_storage(key, eval(value, host));
+            // resolve a thenable value (e.g. a `call` of an async method) before persisting
+            let resolved = resolve_thenable(eval(value, host)).await;
+            host.set_storage(key, resolved);
         }
         Download {
             filename,
             value,
             content_type,
         } => {
-            host.download(
-                eval(filename, host),
-                eval(value, host),
-                content_type.as_deref(),
-            );
+            let resolved = resolve_thenable(eval(value, host)).await;
+            host.download(eval(filename, host), resolved, content_type.as_deref());
         }
         NamedJs { handler } => host.call_named(handler),
     }
 }
 
 async fn await_thenable(value: JsValue) {
+    resolve_thenable(value).await;
+}
+
+/// Resolve a thenable to its settled value (undefined on rejection); pass anything else through.
+async fn resolve_thenable(value: JsValue) -> JsValue {
     let thenable = value.is_object()
         && js_sys::Reflect::has(&value, &JsValue::from_str("then")).unwrap_or(false);
     if thenable {
-        let _ = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::resolve(&value)).await;
+        wasm_bindgen_futures::JsFuture::from(js_sys::Promise::resolve(&value))
+            .await
+            .unwrap_or(JsValue::UNDEFINED)
+    } else {
+        value
     }
 }
 

--- a/js/src/ts/signals.ts
+++ b/js/src/ts/signals.ts
@@ -337,6 +337,8 @@ export function evalExpr(expr: unknown, store?: Store, scope?: Scope): unknown {
         out[k] = evalExpr(v, store, scope);
       return out;
     }
+    case "arr":
+      return (e.of as unknown[]).map((x) => evalExpr(x, store, scope));
     case "concat":
       return (e.parts as unknown[])
         .map((part) => String(evalExpr(part, store, scope)))

--- a/js/tests/actions.spec.js
+++ b/js/tests/actions.spec.js
@@ -995,3 +995,63 @@ test("a Sequence awaits an async Invoke: result lands before the next step", asy
   expect(r.saved).toEqual({ layout: "clean" });
   expect(r.after).toEqual({ layout: "clean" }); // seq ordering held across the await
 });
+
+test("set-storage and download resolve a thenable value (a call of an async method)", async ({
+  page,
+}) => {
+  const r = await page.evaluate(async () => {
+    localStorage.removeItem("async-layout");
+    const downloads = [];
+    const realCreate = URL.createObjectURL;
+    URL.createObjectURL = (blob) => {
+      downloads.push(blob);
+      return "blob:stubbed";
+    };
+    const realClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = function () {
+      downloads.push({ download: this.download });
+    };
+    const workspace = document.createElement("div");
+    workspace.id = "async-ws";
+    workspace.save = async () => ({ layout: "clean" });
+    document.body.appendChild(workspace);
+    const saveCall = {
+      expr: "call",
+      target: { ref: "id", id: "async-ws" },
+      method: "save",
+    };
+    const btn = window.__spaday.mount(document.body, {
+      tag: "button",
+      events: {
+        click: {
+          kind: "seq",
+          actions: [
+            { kind: "set-storage", key: "async-layout", value: saveCall },
+            {
+              kind: "download",
+              filename: { expr: "lit", value: "layout.json" },
+              value: saveCall,
+            },
+          ],
+        },
+      },
+    });
+    btn.click();
+    // the chain defers on the first thenable; wait for the download to land
+    for (let i = 0; i < 100 && downloads.length < 2; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    URL.createObjectURL = realCreate;
+    HTMLAnchorElement.prototype.click = realClick;
+    workspace.remove();
+    return {
+      stored: localStorage.getItem("async-layout"),
+      blobText: await downloads[0].text(),
+      anchor: downloads[1],
+    };
+  });
+  // the resolved object is persisted/downloaded, not the promise's JSON ("{}")
+  expect(JSON.parse(r.stored)).toEqual({ layout: "clean" });
+  expect(JSON.parse(r.blobText)).toEqual({ layout: "clean" });
+  expect(r.anchor.download).toBe("layout.json");
+});

--- a/js/tests/signals.spec.js
+++ b/js/tests/signals.spec.js
@@ -570,3 +570,43 @@ test("a binding to a dotted path reacts to nested state, two-way", async ({
   expect(result.initial).toBe("Main");
   expect(result.stored).toBe("Oak");
 });
+
+test("an arr expr composes a list from sub-expressions reactively", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    // a probe element with a real `selected` property, so the list lands unstringified
+    customElements.define(
+      "arr-probe",
+      class extends HTMLElement {
+        selected = null;
+      },
+    );
+    const store = new Store({ path: "a/b" });
+    const root = mount(
+      document.createElement("div"),
+      {
+        tag: "arr-probe",
+        bindings: {
+          selected: {
+            compute: {
+              expr: "arr",
+              of: [
+                { expr: "field", name: "path" },
+                { expr: "lit", value: "pinned" },
+              ],
+            },
+            mode: "one-way",
+          },
+        },
+      },
+      store,
+    );
+    const initial = root.selected;
+    store.set("path", "c/d");
+    return { initial, after: root.selected };
+  });
+  expect(result.initial).toEqual(["a/b", "pinned"]);
+  expect(result.after).toEqual(["c/d", "pinned"]);
+});


### PR DESCRIPTION
Two gaps surfaced while building against 0.7.6:

- `arr` was in the Python DSL and the wasm action interpreter, but the client compute evaluator (`evalExpr`) had no case for it, so `.compute(prop, arr(field(...)))` silently evaluated to `undefined`. Found while wiring spaday-dagre's new `emphasis` prop.
- `SetStorage` and `Download` passed their evaluated value to the host unresolved, so the documented `Download("layout.json", call(by_id("layout"), "save"))` pattern serialized the pending promise as `{}` for any async method. The interpreter now resolves a thenable value first (same helper the `Invoke result=` path uses), keeping fully-sync chains on the same-tick fast path.