### PR TITLE
Document that RefreshTree re-fetches Lazy bodies

### DIFF
--- a/spaday/components/shell.py
+++ b/spaday/components/shell.py
@@ -284,9 +284,11 @@ class Lazy(Component):
     initial tree at all.
 
     ``src`` must return a serialized component (``tree_json(element(...))`` — any node JSON). The
-    body is fetched once per URL and cached for the page. Without ``when``/``field`` the fetch
-    happens on mount; with a condition it happens when the condition first turns truthy. Children
-    are the placeholder shown until the body arrives::
+    body is fetched once per URL and cached for the page; :class:`~spaday.actions.RefreshTree`
+    re-fetches every loaded body from its ``src`` and swaps it only if it changed, so "defer big
+    subtrees with ``Lazy``, refresh them with ``RefreshTree``" keeps deferred content current.
+    Without ``when``/``field`` the fetch happens on mount; with a condition it happens when the
+    condition first turns truthy. Children are the placeholder shown until the body arrives::
 
         Lazy(Paragraph("Loading…"), src=f"/card/{path}", when=eq(field("selected"), path))
     """


### PR DESCRIPTION
## Description

The `Lazy` docstring's "fetched once per URL and cached for the page" reads as "a deferred body can go stale and there is no way to refresh it", which is enough to stop someone adopting `Lazy` for content that changes. `RefreshTree` already re-fetches every loaded body from its `src` and swaps it only if it changed (as behavior.md says); the docstring now says so where readers decide.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [ ] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)
