### PR TITLE
Write computed binding props once per settled state change

### DIFF
--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -248,8 +248,19 @@ function wireBinding(
   const apply = bindingApply(el, prop);
   if (spec.compute !== undefined) {
     // computed (derived) binding: recompute the prop from the expression whenever any field it reads
-    // changes. One-way by nature — there is nothing to write back.
-    const recompute = () => apply(evalExpr(spec.compute, store, scope));
+    // changes. One-way by nature — there is nothing to write back. One settled state change can notify
+    // several of the fields the expression reads (an object write notifies the field and each changed
+    // sub-path); skip the write when the recomputed value is unchanged, so effectful props (e.g. a
+    // toast queue's message) see one write per real change, not one per notification.
+    let last: unknown;
+    let wrote = false;
+    const recompute = () => {
+      const value = evalExpr(spec.compute, store, scope);
+      if (wrote && Object.is(value, last)) return;
+      last = value;
+      wrote = true;
+      apply(value);
+    };
     recompute(); // initial value
     if (store)
       for (const field of exprFields(spec.compute)) {

--- a/js/tests/signals.spec.js
+++ b/js/tests/signals.spec.js
@@ -201,6 +201,67 @@ test("a computed binding derives a prop from fields and recomputes reactively", 
   expect(result.after).toEqual({ disabled: true, hidden: true }); // recomputed when the fields changed
 });
 
+test("a computed binding writes once per settled change, not once per dependency notification", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({ action_result: null });
+    // The toast pattern: one endpoint-result object, a message expression reading three of
+    // its paths. A single settled write notifies each subscribed path, but an effectful
+    // prop (spa-toast's message enqueues per non-empty write) must see one write.
+    const el = mount(
+      document.body,
+      {
+        tag: "spa-toast",
+        bindings: {
+          message: {
+            compute: {
+              expr: "cond",
+              test: {
+                expr: "all",
+                of: [
+                  { expr: "field", name: "action_result" },
+                  {
+                    expr: "not",
+                    of: { expr: "field", name: "action_result.ok" },
+                  },
+                ],
+              },
+              then: {
+                expr: "concat",
+                parts: [
+                  { expr: "lit", value: "Request failed: " },
+                  { expr: "field", name: "action_result.status" },
+                ],
+              },
+              else: { expr: "lit", value: "" },
+            },
+            mode: "one-way",
+          },
+        },
+      },
+      store,
+    );
+    const toasts = () =>
+      [...el.shadowRoot.querySelectorAll(".toast")].map((t) => t.textContent);
+    store.set("action_result", { ok: false, status: 500, body: "boom" });
+    const afterFailure = toasts();
+    store.set("action_result", { ok: true, status: 200, body: "fine" });
+    const afterSuccess = toasts(); // message cleared to "": enqueues nothing
+    store.set("action_result", { ok: false, status: 502, body: "bad gateway" });
+    return { afterFailure, afterSuccess, afterSecondFailure: toasts() };
+  });
+  // one settled change notified three dependencies but enqueued exactly one toast
+  expect(result.afterFailure).toEqual(["Request failed: 500"]);
+  expect(result.afterSuccess).toEqual(["Request failed: 500"]);
+  // a value that genuinely changes back writes again
+  expect(result.afterSecondFailure).toEqual([
+    "Request failed: 500",
+    "Request failed: 502",
+  ]);
+});
+
 test("a cond expr selects between two values by a field, reactively", async ({
   page,
 }) => {


### PR DESCRIPTION
A computed (compute-expression) one-way binding subscribes to every field its expression reads. One settled state change can notify several of those fields — an object write notifies the field plus each changed sub-path, so `CallEndpoint` writing `result = {ok, status, body}` notifies `action_result`, `action_result.ok`, and `action_result.status`. The binding re-evaluated and re-wrote the bound prop once per notification, which duplicates writes to effectful props: `spa-toast`'s `message` enqueues per non-empty write, so a single failed request produced three identical toasts.

Fix: track the last written value per binding and skip the prop write when the recomputed value is `Object.is`-equal to it. Values that genuinely change back and forth still re-notify, and non-primitive computed values (fresh objects per evaluation) keep their current write-through behavior.

Test: a new signals spec drives the toast pattern (`cond`/`all`/`concat` over three sub-paths of one endpoint-result field) and asserts exactly one `.toast` notice in `spa-toast`'s shadow root per settled change — it fails before the fix with three duplicates — plus a genuine change enqueuing a second toast. Full suites: 135 playwright, 207 pytest, all passing.