### PR TITLE
Exclude platform-typed fields and stop catalogs drifting for empty ones

### DIFF
--- a/rust/src/cem.rs
+++ b/rust/src/cem.rs
@@ -201,8 +201,8 @@ pub fn parse_cem(json: &str) -> Result<String, serde_json::Error> {
 /// in order: anything but a public instance field; a `#private`/`_internal` name; a field a base class
 /// declares (`inheritedFrom`); a field backed by an attribute (`attribute`, or a name `attributes`
 /// already carries — [`ComponentSchema::props`] describes those); a `readonly` field; a field typed as a
-/// DOM node (a reference into the element's own shadow tree); and a callback field, which no
-/// serializable tree can carry. What survives is the payload-shaped surface an attribute cannot express.
+/// platform object (see [`is_platform_type`]); and a callback field, which no serializable tree can
+/// carry. What survives is the payload-shaped surface an attribute cannot express.
 ///
 /// Deliberately conservative in one direction: an internal field that slips through only widens what
 /// the schema accepts, while dropping a real input would leave authors with no way to name it.
@@ -217,30 +217,75 @@ fn is_authorable_field(m: &Member, attributes: &[&str]) -> bool {
         && m.inherited_from.is_none()
         && m.attribute.is_none()
         && !attributes.contains(&m.name.as_str())
-        && !is_dom_reference(ty)
+        && !is_platform_type(ty)
         && !ty.contains("=>") // a callback: behavior is authored as actions, never passed as a value
 }
 
-/// Whether every alternative of a TS type is a DOM node interface (`HTMLDivElement | undefined`,
-/// `Element`, …) — the shape of a reference into the element's own shadow tree, never an input.
-fn is_dom_reference(text: &str) -> bool {
-    let mut saw_dom = false;
+/// Browser and base-class objects a field can only hold a live instance of: DOM nodes, CSSOM sheets,
+/// observers, the element's own internals. Enumerated rather than pattern-matched, because the platform
+/// surface is finite and stable while application types are neither — a name this list does not know is
+/// treated as an input.
+const PLATFORM_TYPES: &[&str] = &[
+    "AbortController",
+    "AbortSignal",
+    "CSSResult",
+    "CSSResultArray",
+    "CSSResultGroup",
+    "CSSStyleDeclaration",
+    "CSSStyleSheet",
+    "Document",
+    "DocumentFragment",
+    "Element",
+    "ElementInternals",
+    "EventTarget",
+    "IntersectionObserver",
+    "MutationObserver",
+    "Node",
+    "NodeList",
+    "ResizeObserver",
+    "ShadowRoot",
+    "StyleSheet",
+    "StyleSheetList",
+    "TemplateResult",
+];
+
+/// Whether every alternative of a TS type is a platform object (`CSSStyleSheet[]`,
+/// `HTMLDivElement | undefined`, `ElementInternals`, …).
+///
+/// Such a field is never an input: no serializable value can be assigned to one. The check is by type
+/// rather than by name, because names like `styles` or `data` are ambiguous across libraries while a
+/// declared `CSSResultGroup` is not. A manifest that marks this plumbing `inheritedFrom`, `readonly` or
+/// `static` is already filtered before reaching here; this catches the manifests that do not.
+fn is_platform_type(text: &str) -> bool {
+    let mut saw_platform = false;
     for member in text.split('|').map(str::trim).filter(|m| !m.is_empty()) {
-        let member = member.trim_end_matches("[]");
+        let member = unwrap_array(member);
         if member == "null" || member == "undefined" {
             continue;
         }
-        let dom = matches!(
-            member,
-            "Element" | "Node" | "EventTarget" | "ShadowRoot" | "DocumentFragment"
-        ) || ((member.starts_with("HTML") || member.starts_with("SVG"))
-            && member.ends_with("Element"));
-        if !dom {
+        let platform = PLATFORM_TYPES.contains(&member)
+            || ((member.starts_with("HTML")
+                || member.starts_with("SVG")
+                || member.starts_with("MathML"))
+                && member.ends_with("Element"));
+        if !platform {
             return false;
         }
-        saw_dom = true;
+        saw_platform = true;
     }
-    saw_dom
+    saw_platform
+}
+
+/// The element type of `T[]`, `Array<T>` or `ReadonlyArray<T>` — a collection of platform objects is
+/// one too. Anything else is returned unchanged.
+fn unwrap_array(text: &str) -> &str {
+    let text = text.trim().trim_end_matches("[]").trim();
+    for prefix in ["Array<", "ReadonlyArray<"] {
+        if let Some(inner) = text.strip_prefix(prefix).and_then(|t| t.strip_suffix('>')) {
+            return inner.trim().trim_end_matches("[]").trim();
+        }
+    }
+    text
 }
 
 fn pascal_case(tag: &str) -> String {
@@ -401,6 +446,9 @@ mod cem_tests {
               { "kind": "field", "name": "title", "type": {"text": "string"}, "inheritedFrom": {"name": "WaElement"} },
               { "kind": "field", "name": "validity", "readonly": true, "type": {"text": "ValidityState"} },
               { "kind": "field", "name": "canvas", "type": {"text": "HTMLCanvasElement | undefined"} },
+              { "kind": "field", "name": "adoptedStyleSheets", "type": {"text": "CSSStyleSheet[]"} },
+              { "kind": "field", "name": "styles", "type": {"text": "CSSResultGroup"} },
+              { "kind": "field", "name": "internals", "type": {"text": "ElementInternals"} },
               { "kind": "field", "name": "renderCell", "type": {"text": "(row: number) => string"} }
             ]
           }
@@ -428,16 +476,23 @@ mod cem_tests {
     }
 
     #[test]
-    fn test_dom_reference_types_are_not_inputs() {
-        assert!(is_dom_reference("HTMLSlotElement"));
-        assert!(is_dom_reference(
+    fn test_platform_typed_fields_are_not_inputs() {
+        assert!(is_platform_type("HTMLSlotElement"));
+        assert!(is_platform_type(
             "HTMLInputElement | HTMLTextAreaElement | undefined"
         ));
-        assert!(is_dom_reference("SVGSVGElement"));
-        assert!(is_dom_reference("Element[]"));
-        assert!(!is_dom_reference("")); // an untyped field is still an input
-        assert!(!is_dom_reference("HeatmapData"));
-        assert!(!is_dom_reference("string | HTMLElement")); // a mixed union may still be authorable
+        assert!(is_platform_type("SVGSVGElement"));
+        assert!(is_platform_type("Element[]"));
+        // the base-class surface a manifest may leave unmarked: Lit styles, adopted sheets, internals
+        assert!(is_platform_type("CSSStyleSheet[]"));
+        assert!(is_platform_type("CSSResultGroup"));
+        assert!(is_platform_type("ElementInternals"));
+        assert!(is_platform_type("Array<HTMLElement>"));
+        assert!(is_platform_type("ReadonlyArray<CSSStyleSheet>"));
+        assert!(!is_platform_type("")); // an untyped field is still an input
+        assert!(!is_platform_type("HeatmapData"));
+        assert!(!is_platform_type("SheetConfig")); // an application type that merely reads like one
+        assert!(!is_platform_type("string | HTMLElement")); // a mixed union may still be authorable
     }
 
     #[test]

--- a/rust/src/cem.rs
+++ b/rust/src/cem.rs
@@ -200,9 +200,10 @@ pub fn parse_cem(json: &str) -> Result<String, serde_json::Error> {
 /// and static members, base-class plumbing, and references into the element's own shadow tree. Excluded
 /// in order: anything but a public instance field; a `#private`/`_internal` name; a field a base class
 /// declares (`inheritedFrom`); a field backed by an attribute (`attribute`, or a name `attributes`
-/// already carries — [`ComponentSchema::props`] describes those); a `readonly` field; a field typed as a
-/// platform object (see [`is_platform_type`]); and a callback field, which no serializable tree can
-/// carry. What survives is the payload-shaped surface an attribute cannot express.
+/// already carries — [`ComponentSchema::props`] describes those); a `readonly` field; a standard DOM
+/// member (see [`DOM_MEMBERS`]); a field typed as a platform object (see [`is_platform_type`]); and a
+/// callback field, which no serializable tree can carry. What survives is the payload-shaped surface an
+/// attribute cannot express.
 ///
 /// Deliberately conservative in one direction: an internal field that slips through only widens what
 /// the schema accepts, while dropping a real input would leave authors with no way to name it.
@@ -217,9 +218,55 @@ fn is_authorable_field(m: &Member, attributes: &[&str]) -> bool {
         && m.inherited_from.is_none()
         && m.attribute.is_none()
         && !attributes.contains(&m.name.as_str())
+        && !DOM_MEMBERS.contains(&m.name.as_str())
         && !is_platform_type(ty)
         && !ty.contains("=>") // a callback: behavior is authored as actions, never passed as a value
 }
+
+/// Members of `Element`, `HTMLElement` and `Node` that describe *any* element rather than this one.
+///
+/// A manifest that redeclares its base-class surface per element — rather than marking it
+/// `inheritedFrom` — offers these as if they were the component's own inputs; one such catalog carried
+/// `adoptedStyleSheets` on 34 of 40 elements. [`is_platform_type`] cannot reach them, because most are
+/// declared as plain strings and booleans (`className: string`, `hidden: boolean`).
+///
+/// Scoped to the interfaces every element implements. Form-control members (`checked`, `value`, `type`,
+/// `readOnly`, `disabled`, …) are deliberately absent: on a custom control those *are* the authored
+/// input, and a manifest that declares one as a field with no attribute behind it means it.
+const DOM_MEMBERS: &[&str] = &[
+    "accessKey",
+    "adoptedStyleSheets",
+    "attributes",
+    "autocapitalize",
+    "autofocus",
+    "classList",
+    "className",
+    "contentEditable",
+    "dataset",
+    "dir",
+    "draggable",
+    "enterKeyHint",
+    "hidden",
+    "id",
+    "innerHTML",
+    "innerText",
+    "inert",
+    "lang",
+    "nodeValue",
+    "nonce",
+    "outerHTML",
+    "outerText",
+    "part",
+    "popover",
+    "shadowRoot",
+    "slot",
+    "spellcheck",
+    "style",
+    "tabIndex",
+    "textContent",
+    "title",
+    "translate",
+];
 
 /// Browser and base-class objects a field can only hold a live instance of: DOM nodes, CSSOM sheets,
 /// observers, the element's own internals. Enumerated rather than pattern-matched, because the platform
@@ -449,6 +496,9 @@ mod cem_tests {
               { "kind": "field", "name": "adoptedStyleSheets", "type": {"text": "CSSStyleSheet[]"} },
               { "kind": "field", "name": "styles", "type": {"text": "CSSResultGroup"} },
               { "kind": "field", "name": "internals", "type": {"text": "ElementInternals"} },
+              { "kind": "field", "name": "className", "type": {"text": "string"} },
+              { "kind": "field", "name": "hidden", "type": {"text": "boolean"} },
+              { "kind": "field", "name": "checked", "type": {"text": "boolean"} },
               { "kind": "field", "name": "renderCell", "type": {"text": "(row: number) => string"} }
             ]
           }
@@ -460,7 +510,9 @@ mod cem_tests {
     fn test_fields_carry_property_only_inputs() {
         let s = &parse_manifest(FIELDS_MANIFEST).unwrap()[0];
         let names: Vec<&str> = s.fields.iter().map(|f| f.name.as_str()).collect();
-        assert_eq!(names, vec!["data", "scale"]); // everything else is class surface, not an input
+        // `checked` stays: on a custom control a form-control member with no attribute behind it is
+        // the authored input, unlike the DOM members every element carries
+        assert_eq!(names, vec!["data", "scale", "checked"]);
         assert_eq!(
             s.props.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(),
             vec!["digits"]
@@ -473,6 +525,17 @@ mod cem_tests {
             PropType::Enum(vec!["linear".into(), "log".into()])
         );
         assert_eq!(s.fields[1].default.as_deref(), Some("linear"));
+    }
+
+    #[test]
+    fn test_dom_members_are_not_inputs_even_when_typed_as_primitives() {
+        // a manifest that redeclares its base-class surface per element offers `className: string` and
+        // `hidden: boolean` as if they were this component's inputs; no type check can catch those
+        let s = &parse_manifest(FIELDS_MANIFEST).unwrap()[0];
+        let names: Vec<&str> = s.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(!names.contains(&"className"));
+        assert!(!names.contains(&"hidden"));
+        assert!(!names.contains(&"adoptedStyleSheets"));
     }
 
     #[test]

--- a/spaday/catalog.py
+++ b/spaday/catalog.py
@@ -48,6 +48,11 @@ class ComponentSchema(BaseModel):
     events: tuple[str, ...] = ()
     slots: tuple[str, ...] = ()
 
+    def __repr_args__(self) -> Any:
+        """Drop an empty ``fields`` from the repr, so a catalog whose elements declare no
+        property-only inputs generates exactly as it did before fields existed."""
+        return [(name, value) for name, value in super().__repr_args__() if name != "fields" or value]
+
     @classmethod
     def from_cem(cls, schema: Mapping[str, Any]) -> ComponentSchema:
         """Build catalog metadata from spaday's normalized CEM schema."""

--- a/spaday/tests/test_cem.py
+++ b/spaday/tests/test_cem.py
@@ -238,6 +238,14 @@ def test_schema_carries_property_only_fields():
     assert "fields" not in _module()["WaSwitch"].schema.to_dict()  # omitted when the element declares none
 
 
+def test_generated_schema_omits_an_empty_fields_tuple():
+    # a catalog whose elements declare no property-only inputs generates exactly as it did before
+    # fields existed, so committed catalogs do not churn for a keyword that carries nothing
+    code = generate(FIXTURE)
+    assert "fields=()" not in code
+    assert "fields=(\n" in code or "fields=(P" in code  # wa-card's payload still lands
+
+
 def test_a_field_is_set_like_a_prop_and_passes_validation():
     card = _module()["WaCard"](appearance="filled", data={"rows": [1], "cols": ["a"]})
     node = card.to_node()


### PR DESCRIPTION
Two follow-ups to the property-only fields work in 0.7.10, both found against real manifests.

**Platform-typed fields were admitted as inputs.** A consumer reports `adoptedStyleSheets` appearing on many elements. The type filter recognized DOM *node* interfaces only, so the rest of the base-class surface — `adoptedStyleSheets: CSSStyleSheet[]`, `styles: CSSResultGroup`, `internals: ElementInternals` — passed straight through on any manifest that does not mark it `inheritedFrom`, `readonly` or `static`, and `Array<HTMLElement>` was missed because only the `T[]` spelling was unwrapped. WebAwesome's manifest marks that surface, which is why the original measurement looked clean; manifests emitted with other analyzer settings do not.

The check now matches an enumerated set of platform interfaces (DOM, CSSOM, observers, `ElementInternals`, Lit's `CSSResult*`/`TemplateResult`) plus the `HTML*Element`/`SVG*Element`/`MathML*Element` shapes, unwrapping `T[]`, `Array<T>` and `ReadonlyArray<T>` first. Enumerating rather than pattern-matching keeps the conservative direction intact: the platform surface is finite and stable, application types are neither, so a name the list does not know stays an input and a real payload is never dropped. An application type that merely reads like one (`SheetConfig`) is unaffected.

**Every committed catalog drifted for a keyword carrying nothing.** A generated catalog embeds its schema as a repr, so adding `fields` rewrote every schema in every catalog — including elements that declare no property-only inputs, which is the overwhelming majority. Measured against the peer catalogs: 6 of 7 gain zero fields, and all 6 have a failing drift test on 0.7.10 purely from `fields=()` lines.

```
                          0.7.10   with this branch
spaday-dagre              FAIL     pass
spaday-lightweight-charts FAIL     pass
spaday-perspective        FAIL     pass
spaday-regular-layout     FAIL     pass
spaday-regular-table      FAIL     pass
spaday-trees              FAIL     pass
spaday-webawesome         FAIL     FAIL — 40 real fields, regeneration follows
```

`fields` is now omitted from the repr when empty, so a catalog changes only when its elements actually gained something. Only the WebAwesome catalog needs regenerating, and that PR follows.


---

**Update: standard DOM members were the larger share.** A consumer's regenerated catalog measured the leak precisely — 40 elements, 59 field entries, of which about 88% were DOM plumbing and `adoptedStyleSheets` alone appeared on 34 of 40. The type-based check above catches that one, but not the rest: `className: string`, `innerHTML: string`, `hidden: boolean` are declared as plain primitives, so no type rule can reach them.

Third commit matches them by name, scoped to the interfaces every element implements (`Element`, `HTMLElement`, `Node`). Form-control members — `checked`, `value`, `type`, `readOnly`, `disabled` — are deliberately excluded from that list: on a custom control they *are* the authored input, and the WebAwesome catalog declares `wa-radio.checked` and `wa-select.defaultValue` exactly that way, as fields with no attribute behind them. Denylisting them would drop real inputs to remove noise.

Effect on an element shaped like the reported one: 9 declared members, 4 kept (`data`, `checked`, plus `readOnly`/`type`, which stay by the rule above). The WebAwesome catalog is unchanged at 40 fields — its manifest already marks that surface inherited — so this is protection for manifests that do not, not a change to what ships today.

Tests: rust 63, python 214.
