### PR TITLE
Bind root attributes and carry property-only fields in schemas

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -166,3 +166,18 @@ through whichever channel themes them:
 - a package themed by a **prop or constructor options** (Perspective's `theme`, Lightweight Charts)
   binds that prop to the same field that drives the root class:
   `component.compute("theme", cond(field("dark"), "dark", "light"))`.
+
+A class states a boolean. For page-level state that carries a *value* — a design system whose tokens
+hang off `:root[data-density='comfortable']`, or a family of root flags in one control group —
+`Component.bind_root_attr(name, field)` writes an attribute on `<html>` instead:
+
+```python
+App(...).bind_root_attr("data-density", "density")  # "comfortable" | None
+App(...).bind_root_attr("data-vivid", "vivid")      # True | False
+```
+
+The field's value is written as the runtime writes any attribute: `None`/`False` remove it, `True` and
+`""` give the bare form (`data-vivid`), anything else is stringified — so an enumerated field replaces
+the attribute's value rather than accumulating names, and clearing the field removes it. Both root
+bindings are one-way and seeded from the store at mount, so a field restored by `persist=` or `url=`
+themes the page before the tree renders.

--- a/docs/src/behavior.md
+++ b/docs/src/behavior.md
@@ -323,8 +323,11 @@ spelling of each camelCase CEM prop and normalizes it to the canonical name —
 `Dagre(max_label_width=180)` sets `maxLabelWidth`; passing both spellings at once raises. And
 `spaday.validate` checks every node that still knows its catalog schema for unknown prop and binding
 names: a typo raises a `ValidationError` naming the tag and prop, with a "did you mean" hint when the
-unknown name is the snake_case spelling of a real prop. Generic globals (`id`, `class`, `style`,
-`slot`, `data-*` / `aria-*`, …) always pass. On a serialized dict tree, schemas resolve by tag
+unknown name is the snake_case spelling of a real prop. A component's known names are its attributes
+*and* its property-only fields (`schema.fields` — see the [manifest guide](cem.md)), so a data
+component's payload keyword passes. Generic globals (`id`, `class`, `style`, `slot`, `data-*` /
+`aria-*`, …) always pass, and so do the `root-class:` / `root-attr:` bindings, which name a class or
+attribute on `<html>` rather than a prop of the element they are authored on. On a serialized dict tree, schemas resolve by tag
 instead — every schema-carrying class that has been imported registers its tag — so
 `validate(component.to_node())` checks the same props as `validate(component)`. Nodes with no
 schema either way (`element(...)` escape hatches) stay unvalidated, as do two-way binding names,

--- a/docs/src/cem.md
+++ b/docs/src/cem.md
@@ -24,10 +24,21 @@ Peer packages use this workflow for committed catalogs. For example, `spaday-web
 Generated classes expose their normalized CEM metadata through `Component.schema`, ready for inclusion
 in a [`ComponentPackage` catalog](serving.md).
 
+A manifest describes two kinds of input, and the schema carries both. `schema.props` are the element's
+**attributes** — each one becomes a typed keyword argument. `schema.fields` are its **property-only
+inputs**: public fields the element declares with no attribute of their own, which is where a data
+component keeps its payload (an object no attribute can express). A field is set exactly like a prop —
+`Chart(data={...})` — and the runtime writes the property; it is not a typed parameter, because a
+manifest's `members` describe the element's whole class surface, so only what survives filtering
+(methods, private and static members, inherited and attribute-backed fields, element references and
+callbacks are all dropped) is carried. Both kinds accept the snake_case spelling and both are checked
+by `spaday.validate`.
+
 ## Build classes at runtime
 
-For a one-off or experimental manifest, `spaday.classes` builds the classes in memory instead — no file,
-no static types, but it still validates keyword names:
+For a one-off or experimental manifest, `spaday.classes` builds the classes in memory instead — no file
+and no static types, but the same `Component.schema`, so `spaday.validate` checks keyword names on the
+built tree either way:
 
 ```python
 import spaday

--- a/js/src/ts/cem.ts
+++ b/js/src/ts/cem.ts
@@ -22,6 +22,8 @@ export interface ComponentSchema {
   class_name: string;
   summary?: string;
   props: PropSchema[];
+  /** Property-only inputs: public fields with no attribute of their own, so `props` omits them. */
+  fields?: PropSchema[];
   events: string[];
   slots: string[];
 }

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -224,14 +224,22 @@ function readProp(el: Element, name: string): unknown {
   return el.hasAttribute(name) ? el.getAttribute(name) : null;
 }
 
-// The setter a binding drives. Normally a prop on the bound element; a `root-class:NAME` binding instead
-// toggles a class on the document root (`<html>`) — page-level theming (e.g. WebAwesome's `wa-dark`) that
-// lives outside the component tree. Authored via `Component.bind_root_class`.
+// The setter a binding drives. Normally a prop on the bound element; a `root-class:NAME` or
+// `root-attr:NAME` binding instead writes the document root (`<html>`) — page-level theming (e.g.
+// WebAwesome's `wa-dark`, or a `:root[data-density='comfortable']` token set) that lives outside the
+// component tree. Authored via `Component.bind_root_class` / `bind_root_attr`. A class is a boolean, so
+// it coerces; an attribute keeps its value, and is written as an attribute even when the name shadows a
+// property of `<html>` (`title`, `lang`, `dir`, …).
 function bindingApply(el: Element, prop: string): (value: unknown) => void {
   const ROOT_CLASS = "root-class:";
+  const ROOT_ATTR = "root-attr:";
   if (prop.startsWith(ROOT_CLASS)) {
     const name = prop.slice(ROOT_CLASS.length);
     return (v) => document.documentElement.classList.toggle(name, !!v);
+  }
+  if (prop.startsWith(ROOT_ATTR)) {
+    const name = prop.slice(ROOT_ATTR.length);
+    return (v) => setAttr(document.documentElement, name, v);
   }
   return (v) => setProp(el, prop, v);
 }
@@ -978,6 +986,11 @@ export function setProp(el: Element, name: string, value: unknown): void {
     (el as unknown as Record<string, unknown>)[name] = value;
     return;
   }
+  setAttr(el, name, value);
+}
+
+/** Write `value` as an attribute: `false`/`null`/`undefined` remove it, `true` gives the bare form. */
+function setAttr(el: Element, name: string, value: unknown): void {
   if (value === false || value === null || value === undefined) {
     el.removeAttribute(name);
   } else {

--- a/js/tests/signals.spec.js
+++ b/js/tests/signals.spec.js
@@ -424,6 +424,49 @@ test("a root-class binding toggles a class on <html> from a field", async ({
   expect(result).toEqual({ initial: false, on: true, off: false });
 });
 
+test("a root-attr binding writes the field's value as an attribute on <html>", async ({
+  page,
+}) => {
+  const result = await page.evaluate(() => {
+    const { mount, Store } = window.__spaday;
+    const store = new Store({
+      density: "comfortable",
+      vivid: false,
+      lang: "en",
+    });
+    mount(
+      document.createElement("div"),
+      {
+        tag: "div",
+        bindings: {
+          "root-attr:data-density": { field: "density", mode: "one-way" },
+          "root-attr:data-vivid": { field: "vivid", mode: "one-way" },
+          "root-attr:lang": { field: "lang", mode: "one-way" },
+        },
+      },
+      store,
+    );
+    const root = document.documentElement;
+    const seeded = root.getAttribute("data-density"); // seeded field applies at mount
+    store.set("density", "compact"); // an enum replaces rather than accumulates
+    const replaced = root.getAttribute("data-density");
+    store.set("density", null);
+    const cleared = root.hasAttribute("data-density");
+    store.set("vivid", true); // true is the bare attribute, not the string "true"
+    const bare = root.getAttribute("data-vivid");
+    // `lang` is also a property of <html>: a root-attr binding still writes the attribute
+    const attribute = root.getAttribute("lang");
+    return { seeded, replaced, cleared, bare, attribute };
+  });
+  expect(result).toEqual({
+    seeded: "comfortable",
+    replaced: "compact",
+    cleared: false,
+    bare: "",
+    attribute: "en",
+  });
+});
+
 test("nested-path fields: set/get a dotted path; notify the leaf and its ancestor, not a sibling", async ({
   page,
 }) => {

--- a/rust/src/cem.rs
+++ b/rust/src/cem.rs
@@ -1,8 +1,8 @@
 //! Custom Elements Manifest (CEM) parser — the binding-generator foundation.
 //!
 //! Web-component libraries publish a `custom-elements.json` (the [Custom Elements Manifest]) that
-//! describes every element: its tag, attributes (with types and defaults), events, and slots.
-//! [`parse_manifest`] reads one into a normalized [`ComponentSchema`] per element. The bindings then
+//! describes every element: its tag, attributes (with types and defaults), class members, events, and
+//! slots. [`parse_manifest`] reads one into a normalized [`ComponentSchema`] per element. The bindings then
 //! render that schema two ways — build-time typed **Python** classes and a **JS** runtime registry —
 //! so a UI authored in typed Python binds to the real web components. One parse, two outputs, the
 //! same "one core, two bindings" shape as the diff engine.
@@ -39,9 +39,38 @@ struct Declaration {
     #[serde(default)]
     attributes: Vec<Attribute>,
     #[serde(default)]
+    members: Vec<Member>,
+    #[serde(default)]
     events: Vec<Named>,
     #[serde(default)]
     slots: Vec<Named>,
+}
+
+/// A class member (`kind: "field"` or `"method"`). Only public, element-specific, writable fields with
+/// no attribute of their own become [`ComponentSchema::fields`]; see [`is_authorable_field`].
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Member {
+    kind: String,
+    name: String,
+    #[serde(default, rename = "type")]
+    ty: Option<TypeText>,
+    #[serde(default)]
+    privacy: Option<String>,
+    #[serde(default, rename = "static")]
+    is_static: bool,
+    #[serde(default)]
+    readonly: bool,
+    /// Present when the field is declared by a base class rather than this element.
+    #[serde(default)]
+    inherited_from: Option<serde_json::Value>,
+    /// Present when the field is backed by an attribute (already carried by `attributes`).
+    #[serde(default)]
+    attribute: Option<String>,
+    #[serde(default)]
+    default: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -92,7 +121,7 @@ pub struct PropSchema {
     pub doc: Option<String>,
 }
 
-/// A normalized custom element: its tag, a class name, props, events, and slots.
+/// A normalized custom element: its tag, a class name, props, property-only fields, events, and slots.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ComponentSchema {
     pub tag_name: String,
@@ -101,6 +130,11 @@ pub struct ComponentSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
     pub props: Vec<PropSchema>,
+    /// Property-only inputs: public fields the element declares with no attribute of their own, so they
+    /// are absent from `props`. Data components carry their payload here (an object a plain attribute
+    /// cannot express), and the author sets one exactly like a prop — the runtime writes the property.
+    #[serde(default)]
+    pub fields: Vec<PropSchema>,
     pub events: Vec<String>,
     /// Slot names; the empty string is the default (unnamed) slot.
     pub slots: Vec<String>,
@@ -128,11 +162,25 @@ pub fn parse_manifest(json: &str) -> Result<Vec<ComponentSchema>, serde_json::Er
                     doc: a.description.clone(),
                 })
                 .collect();
+            let attribute_names: Vec<&str> =
+                decl.attributes.iter().map(|a| a.name.as_str()).collect();
+            let fields = decl
+                .members
+                .iter()
+                .filter(|m| is_authorable_field(m, &attribute_names))
+                .map(|m| PropSchema {
+                    name: m.name.clone(),
+                    ty: parse_type(m.ty.as_ref().and_then(|t| t.text.as_deref())),
+                    default: clean_default(m.default.as_deref()),
+                    doc: m.description.clone(),
+                })
+                .collect();
             out.push(ComponentSchema {
                 class_name: pascal_case(&tag_name),
                 tag_name,
                 summary: decl.summary.or(decl.description),
                 props,
+                fields,
                 events: decl.events.into_iter().map(|e| e.name).collect(),
                 slots: decl.slots.into_iter().map(|s| s.name).collect(),
             });
@@ -144,6 +192,55 @@ pub fn parse_manifest(json: &str) -> Result<Vec<ComponentSchema>, serde_json::Er
 /// String-in/string-out facade for the bindings: manifest JSON → schemas JSON.
 pub fn parse_cem(json: &str) -> Result<String, serde_json::Error> {
     serde_json::to_string(&parse_manifest(json)?)
+}
+
+/// Whether a manifest member is a property-only input an author can set.
+///
+/// `members` is the element's whole class surface, most of which is not authorable: methods, private
+/// and static members, base-class plumbing, and references into the element's own shadow tree. Excluded
+/// in order: anything but a public instance field; a `#private`/`_internal` name; a field a base class
+/// declares (`inheritedFrom`); a field backed by an attribute (`attribute`, or a name `attributes`
+/// already carries — [`ComponentSchema::props`] describes those); a `readonly` field; a field typed as a
+/// DOM node (a reference into the element's own shadow tree); and a callback field, which no
+/// serializable tree can carry. What survives is the payload-shaped surface an attribute cannot express.
+///
+/// Deliberately conservative in one direction: an internal field that slips through only widens what
+/// the schema accepts, while dropping a real input would leave authors with no way to name it.
+fn is_authorable_field(m: &Member, attributes: &[&str]) -> bool {
+    let ty = m.ty.as_ref().and_then(|t| t.text.as_deref()).unwrap_or("");
+    m.kind == "field"
+        && m.privacy.as_deref().unwrap_or("public") == "public"
+        && !m.is_static
+        && !m.readonly
+        && !m.name.starts_with('#')
+        && !m.name.starts_with('_')
+        && m.inherited_from.is_none()
+        && m.attribute.is_none()
+        && !attributes.contains(&m.name.as_str())
+        && !is_dom_reference(ty)
+        && !ty.contains("=>") // a callback: behavior is authored as actions, never passed as a value
+}
+
+/// Whether every alternative of a TS type is a DOM node interface (`HTMLDivElement | undefined`,
+/// `Element`, …) — the shape of a reference into the element's own shadow tree, never an input.
+fn is_dom_reference(text: &str) -> bool {
+    let mut saw_dom = false;
+    for member in text.split('|').map(str::trim).filter(|m| !m.is_empty()) {
+        let member = member.trim_end_matches("[]");
+        if member == "null" || member == "undefined" {
+            continue;
+        }
+        let dom = matches!(
+            member,
+            "Element" | "Node" | "EventTarget" | "ShadowRoot" | "DocumentFragment"
+        ) || ((member.starts_with("HTML") || member.starts_with("SVG"))
+            && member.ends_with("Element"));
+        if !dom {
+            return false;
+        }
+        saw_dom = true;
+    }
+    saw_dom
 }
 
 fn pascal_case(tag: &str) -> String {
@@ -280,6 +377,72 @@ mod cem_tests {
         let json = parse_cem(MANIFEST).unwrap();
         let back: Vec<ComponentSchema> = serde_json::from_str(&json).unwrap();
         assert_eq!(back, parse_manifest(MANIFEST).unwrap());
+    }
+
+    /// A data component: its payload is a *field* (an object no attribute can express), alongside the
+    /// class surface a manifest also lists — methods, private/static/internal members, inherited and
+    /// attribute-backed fields, and references into its own shadow tree.
+    const FIELDS_MANIFEST: &str = r##"{
+      "modules": [
+        { "declarations": [
+          {
+            "kind": "class", "name": "SpaHeatmap", "customElement": true, "tagName": "spa-heatmap",
+            "attributes": [ { "name": "digits", "type": {"text": "number"} } ],
+            "members": [
+              { "kind": "field", "name": "data", "type": {"text": "HeatmapData"}, "description": "The payload." },
+              { "kind": "field", "name": "scale", "type": {"text": "'linear' | 'log'"}, "default": "'linear'" },
+              { "kind": "method", "name": "render" },
+              { "kind": "field", "name": "#buffer", "type": {"text": "number[]"} },
+              { "kind": "field", "name": "_cache", "type": {"text": "object"} },
+              { "kind": "field", "name": "internals", "privacy": "private", "type": {"text": "object"} },
+              { "kind": "field", "name": "version", "static": true, "type": {"text": "string"} },
+              { "kind": "field", "name": "digits", "type": {"text": "number"} },
+              { "kind": "field", "name": "formAction", "attribute": "formaction", "type": {"text": "string"} },
+              { "kind": "field", "name": "title", "type": {"text": "string"}, "inheritedFrom": {"name": "WaElement"} },
+              { "kind": "field", "name": "validity", "readonly": true, "type": {"text": "ValidityState"} },
+              { "kind": "field", "name": "canvas", "type": {"text": "HTMLCanvasElement | undefined"} },
+              { "kind": "field", "name": "renderCell", "type": {"text": "(row: number) => string"} }
+            ]
+          }
+        ] }
+      ]
+    }"##;
+
+    #[test]
+    fn test_fields_carry_property_only_inputs() {
+        let s = &parse_manifest(FIELDS_MANIFEST).unwrap()[0];
+        let names: Vec<&str> = s.fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["data", "scale"]); // everything else is class surface, not an input
+        assert_eq!(
+            s.props.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(),
+            vec!["digits"]
+        );
+        let data = &s.fields[0];
+        assert_eq!(data.ty, PropType::Any); // an object type stays unmodeled, as a `json` attribute does
+        assert_eq!(data.doc.as_deref(), Some("The payload."));
+        assert_eq!(
+            s.fields[1].ty,
+            PropType::Enum(vec!["linear".into(), "log".into()])
+        );
+        assert_eq!(s.fields[1].default.as_deref(), Some("linear"));
+    }
+
+    #[test]
+    fn test_dom_reference_types_are_not_inputs() {
+        assert!(is_dom_reference("HTMLSlotElement"));
+        assert!(is_dom_reference(
+            "HTMLInputElement | HTMLTextAreaElement | undefined"
+        ));
+        assert!(is_dom_reference("SVGSVGElement"));
+        assert!(is_dom_reference("Element[]"));
+        assert!(!is_dom_reference("")); // an untyped field is still an input
+        assert!(!is_dom_reference("HeatmapData"));
+        assert!(!is_dom_reference("string | HTMLElement")); // a mixed union may still be authorable
+    }
+
+    #[test]
+    fn test_a_manifest_without_members_has_no_fields() {
+        assert!(parse_manifest(MANIFEST).unwrap()[0].fields.is_empty());
     }
 
     #[test]

--- a/spaday/catalog.py
+++ b/spaday/catalog.py
@@ -41,6 +41,10 @@ class ComponentSchema(BaseModel):
     class_name: str
     summary: str | None = None
     props: tuple[PropertySchema, ...] = ()
+    #: Property-only inputs — public fields the element declares with no attribute of their own, so a
+    #: manifest leaves them out of ``props``. A data component's payload (an object no attribute can
+    #: express) lives here; authors set one exactly like a prop and the runtime writes the property.
+    fields: tuple[PropertySchema, ...] = ()
     events: tuple[str, ...] = ()
     slots: tuple[str, ...] = ()
 
@@ -52,6 +56,7 @@ class ComponentSchema(BaseModel):
             class_name=schema["class_name"],
             summary=schema.get("summary"),
             props=tuple(_property_from_cem(prop) for prop in schema.get("props", ())),
+            fields=tuple(_property_from_cem(prop) for prop in schema.get("fields", ())),
             events=tuple(schema.get("events", ())),
             slots=tuple(schema.get("slots", ())),
         )
@@ -65,6 +70,8 @@ class ComponentSchema(BaseModel):
             "events": list(self.events),
             "slots": list(self.slots),
         }
+        if self.fields:  # omitted when empty, as PropertySchema omits its own empty entries
+            value["fields"] = [prop.to_dict() for prop in self.fields]
         if self.summary is not None:
             value["summary"] = self.summary
         return value

--- a/spaday/cem.py
+++ b/spaday/cem.py
@@ -41,8 +41,9 @@ def classes(manifest_path: str, name: str | None = None) -> dict[str, type[Compo
     ``{class_name: class}`` for the whole manifest. Handy for binding an arbitrary or one-off manifest
     on the fly. Unlike a committed, generated peer-package catalog,
     these classes are **not statically typed** — the type checker can't see their per-attribute
-    signatures — though they still validate keyword names at call time. Reach for :func:`generate`
-    (committed codegen) when you want typing.
+    signatures. They do carry the same ``schema``, so :func:`~spaday.validate.validate` checks their
+    keyword names on the built tree exactly as it does a generated catalog's. Reach for
+    :func:`generate` (committed codegen) when you want typing.
     """
     built = {schema["class_name"]: _make_class(schema) for schema in schemas(manifest_path)}
     if name is None:

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -18,7 +18,7 @@ from functools import lru_cache
 from typing import Any, ClassVar, Union
 
 from .actions import Action, Expr
-from .catalog import ComponentSchema
+from .catalog import ComponentSchema, PropertySchema
 
 #: The conventional name of a component's unnamed (default) slot (matches the Rust core).
 DEFAULT_SLOT = "default"
@@ -43,11 +43,18 @@ _SCHEMAS_BY_TAG: dict[str, ComponentSchema] = {}
 
 
 @lru_cache(maxsize=None)
+def _settable(schema: ComponentSchema) -> tuple[PropertySchema, ...]:
+    """Every input a schema describes: its attributes and its property-only fields. Both are set the
+    same way — as a keyword on the component — so both take the same aliasing and kind checks."""
+    return schema.props + schema.fields
+
+
+@lru_cache(maxsize=None)
 def _prop_aliases(schema: ComponentSchema) -> dict[str, str]:
-    """snake_case spelling → canonical prop name, for schema props where the two spellings differ."""
-    names = {prop.name for prop in schema.props}
+    """snake_case spelling → canonical name, for schema props and fields where the two spellings differ."""
+    names = {prop.name for prop in _settable(schema)}
     aliases: dict[str, str] = {}
-    for prop in schema.props:
+    for prop in _settable(schema):
         snake = _snake_name(prop.name)
         if snake != prop.name and snake not in names:
             aliases.setdefault(snake, prop.name)
@@ -148,7 +155,7 @@ class Component:
         kinds with an unambiguous Python shape are checked (see ``_KIND_TYPES``); ``json`` props and
         props outside the schema (``id``, ``style``, …) pass through.
         """
-        kinds = {prop.name: prop.kind for prop in self.schema.props}
+        kinds = {prop.name: prop.kind for prop in _settable(self.schema)}
         for name, value in self._props.items():
             expected = _KIND_TYPES.get(kinds.get(name, ""))
             if expected is None:
@@ -261,6 +268,22 @@ class Component:
         One-way (the field drives the class); active only when mounted with a signal ``Store``.
         """
         self._bindings[f"root-class:{name}"] = {"field": field, "mode": "one-way"}
+        return self
+
+    def bind_root_attr(self, name: str, field: str) -> "Component":
+        """Set an attribute on the document root (``<html>``) from a reactive state ``field``.
+
+        The attribute counterpart to :meth:`bind_root_class`, for the page-level state a class cannot
+        carry: a theme selector whose *value* is matched (``:root[data-density='comfortable']``) needs an
+        attribute, since a class carries no value and enumerated values would need mutually exclusive
+        naming plus removal logic. The field's value is written as the runtime writes any attribute —
+        ``None``/``False`` remove it, ``True`` and ``""`` give the bare form (``data-vivid``), anything
+        else is stringified — so one binding covers both enumerated and boolean root state.
+        One-way (the field drives the attribute); active only when mounted with a signal ``Store``.
+        """
+        if name in ("class", "style"):
+            raise ValueError(f"bind_root_attr cannot set {name!r} on the document root (use bind_root_class / theme tokens)")
+        self._bindings[f"root-attr:{name}"] = {"field": field, "mode": "one-way"}
         return self
 
     def _final_props(self) -> dict[str, Any]:

--- a/spaday/tests/fixtures/webawesome.cem.json
+++ b/spaday/tests/fixtures/webawesome.cem.json
@@ -52,6 +52,14 @@
           "attributes": [
             { "name": "appearance", "type": { "text": "'accent' | 'filled' | 'outlined' | 'plain'" }, "default": "'outlined'" }
           ],
+          "members": [
+            { "kind": "field", "name": "data", "type": { "text": "CardData" }, "description": "An object payload no attribute can express." },
+            { "kind": "method", "name": "refresh" },
+            { "kind": "field", "name": "#internals", "type": { "text": "ElementInternals" } },
+            { "kind": "field", "name": "appearance", "type": { "text": "string" } },
+            { "kind": "field", "name": "body", "type": { "text": "HTMLDivElement" } },
+            { "kind": "field", "name": "title", "type": { "text": "string" }, "inheritedFrom": { "name": "WaElement" } }
+          ],
           "slots": [{ "name": "" }, { "name": "header" }, { "name": "footer" }]
         },
         {

--- a/spaday/tests/test_bindings.py
+++ b/spaday/tests/test_bindings.py
@@ -64,3 +64,15 @@ def test_bind_root_class_targets_the_document_root():
     # page-level theming outside the tree: a field toggles a class on <html> (e.g. WebAwesome's wa-dark)
     node = element("spa-app").bind_root_class("wa-dark", "dark").to_node()
     assert node["bindings"]["root-class:wa-dark"] == {"field": "dark", "mode": "one-way"}
+
+
+def test_bind_root_attr_targets_the_document_root():
+    # enumerated page-level state a class cannot carry: the field's *value* lands on <html>
+    node = element("spa-app").bind_root_attr("data-density", "density").to_node()
+    assert node["bindings"]["root-attr:data-density"] == {"field": "density", "mode": "one-way"}
+
+
+def test_bind_root_attr_rejects_class_and_style():
+    for name in ("class", "style"):
+        with pytest.raises(ValueError, match="cannot set"):
+            element("spa-app").bind_root_attr(name, "value")

--- a/spaday/tests/test_cem.py
+++ b/spaday/tests/test_cem.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from spaday import Component, ComponentSchema, PropertySchema, apply, classes, diff, generate, parse_cem
+from spaday import Component, ComponentSchema, PropertySchema, apply, classes, diff, generate, parse_cem, validate
 
 FIXTURES = Path(__file__).parent / "fixtures"
 FIXTURE = str(FIXTURES / "webawesome.cem.json")
@@ -222,6 +222,27 @@ def test_slots_compose_typed_components():
     assert node["tag"] == "wa-card"
     assert node["slots"]["header"][0]["tag"] == "wa-button"
     assert node["slots"]["default"][0]["tag"] == "wa-switch"
+
+
+def test_schema_carries_property_only_fields():
+    schema = _module()["WaCard"].schema
+    assert [prop.name for prop in schema.props] == ["appearance"]
+    # the payload is a field, so a manifest lists it nowhere else; the class surface around it is not
+    # an input (a method, a private field, an attribute-backed field, an element reference, an
+    # inherited field) and stays out
+    assert [prop.name for prop in schema.fields] == ["data"]
+    data = schema.fields[0]
+    assert data.kind == "json"  # an object type, like a `json` attribute
+    assert data.description == "An object payload no attribute can express."
+    assert schema.to_dict()["fields"] == [{"name": "data", "kind": "json", "description": data.description}]
+    assert "fields" not in _module()["WaSwitch"].schema.to_dict()  # omitted when the element declares none
+
+
+def test_a_field_is_set_like_a_prop_and_passes_validation():
+    card = _module()["WaCard"](appearance="filled", data={"rows": [1], "cols": ["a"]})
+    node = card.to_node()
+    assert node["props"]["data"] == {"Map": {"rows": {"List": [{"Int": 1}]}, "cols": {"List": [{"Str": "a"}]}}}
+    validate(card)  # the payload keyword is known — a schema without fields would reject it
 
 
 def test_classes_builds_components_at_runtime():

--- a/spaday/tests/test_validate.py
+++ b/spaday/tests/test_validate.py
@@ -108,6 +108,8 @@ def test_schema_props_globals_and_schema_free_nodes_pass_the_prop_check():
     validate(element("div", max_label_width=1))  # element() carries no schema — stays unvalidated
     # two-way bindings target live form-control properties a manifest routinely omits — unchecked
     validate(Dagre().bind("value", "selection", mode="two-way"))
+    # root bindings name a class/attribute on <html>, not a prop of the element they are authored on
+    validate(Dagre().bind_root_class("wa-dark", "dark").bind_root_attr("data-density", "density"))
 
 
 def test_serialized_dict_trees_resolve_schemas_by_tag():
@@ -124,6 +126,7 @@ def test_dict_trees_get_the_snake_case_hint_and_two_way_exemption():
     assert "did you mean 'maxLabelWidth'?" in str(excinfo.value)
     # two-way bindings and unknown tags stay unchecked, as in the Component form
     validate({"tag": "spa-dagre", "bindings": {"value": {"field": "selection", "mode": "two-way"}}})
+    validate({"tag": "spa-dagre", "bindings": {"root-attr:data-density": {"field": "density", "mode": "one-way"}}})
     validate({"tag": "not-a-registered-tag", "props": {"mystery": {"Int": 1}}})
     # globals and data-*/aria-* pass in the dict form too
     validate({"tag": "spa-dagre", "props": {"id": {"Str": "g"}, "data-x": {"Str": "1"}}})

--- a/spaday/validate.py
+++ b/spaday/validate.py
@@ -12,11 +12,14 @@ binding *names* are checked too, wherever a catalog schema is known — see :fun
 from collections.abc import Iterator
 from typing import Any
 
-from .component import _SCHEMAS_BY_TAG, Component, _snake_name
+from .component import _SCHEMAS_BY_TAG, Component, _settable, _snake_name
 
 #: Generic props the runtime sets on any element, so they pass the unknown-prop check everywhere.
 _GLOBAL_PROPS = {"id", "class", "style", "slot", "part", "title", "role", "hidden", "tabindex", "textContent"}
 _GLOBAL_PREFIXES = ("data-", "aria-")
+#: Binding names that target the document root rather than a prop on the bound element; one-way by
+#: construction, so they are exempt from the two-way and unknown-prop checks below.
+_ROOT_PREFIXES = ("root-class:", "root-attr:")
 
 
 class ValidationError(ValueError):
@@ -74,10 +77,10 @@ def _collect_refs(node: dict, refs: list[str]) -> None:
 def _collect_unknown_props(component: Component, problems: list[str]) -> None:
     schema = type(component).schema
     if schema is not None:
-        known = {prop.name for prop in schema.props}
+        known = {prop.name for prop in _settable(schema)}
         # two-way bindings target live form-control properties (a composed control's `value` is
         # routinely absent from its manifest), so their names stay unchecked
-        bound = [n for n, b in component._bindings.items() if b.get("mode") != "two-way" and not n.startswith("root-class:")]
+        bound = [n for n, b in component._bindings.items() if b.get("mode") != "two-way" and not n.startswith(_ROOT_PREFIXES)]
         names = list(component._props) + bound
         for name in names:
             if name in known or name in _GLOBAL_PROPS or name.startswith(_GLOBAL_PREFIXES):
@@ -97,9 +100,9 @@ def _collect_unknown_props_dict(node: dict, problems: list[str]) -> None:
     schema-carrying class (``Component.__init_subclass__`` registers them)."""
     schema = _SCHEMAS_BY_TAG.get(node.get("tag", ""))
     if schema is not None:
-        known = {prop.name for prop in schema.props}
+        known = {prop.name for prop in _settable(schema)}
         bindings = node.get("bindings") or {}
-        bound = [n for n, b in bindings.items() if b.get("mode") != "two-way" and not n.startswith("root-class:")]
+        bound = [n for n, b in bindings.items() if b.get("mode") != "two-way" and not n.startswith(_ROOT_PREFIXES)]
         for name in list(node.get("props") or {}) + bound:
             if name in known or name in _GLOBAL_PROPS or name.startswith(_GLOBAL_PREFIXES):
                 continue


### PR DESCRIPTION
Two authoring-surface gaps reported by a catalog consumer, plus a documentation correction they turned up.

**Root attributes.** `Component.bind_root_class` toggles a class on `<html>`, which is the only root-level binding there is — so page-level state whose *value* is matched (`:root[data-density='comfortable']`) had no declarative spelling and had to be mirrored onto the root by hand-written script. `bind_root_attr(name, field)` sets an attribute instead: `None`/`False` remove it, `True` and `""` give the bare form, anything else is stringified, so one binding covers enumerated and boolean root state alike. Root attributes are written with `setAttribute` rather than through `setProp`, whose `name in el` branch would assign a property for names that shadow one on `<html>` (`title`, `lang`, `dir`, …). Because root bindings apply the store's value at wire time, a field restored by `persist=` or `url=` now themes the page before the tree renders.

**Property-only fields.** The manifest parser only ever read `attributes`, so a component's field-only inputs were invisible to the Python schema, the generated classes and the JS registry — including the payload object on a data component, which is exactly the input that cannot be expressed as an attribute. `ComponentSchema` now carries `fields` beside `props`, and `validate()`, the snake_case aliasing and the authoring-time kind check all treat both as inputs, so a correct payload keyword stops being reported as an unknown prop.

The filter is the substance here. A manifest's `members` are the element's whole class surface: on the WebAwesome manifest, 70 elements with 776 attributes carry 703 public field-only members, most of them shadow-tree element references, base-class plumbing and internal state. Excluded on structural signals — non-fields, private/protected/static, `#`/`_` names, `inheritedFrom`, attribute-backed, `readonly`, DOM-node-typed and callback-typed — that same manifest yields 40. The filter is deliberately lopsided: a stray internal field only widens what the schema accepts, while dropping a real input leaves an author with no way to name their payload. Fields are not generated as typed keyword arguments for the same reason — a filter miss in a typed signature is worse than one in a schema entry.