### PR TITLE
Refresh structural subtrees and validate serialized dict trees

### DIFF
--- a/docs/src/behavior.md
+++ b/docs/src/behavior.md
@@ -195,7 +195,10 @@ megabytes on first paint.
 
 Finally, `RefreshTree` covers "server state changed, re-render" for apps that don't need a live wire:
 it re-fetches the page's `tree.json` (or an explicit `url=`) and diffs it into the mounted tree with
-the core's patch machinery, so unchanged nodes keep their identity and client state. Actions in a
+the core's patch machinery, so unchanged nodes keep their identity and client state. The diff
+descends into structural bindings: a changed branch inside a `Show`/`Switch` re-renders (including
+the stored bodies of a `Switch`'s non-mounted cases), and every loaded `Lazy` body is re-fetched
+from its `src` — swapped only if the payload actually changed. Actions in a
 `Sequence` are awaited in order — `CallEndpoint` resolves before the next action runs — so mutate-
 then-refresh is one chain:
 
@@ -319,6 +322,8 @@ spelling of each camelCase CEM prop and normalizes it to the canonical name —
 `spaday.validate` checks every node that still knows its catalog schema for unknown prop and binding
 names: a typo raises a `ValidationError` naming the tag and prop, with a "did you mean" hint when the
 unknown name is the snake_case spelling of a real prop. Generic globals (`id`, `class`, `style`,
-`slot`, `data-*` / `aria-*`, …) always pass; nodes without a schema — `element(...)` escape hatches
-and serialized dict trees — stay unvalidated, as do two-way binding names, which target live
-form-control properties a manifest routinely omits.
+`slot`, `data-*` / `aria-*`, …) always pass. On a serialized dict tree, schemas resolve by tag
+instead — every schema-carrying class that has been imported registers its tag — so
+`validate(component.to_node())` checks the same props as `validate(component)`. Nodes with no
+schema either way (`element(...)` escape hatches) stay unvalidated, as do two-way binding names,
+which target live form-control properties a manifest routinely omits.

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -83,6 +83,7 @@ export function trackRoot(
 
 export async function refreshRoots(url?: string): Promise<void> {
   const { diff } = await import("../../dist/pkg/spaday");
+  lazyCache.clear(); // server state changed: cached lazy bodies are stale
   for (const tracked of trackedRoots) {
     const source = url ?? tracked.src;
     if (!source) continue;
@@ -95,6 +96,12 @@ export async function refreshRoots(url?: string): Promise<void> {
     ) as { ops: Op[] };
     tracked.root = applyPatch(tracked.root, patch, tracked.store);
     tracked.node = next;
+    // mounted lazy bodies live at their own URLs, which the tree diff can't see — refetch
+    // them (the reloader swaps the body only if the payload actually changed)
+    for (const el of tracked.root.querySelectorAll("spa-lazy"))
+      lazyReloaders.get(el)?.();
+    if (tracked.root.tagName.toLowerCase() === "spa-lazy")
+      lazyReloaders.get(tracked.root)?.();
   }
 }
 
@@ -105,7 +112,12 @@ export function applyPatch(
   scope?: Scope,
 ): Element {
   let current = root;
-  for (const op of patch.ops) current = applyOp(current, op, store, scope);
+  const refreshed = new Set<Element>();
+  for (const op of patch.ops)
+    current = applyOp(current, op, store, scope, refreshed);
+  // structural elements whose stored definitions changed re-wire once, after all ops landed
+  for (const el of refreshed)
+    if (el.isConnected) refreshStructural(el, store, scope);
   return current;
 }
 
@@ -202,6 +214,9 @@ function unbindEvent(el: Element, name: string): void {
 // subscribes the prop to its state field; a two-way binding also writes the field when the control changes.
 const bindings = new WeakMap<Element, Map<string, () => void>>();
 const structuralNodes = new WeakMap<Element, Node>();
+// `refreshRoots` re-fetches lazy bodies too (server state changed): each spa-lazy registers a
+// reloader that refetches its src and swaps the mounted body only when the payload changed.
+const lazyReloaders = new WeakMap<Element, () => void>();
 const VALUE_EVENTS = ["change", "input", "wa-tab-show"]; // a control writes its bound field on these (wa-tab-show: a wa-tab-group's active tab changed)
 
 function readProp(el: Element, name: string): unknown {
@@ -410,6 +425,7 @@ function wireLazy(el: Element, node: Node, store?: Store, scope?: Scope): void {
   let mounted: Element[] = [];
   let loaded = false;
   let disposed = false;
+  let lastBodyJson: string | null = null;
   const clear = (): void => {
     for (const child of mounted) {
       teardownTree(child);
@@ -438,6 +454,9 @@ function wireLazy(el: Element, node: Node, store?: Store, scope?: Scope): void {
     promise
       .then((body) => {
         if (disposed) return;
+        const json = JSON.stringify(body);
+        if (json === lastBodyJson) return; // a reload with an unchanged payload is a no-op
+        lastBodyJson = json;
         clear();
         const built = build(body, store, scope);
         el.appendChild(built);
@@ -449,6 +468,12 @@ function wireLazy(el: Element, node: Node, store?: Store, scope?: Scope): void {
         console.error("spa-lazy: failed to load", src, error);
       });
   };
+  // `refreshRoots` refetches an already-loaded body (its cache entry was just invalidated)
+  lazyReloaders.set(el, () => {
+    if (disposed || !loaded) return;
+    loaded = false;
+    activate();
+  });
   const subs: (() => void)[] = [];
   if (!cond) {
     activate();
@@ -1006,7 +1031,104 @@ function resolve(root: Element, path: Path): Element {
   return el;
 }
 
-function applyOp(root: Element, op: Op, store?: Store, scope?: Scope): Element {
+const STRUCTURAL_BINDING: Record<string, string> = {
+  "spa-show": "when",
+  "spa-each": "items",
+  "spa-switch": "on",
+  "spa-lazy": "when",
+};
+
+/** Re-wire a structural element from its (mutated) stored definition. A structural element's
+ * subtrees live in its wiring closures, not the DOM, so a tree patch that changes anything at or
+ * below its slots updates the definition and re-wires — the mounted branch rebuilds from the new
+ * definition, and non-mounted branches (a Switch's other cases) pick it up on their next mount. */
+function refreshStructural(el: Element, store?: Store, scope?: Scope): void {
+  const node = structuralNodes.get(el);
+  const name = node && STRUCTURAL_BINDING[node.tag];
+  if (!node || !name) return;
+  unwireBinding(el, name); // tears down the mounted branch and its subscriptions
+  if (node.tag === "spa-show") wireShow(el, node, store, scope);
+  else if (node.tag === "spa-switch") wireSwitch(el, node, store, scope);
+  else if (node.tag === "spa-lazy") wireLazy(el, node, store, scope);
+  else wireEach(el, node, store, scope);
+}
+
+function opPath(op: Op): Path {
+  return (Object.values(op)[0] as { path: Path }).path;
+}
+
+/** Walk `path` from `root`; if it enters a structural element's slots (or is a child op targeting
+ * one), the definition owns that subtree — return the element and the remaining path within it. */
+function structuralBoundary(
+  root: Element,
+  op: Op,
+): { el: Element; node: Node; rest: Path } | null {
+  const path = opPath(op);
+  let el: Element = root;
+  for (let i = 0; i < path.length; i++) {
+    const node = structuralNodes.get(el);
+    if (node) return { el, node, rest: path.slice(i) };
+    el = childrenInSlot(el, path[i].slot)[path[i].index];
+    if (!el) return null;
+  }
+  // a child op's payload addresses the resolved element's slots; for a structural element those
+  // are definition slots, not DOM children
+  if ("InsertChild" in op || "RemoveChild" in op || "MoveChild" in op) {
+    const node = structuralNodes.get(el);
+    if (node) return { el, node, rest: [] };
+  }
+  return null;
+}
+
+/** Apply one patch op to a serialized definition subtree instead of the DOM. */
+function applyOpToDefinition(node: Node, rest: Path, op: Op): void {
+  const parentDepth = "Replace" in op ? rest.length - 1 : rest.length;
+  for (let i = 0; i < parentDepth; i++)
+    node = node.slots![rest[i].slot]![rest[i].index]; // paths come from a diff of this very tree
+  if ("SetProp" in op) (node.props ??= {})[op.SetProp.name] = op.SetProp.value;
+  else if ("RemoveProp" in op) delete node.props?.[op.RemoveProp.name];
+  else if ("SetEvent" in op)
+    (node.events ??= {})[op.SetEvent.name] = op.SetEvent.action;
+  else if ("RemoveEvent" in op) delete node.events?.[op.RemoveEvent.name];
+  else if ("SetBinding" in op)
+    (node.bindings ??= {})[op.SetBinding.name] = op.SetBinding.binding;
+  else if ("RemoveBinding" in op) delete node.bindings?.[op.RemoveBinding.name];
+  else if ("SetKey" in op) {
+    if (op.SetKey.key === null) delete node.key;
+    else node.key = op.SetKey.key;
+  } else if ("InsertChild" in op)
+    ((node.slots ??= {})[op.InsertChild.slot] ??= []).splice(
+      op.InsertChild.index,
+      0,
+      op.InsertChild.node,
+    );
+  else if ("RemoveChild" in op)
+    node.slots?.[op.RemoveChild.slot]?.splice(op.RemoveChild.index, 1);
+  else if ("MoveChild" in op) {
+    const children = node.slots?.[op.MoveChild.slot];
+    if (children) {
+      const [moving] = children.splice(op.MoveChild.from, 1);
+      children.splice(op.MoveChild.to, 0, moving);
+    }
+  } else if ("Replace" in op) {
+    const last = rest[rest.length - 1];
+    node.slots![last.slot]![last.index] = op.Replace.node;
+  }
+}
+
+function applyOp(
+  root: Element,
+  op: Op,
+  store?: Store,
+  scope?: Scope,
+  refreshed?: Set<Element>,
+): Element {
+  const boundary = structuralBoundary(root, op);
+  if (boundary) {
+    applyOpToDefinition(boundary.node, boundary.rest, op);
+    refreshed?.add(boundary.el);
+    return root;
+  }
   if ("SetProp" in op) {
     setProp(
       resolve(root, op.SetProp.path),

--- a/js/tests/switch-lazy.spec.js
+++ b/js/tests/switch-lazy.spec.js
@@ -138,3 +138,178 @@ test("the refresh action re-fetches the tracked tree and diffs it in place", asy
   expect(after.text).toBe("version 2"); // the server's new state landed
   expect(after.identity).toBe("kept"); // unchanged elements kept identity through the diff
 });
+
+test("refresh reaches into Show and Switch subtrees (mounted branch and stored cases)", async ({
+  page,
+}) => {
+  let version = 1;
+  await page.route("**/cond-tree.json", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        tag: "main",
+        slots: {
+          default: [
+            {
+              tag: "h1",
+              props: {
+                id: { Str: "plain" },
+                textContent: { Str: `plain=${version}` },
+              },
+            },
+            {
+              tag: "spa-switch",
+              bindings: { on: { field: "sel", mode: "one-way" } },
+              slots: {
+                a: [
+                  {
+                    tag: "p",
+                    props: {
+                      id: { Str: "in-switch" },
+                      textContent: { Str: `switch=${version}` },
+                    },
+                  },
+                ],
+                b: [
+                  {
+                    tag: "p",
+                    props: {
+                      id: { Str: "case-b" },
+                      textContent: { Str: `b=${version}` },
+                    },
+                  },
+                ],
+                default: [{ tag: "p" }],
+              },
+            },
+            {
+              tag: "spa-show",
+              bindings: { when: { field: "showing", mode: "one-way" } },
+              slots: {
+                default: [
+                  {
+                    tag: "p",
+                    props: {
+                      id: { Str: "in-show" },
+                      textContent: { Str: `show=${version}` },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    }),
+  );
+  const before = await page.evaluate(async () => {
+    const node = await (await fetch("/cond-tree.json")).json();
+    const store = new window.__spaday.Store({ sel: "a", showing: true });
+    const root = window.__spaday.mount(document.body, node, store);
+    window.__spaday.trackRoot(root, node, "/cond-tree.json", store);
+    window.__store = store;
+    return {
+      plain: document.getElementById("plain").textContent,
+      inSwitch: document.getElementById("in-switch").textContent,
+      inShow: document.getElementById("in-show").textContent,
+    };
+  });
+  version = 2;
+  const after = await page.evaluate(async () => {
+    await window.__spaday.refreshRoots();
+    const read = () => ({
+      plain: document.getElementById("plain").textContent,
+      inSwitch: document.getElementById("in-switch")?.textContent ?? null,
+      inShow: document.getElementById("in-show")?.textContent ?? null,
+    });
+    const refreshed = read();
+    // the stored definition of the non-mounted case updated too: flip to it
+    window.__store.set("sel", "b");
+    const caseB = document.getElementById("case-b")?.textContent ?? null;
+    // and a Show toggle re-mounts from the refreshed definition
+    window.__store.set("showing", false);
+    window.__store.set("showing", true);
+    const remounted = document.getElementById("in-show")?.textContent ?? null;
+    return { refreshed, caseB, remounted };
+  });
+  expect(before).toEqual({
+    plain: "plain=1",
+    inSwitch: "switch=1",
+    inShow: "show=1",
+  });
+  expect(after.refreshed).toEqual({
+    plain: "plain=2",
+    inSwitch: "switch=2",
+    inShow: "show=2",
+  });
+  expect(after.caseB).toBe("b=2");
+  expect(after.remounted).toBe("show=2");
+});
+
+test("refresh refetches a loaded Lazy body and swaps it only when changed", async ({
+  page,
+}) => {
+  let version = 1;
+  let hits = 0;
+  await page.route("**/lazy-body.json", (route) => {
+    hits += 1;
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        tag: "article",
+        props: {
+          id: { Str: "card" },
+          textContent: { Str: `card v${version}` },
+        },
+      }),
+    });
+  });
+  await page.route("**/lazy-tree.json", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        tag: "div",
+        slots: {
+          default: [
+            {
+              tag: "spa-lazy",
+              props: { src: { Str: "/lazy-body.json" } },
+              slots: {
+                default: [
+                  { tag: "em", props: { textContent: { Str: "loading" } } },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    }),
+  );
+  const before = await page.evaluate(async () => {
+    const node = await (await fetch("/lazy-tree.json")).json();
+    const root = window.__spaday.mount(document.body, node);
+    window.__spaday.trackRoot(root, node, "/lazy-tree.json");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return document.getElementById("card").textContent;
+  });
+  // an unchanged payload refresh keeps the mounted body's identity
+  await page.evaluate(async () => {
+    document.getElementById("card").dataset.identity = "kept";
+    await window.__spaday.refreshRoots();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+  const unchanged = await page.evaluate(() => ({
+    text: document.getElementById("card").textContent,
+    identity: document.getElementById("card").dataset.identity,
+  }));
+  version = 2;
+  const after = await page.evaluate(async () => {
+    await window.__spaday.refreshRoots();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return document.getElementById("card").textContent;
+  });
+  expect(before).toBe("card v1");
+  expect(unchanged).toEqual({ text: "card v1", identity: "kept" });
+  expect(after).toBe("card v2");
+  expect(hits).toBe(3); // initial load + one refetch per refresh (cache invalidated)
+});

--- a/js/tests/switch-lazy.spec.js
+++ b/js/tests/switch-lazy.spec.js
@@ -313,3 +313,210 @@ test("refresh refetches a loaded Lazy body and swaps it only when changed", asyn
   expect(after).toBe("card v2");
   expect(hits).toBe(3); // initial load + one refetch per refresh (cache invalidated)
 });
+
+test("patch ops route into structural definitions: child ops, events, bindings, replace", async ({
+  page,
+}) => {
+  const r = await page.evaluate(() => {
+    const store = new window.__spaday.Store({
+      sel: "a",
+      label: "bound",
+      fired: "",
+    });
+    const root = window.__spaday.mount(
+      document.body,
+      {
+        tag: "div",
+        slots: {
+          default: [
+            {
+              tag: "spa-switch",
+              bindings: { on: { field: "sel", mode: "one-way" } },
+              slots: {
+                a: [
+                  {
+                    tag: "p",
+                    key: "first",
+                    props: { id: { Str: "one" }, textContent: { Str: "one" } },
+                  },
+                  {
+                    tag: "p",
+                    props: { id: { Str: "two" }, textContent: { Str: "two" } },
+                  },
+                ],
+                default: [],
+              },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    const at = (index) => [
+      { slot: "default", index: 0 },
+      { slot: "a", index },
+    ];
+    window.__spaday.applyPatch(
+      root,
+      {
+        ops: [
+          // all paths cross the spa-switch boundary, so they mutate its stored definition
+          {
+            Replace: {
+              path: at(0),
+              node: {
+                tag: "p",
+                props: { id: { Str: "uno" }, textContent: { Str: "uno" } },
+              },
+            },
+          },
+          { SetKey: { path: at(0), key: null } },
+          {
+            RemoveChild: {
+              path: [{ slot: "default", index: 0 }],
+              slot: "a",
+              index: 1,
+            },
+          },
+          {
+            InsertChild: {
+              path: [{ slot: "default", index: 0 }],
+              slot: "a",
+              index: 1,
+              node: {
+                tag: "p",
+                props: { id: { Str: "tres" }, textContent: { Str: "tres" } },
+              },
+            },
+          },
+          {
+            InsertChild: {
+              path: [{ slot: "default", index: 0 }],
+              slot: "a",
+              index: 2,
+              node: { tag: "button", props: { id: { Str: "btn" } } },
+            },
+          },
+          {
+            MoveChild: {
+              path: [{ slot: "default", index: 0 }],
+              slot: "a",
+              from: 1,
+              to: 0,
+            },
+          },
+          {
+            SetProp: {
+              path: at(0),
+              name: "textContent",
+              value: { Str: "tres!" },
+            },
+          },
+          { RemoveProp: { path: at(1), name: "textContent" } },
+          {
+            SetEvent: {
+              path: at(2),
+              name: "click",
+              action: {
+                kind: "set-field",
+                field: "fired",
+                value: { expr: "lit", value: "yes" },
+              },
+            },
+          },
+          {
+            SetBinding: {
+              path: at(2),
+              name: "textContent",
+              binding: { field: "label", mode: "one-way" },
+            },
+          },
+        ],
+      },
+      store,
+    );
+    const texts = Array.from(
+      document.querySelectorAll("spa-switch > p, spa-switch > button"),
+    ).map((el) => `${el.id}:${el.textContent}`);
+    document.getElementById("btn").click();
+    store.set("label", "rebound");
+    return {
+      texts,
+      fired: store.get("fired"),
+      rebound: document.getElementById("btn").textContent,
+    };
+  });
+  expect(r.texts).toEqual(["tres:tres!", "uno:", "btn:bound"]);
+  expect(r.fired).toBe("yes");
+  expect(r.rebound).toBe("rebound");
+});
+
+test("patch ops into an Each template re-wire its instances", async ({
+  page,
+}) => {
+  const r = await page.evaluate(() => {
+    const store = new window.__spaday.Store({
+      rows: [
+        { id: "x", name: "X" },
+        { id: "y", name: "Y" },
+      ],
+    });
+    const root = window.__spaday.mount(
+      document.body,
+      {
+        tag: "div",
+        slots: {
+          default: [
+            {
+              tag: "spa-each",
+              props: { itemKey: { Str: "id" } },
+              bindings: { items: { field: "rows", mode: "one-way" } },
+              slots: {
+                default: [
+                  {
+                    tag: "span",
+                    props: { class: { Str: "row" } },
+                    bindings: {
+                      textContent: {
+                        compute: { expr: "item", path: "name" },
+                        mode: "one-way",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      store,
+    );
+    const before = Array.from(document.querySelectorAll(".row")).map(
+      (el) => el.className,
+    );
+    window.__spaday.applyPatch(
+      root,
+      {
+        ops: [
+          {
+            SetProp: {
+              path: [
+                { slot: "default", index: 0 },
+                { slot: "default", index: 0 },
+              ],
+              name: "class",
+              value: { Str: "row loud" },
+            },
+          },
+        ],
+      },
+      store,
+    );
+    const after = Array.from(document.querySelectorAll(".row")).map(
+      (el) => el.className,
+    );
+    return { before, after };
+  });
+  expect(r.before).toEqual(["row", "row"]);
+  expect(r.after).toEqual(["row loud", "row loud"]);
+});

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -38,6 +38,10 @@ def _snake_name(name: str) -> str:
     return re.sub(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", "_", name).lower()
 
 
+#: tag -> schema for every imported schema-carrying class (validate uses it for dict trees)
+_SCHEMAS_BY_TAG: dict[str, ComponentSchema] = {}
+
+
 @lru_cache(maxsize=None)
 def _prop_aliases(schema: ComponentSchema) -> dict[str, str]:
     """snake_case spelling → canonical prop name, for schema props where the two spellings differ."""
@@ -103,6 +107,13 @@ class Component:
 
     tag: str = ""
     schema: ClassVar[ComponentSchema | None] = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # schema-carrying classes register by tag, so `validate` can check props on serialized
+        # dict trees too (a node dict carries no schema of its own)
+        if cls.schema is not None and cls.tag:
+            _SCHEMAS_BY_TAG[cls.tag] = cls.schema
 
     def __init__(self, *children: Child, key: str | None = None, props: dict[str, Any] | None = None, **attrs: Any) -> None:
         self._key = key

--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -333,6 +333,12 @@ class Toast(Component):
         toasts.compute("message", cond(field("submit_result.ok"), lit(""), field("submit_result.body")))
         # … or drive any reactive fallback UI from the same field
         page.add(Show(..., when=not_(field("submit_result.ok"))))
+
+    **Testing note**: notices render in the element's *shadow root*, so ``innerText``/``textContent``
+    on ``<spa-toast>`` are ``""`` even while toasts are visible — assert via
+    ``el.shadowRoot.querySelectorAll(".toast")`` (the same pattern as ``spaday-tree`` rows). And the
+    ``message`` prop is *cleared after each enqueue* (so the same text can re-notify), so reading it
+    back is not a way to assert what was shown.
     """
 
     tag = "spa-toast"

--- a/spaday/tests/test_validate.py
+++ b/spaday/tests/test_validate.py
@@ -125,6 +125,14 @@ def test_dict_trees_get_the_snake_case_hint_and_two_way_exemption():
     # two-way bindings and unknown tags stay unchecked, as in the Component form
     validate({"tag": "spa-dagre", "bindings": {"value": {"field": "selection", "mode": "two-way"}}})
     validate({"tag": "not-a-registered-tag", "props": {"mystery": {"Int": 1}}})
+    # globals and data-*/aria-* pass in the dict form too
+    validate({"tag": "spa-dagre", "props": {"id": {"Str": "g"}, "data-x": {"Str": "1"}}})
+
+
+def test_a_dict_child_nested_in_a_component_is_checked():
+    with pytest.raises(ValidationError) as excinfo:
+        validate(element("div").child(Dagre().to_node() | {"props": {"mystery": {"Int": 1}}}))
+    assert "<spa-dagre> unknown prop 'mystery'" in str(excinfo.value)
 
 
 def test_exported_from_package():

--- a/spaday/tests/test_validate.py
+++ b/spaday/tests/test_validate.py
@@ -110,9 +110,21 @@ def test_schema_props_globals_and_schema_free_nodes_pass_the_prop_check():
     validate(Dagre().bind("value", "selection", mode="two-way"))
 
 
-def test_serialized_dict_trees_skip_the_prop_check():
-    # a plain node dict no longer knows its schema, so only by_id resolution runs on it
-    validate(Dagre().prop("mystery", 1).to_node())
+def test_serialized_dict_trees_resolve_schemas_by_tag():
+    # a plain node dict carries no schema, but every imported schema-carrying class registered its
+    # tag — so the dict form checks the same props as the Component form
+    with pytest.raises(ValidationError) as excinfo:
+        validate(Dagre().prop("mystery", 1).to_node())
+    assert "<spa-dagre> unknown prop 'mystery'" in str(excinfo.value)
+
+
+def test_dict_trees_get_the_snake_case_hint_and_two_way_exemption():
+    with pytest.raises(ValidationError) as excinfo:
+        validate({"tag": "div", "slots": {"default": [{"tag": "spa-dagre", "props": {"max_label_width": {"Int": 1}}}]}})
+    assert "did you mean 'maxLabelWidth'?" in str(excinfo.value)
+    # two-way bindings and unknown tags stay unchecked, as in the Component form
+    validate({"tag": "spa-dagre", "bindings": {"value": {"field": "selection", "mode": "two-way"}}})
+    validate({"tag": "not-a-registered-tag", "props": {"mystery": {"Int": 1}}})
 
 
 def test_exported_from_package():

--- a/spaday/validate.py
+++ b/spaday/validate.py
@@ -12,7 +12,7 @@ binding *names* are checked too, wherever a catalog schema is known — see :fun
 from collections.abc import Iterator
 from typing import Any
 
-from .component import Component, _snake_name
+from .component import _SCHEMAS_BY_TAG, Component, _snake_name
 
 #: Generic props the runtime sets on any element, so they pass the unknown-prop check everywhere.
 _GLOBAL_PROPS = {"id", "class", "style", "slot", "part", "title", "role", "hidden", "tabindex", "textContent"}
@@ -88,6 +88,26 @@ def _collect_unknown_props(component: Component, problems: list[str]) -> None:
         for child in children:
             if isinstance(child, Component):
                 _collect_unknown_props(child, problems)
+            elif isinstance(child, dict):
+                _collect_unknown_props_dict(child, problems)
+
+
+def _collect_unknown_props_dict(node: dict, problems: list[str]) -> None:
+    """The dict-tree half of the unknown-prop check: schemas resolve by tag, from every imported
+    schema-carrying class (``Component.__init_subclass__`` registers them)."""
+    schema = _SCHEMAS_BY_TAG.get(node.get("tag", ""))
+    if schema is not None:
+        known = {prop.name for prop in schema.props}
+        bindings = node.get("bindings") or {}
+        bound = [n for n, b in bindings.items() if b.get("mode") != "two-way" and not n.startswith("root-class:")]
+        for name in list(node.get("props") or {}) + bound:
+            if name in known or name in _GLOBAL_PROPS or name.startswith(_GLOBAL_PREFIXES):
+                continue
+            hint = next((p for p in sorted(known) if _snake_name(p) == name), None)
+            problems.append(f"<{node['tag']}> unknown prop {name!r}" + (f" (did you mean {hint!r}?)" if hint else ""))
+    for children in (node.get("slots") or {}).values():
+        for child in children:
+            _collect_unknown_props_dict(child, problems)
 
 
 def validate(tree: Component | dict) -> None:
@@ -99,10 +119,11 @@ def validate(tree: Component | dict) -> None:
     to a node's id in the same tree. And on each node that carries a catalog ``schema`` (CEM-generated
     components retain one), every prop and binding name must be a schema prop or a generic global
     (``id``, ``class``, ``style``, ``slot``, …, plus ``data-*``/``aria-*``); an unknown name is reported
-    with the tag and — when it is the snake_case spelling of a real prop — a "did you mean" hint. The
-    prop check only reaches what still knows its schema: nodes built by ``element(...)`` and serialized
-    dict trees carry none, so they stay unvalidated — as do two-way binding names, which target live
-    form-control properties a manifest routinely omits.
+    with the tag and — when it is the snake_case spelling of a real prop — a "did you mean" hint. On a
+    serialized dict tree, schemas resolve by tag instead, covering every schema-carrying class that has
+    been imported — so ``validate(component.to_node())`` checks the same props as ``validate(component)``.
+    Nodes with no schema either way (``element(...)`` tags) stay unvalidated, as do two-way binding
+    names, which target live form-control properties a manifest routinely omits.
     """
     node = tree.to_node() if isinstance(tree, Component) else tree
     ids: set[str] = set()
@@ -113,8 +134,10 @@ def validate(tree: Component | dict) -> None:
     if missing:
         known = sorted(ids)
         raise ValidationError("unresolved by_id reference(s): " + ", ".join(repr(m) for m in missing) + f" (known ids: {known})")
+    problems: list[str] = []
     if isinstance(tree, Component):
-        problems: list[str] = []
         _collect_unknown_props(tree, problems)
-        if problems:
-            raise ValidationError("unknown prop(s): " + "; ".join(problems))
+    else:
+        _collect_unknown_props_dict(tree, problems)
+    if problems:
+        raise ValidationError("unknown prop(s): " + "; ".join(problems))


### PR DESCRIPTION
Fixes the reported bug that `RefreshTree` never updated content inside `Show`/`Switch` — which is where a real app's interesting content lives — plus the two smaller reports.

**Structural refresh.** A structural element's subtrees live in its wiring closures, not the DOM, so patch ops whose paths descended into them either missed silently or threw. `applyPatch` now detects when an op's path crosses a `spa-show`/`spa-switch`/`spa-lazy`/`spa-each` boundary, applies the op to the element's **stored definition**, and re-wires the element once per patch: the mounted branch rebuilds from the new definition, and a `Switch`'s non-mounted cases pick theirs up on next mount. `refreshRoots` additionally invalidates the lazy cache and refetches every loaded `Lazy` body (their content lives at their own URLs, invisible to the tree diff), swapping the body only when the payload actually changed — an unchanged card keeps its element identity, no flash. Browser tests cover the exact reported repro (plain node + mounted Switch case + Show body + non-mounted case + Show re-mount) and the Lazy refetch/no-op-swap behavior.

**`validate()` on dict trees.** `validate(component.to_node())` silently skipped the unknown-prop check because a node dict carries no schema. Schema-carrying classes now register by tag on definition, and the dict path resolves schemas from that registry — same checks, same snake_case hints, same two-way-binding exemption as the `Component` path. Documented in behavior.md.

**`Toast` docs.** The docstring now notes that notices render in the shadow root (`shadowRoot.querySelectorAll('.toast')` is the test hook; `textContent` is empty) and that `message` clears after each enqueue, so reading it back doesn't reflect what was shown.