### PR TITLE
Add an opt-in strict constructor for unknown keywords

### DIFF
--- a/docs/src/behavior.md
+++ b/docs/src/behavior.md
@@ -332,3 +332,20 @@ instead — every schema-carrying class that has been imported registers its tag
 `validate(component.to_node())` checks the same props as `validate(component)`. Nodes with no
 schema either way (`element(...)` escape hatches) stay unvalidated, as do two-way binding names,
 which target live form-control properties a manifest routinely omits.
+
+Name checking is a `validate` call by default, not a constructor error, because a manifest describes an
+element's inputs approximately — `schema.fields` is filtered from a class surface that mixes real inputs
+with plumbing, so a name spaday does not recognize is not proof of a mistake. Where the earlier error is
+worth that risk, turn it on with `set_strict_props`:
+
+```python
+from spaday import Component
+from spaday_webawesome import WaSelect
+
+Component.set_strict_props()      # every schema-carrying class, catalogs you don't own included
+WaSelect.set_strict_props(False)  # ...except one the manifest describes badly
+```
+
+An unknown keyword then raises `TypeError` at construction, naming every unknown name at once in the
+same words `validate` uses. A class that sets it explicitly keeps that setting when a base class is
+toggled later, so the opt-out above survives. Only constructor keywords are checked — `.prop(name, value)` stays the explicit way to set an attribute the manifest does not describe.

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -41,6 +41,10 @@ def _snake_name(name: str) -> str:
 #: tag -> schema for every imported schema-carrying class (validate uses it for dict trees)
 _SCHEMAS_BY_TAG: dict[str, ComponentSchema] = {}
 
+#: Generic props the runtime sets on any element, so they pass the unknown-prop check everywhere.
+_GLOBAL_PROPS = {"id", "class", "style", "slot", "part", "title", "role", "hidden", "tabindex", "textContent"}
+_GLOBAL_PREFIXES = ("data-", "aria-")
+
 
 @lru_cache(maxsize=None)
 def _settable(schema: ComponentSchema) -> tuple[PropertySchema, ...]:
@@ -59,6 +63,20 @@ def _prop_aliases(schema: ComponentSchema) -> dict[str, str]:
         if snake != prop.name and snake not in names:
             aliases.setdefault(snake, prop.name)
     return aliases
+
+
+def _unknown_prop(schema: ComponentSchema, tag: str, name: str) -> str | None:
+    """The problem text for a keyword ``schema`` does not describe, or ``None`` when the name is fine.
+
+    One definition of "accepted name", shared by the strict constructor and :func:`spaday.validate`:
+    the schema's attributes and property-only fields, plus the generic props the runtime sets on any
+    element. A name that is the snake_case spelling of a real one carries a did-you-mean hint.
+    """
+    known = {prop.name for prop in _settable(schema)}
+    if name in known or name in _GLOBAL_PROPS or name.startswith(_GLOBAL_PREFIXES):
+        return None
+    hint = next((p for p in sorted(known) if _snake_name(p) == name), None)
+    return f"<{tag}> unknown prop {name!r}" + (f" (did you mean {hint!r}?)" if hint else "")
 
 
 def _tag(value: Any) -> Any:
@@ -114,6 +132,8 @@ class Component:
 
     tag: str = ""
     schema: ClassVar[ComponentSchema | None] = None
+    #: Reject unknown keywords at construction (see :meth:`set_strict_props`). Off by default.
+    strict_props: ClassVar[bool] = False
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -138,6 +158,8 @@ class Component:
         merged.update(generic)
         self._props: dict[str, Any] = {k: v for k, v in merged.items() if v is not None}
         if type(self).schema is not None:
+            if type(self).strict_props:
+                self._check_prop_names()
             self._check_prop_kinds()
         self._slots: dict[str, list[Child]] = {}
         self._events: dict[str, dict] = {}
@@ -145,6 +167,34 @@ class Component:
         self._style: dict[str, str] = {}  # inline CSS declarations + custom properties (theming)
         self._classes: list[str] = []  # CSS classes (variants / states)
         self.child(*children)
+
+    @classmethod
+    def set_strict_props(cls, strict: bool = True) -> None:
+        """Make unknown keyword arguments raise at construction, for ``cls`` and its subclasses.
+
+        Off by default: a manifest describes an element's inputs approximately (see
+        :attr:`ComponentSchema.fields`), so an unrecognized keyword is reported by
+        :func:`spaday.validate` over a built tree rather than assumed to be a mistake. Turn it on where
+        the earlier error is worth that risk, at whichever scope fits — the whole catalog
+        (``Component.set_strict_props()``), one package's components
+        (``WaButton.set_strict_props()``, which works on a generated catalog you don't own), or off
+        again for a single class the manifest describes badly (``WaSelect.set_strict_props(False)``).
+        A class that sets it explicitly keeps that setting when a base class is toggled later, so a
+        per-class opt-out survives turning the catalog strict. Classes without a ``schema`` have
+        nothing to check and are unaffected.
+
+        Only constructor keywords are checked; :meth:`prop` stays the explicit escape hatch for an
+        attribute the manifest does not describe.
+        """
+        cls.strict_props = strict
+
+    def _check_prop_names(self) -> None:
+        """Reject keywords the class's catalog ``schema`` does not describe (opt-in; see
+        :meth:`set_strict_props`). Reports every unknown name at once, by the same rules and in the
+        same words :func:`spaday.validate` uses on a built tree."""
+        problems = [problem for name in self._props if (problem := _unknown_prop(self.schema, self.tag, name))]
+        if problems:
+            raise TypeError("; ".join(problems))
 
     def _check_prop_kinds(self) -> None:
         """Reject a literal prop value that contradicts the class's catalog ``schema`` kind.

--- a/spaday/tests/test_validate.py
+++ b/spaday/tests/test_validate.py
@@ -138,6 +138,33 @@ def test_a_dict_child_nested_in_a_component_is_checked():
     assert "<spa-dagre> unknown prop 'mystery'" in str(excinfo.value)
 
 
+def test_strict_props_is_opt_in_and_reports_what_validate_reports():
+    assert Dagre(mystery=1).to_node()["props"] == {"mystery": {"Int": 1}}  # off by default
+    Dagre.set_strict_props()
+    try:
+        with pytest.raises(TypeError) as excinfo:
+            Dagre(mystery=1, max_label_wdith=2)
+        message = str(excinfo.value)  # every unknown name at once, worded as validate words it
+        assert "<spa-dagre> unknown prop 'mystery'; <spa-dagre> unknown prop 'max_label_wdith'" == message
+        Dagre(maxLabelWidth=180, id="graph", class_="card")  # schema names and globals still pass
+        Dagre(max_label_width=180)  # a real snake_case alias is normalized before the check, not rejected
+        Dagre().prop("mystery", 1)  # prop() stays the explicit escape hatch
+    finally:
+        del Dagre.strict_props
+
+
+def test_strict_props_set_on_the_base_reaches_a_catalog_you_do_not_own():
+    Component.set_strict_props(True)
+    try:
+        with pytest.raises(TypeError):
+            Dagre(mystery=1)
+        Dagre.set_strict_props(False)  # an explicit per-class opt-out wins over the base
+        assert Dagre(mystery=1).to_node()["props"] == {"mystery": {"Int": 1}}
+    finally:
+        Component.set_strict_props(False)
+        del Dagre.strict_props
+
+
 def test_exported_from_package():
     assert spaday.validate is validate
     assert issubclass(spaday.ValidationError, ValueError)

--- a/spaday/validate.py
+++ b/spaday/validate.py
@@ -12,11 +12,8 @@ binding *names* are checked too, wherever a catalog schema is known — see :fun
 from collections.abc import Iterator
 from typing import Any
 
-from .component import _SCHEMAS_BY_TAG, Component, _settable, _snake_name
+from .component import _SCHEMAS_BY_TAG, Component, _unknown_prop
 
-#: Generic props the runtime sets on any element, so they pass the unknown-prop check everywhere.
-_GLOBAL_PROPS = {"id", "class", "style", "slot", "part", "title", "role", "hidden", "tabindex", "textContent"}
-_GLOBAL_PREFIXES = ("data-", "aria-")
 #: Binding names that target the document root rather than a prop on the bound element; one-way by
 #: construction, so they are exempt from the two-way and unknown-prop checks below.
 _ROOT_PREFIXES = ("root-class:", "root-attr:")
@@ -77,16 +74,12 @@ def _collect_refs(node: dict, refs: list[str]) -> None:
 def _collect_unknown_props(component: Component, problems: list[str]) -> None:
     schema = type(component).schema
     if schema is not None:
-        known = {prop.name for prop in _settable(schema)}
         # two-way bindings target live form-control properties (a composed control's `value` is
         # routinely absent from its manifest), so their names stay unchecked
         bound = [n for n, b in component._bindings.items() if b.get("mode") != "two-way" and not n.startswith(_ROOT_PREFIXES)]
-        names = list(component._props) + bound
-        for name in names:
-            if name in known or name in _GLOBAL_PROPS or name.startswith(_GLOBAL_PREFIXES):
-                continue
-            hint = next((p for p in sorted(known) if _snake_name(p) == name), None)
-            problems.append(f"<{component.tag}> unknown prop {name!r}" + (f" (did you mean {hint!r}?)" if hint else ""))
+        for name in list(component._props) + bound:
+            if problem := _unknown_prop(schema, component.tag, name):
+                problems.append(problem)
     for children in component._slots.values():
         for child in children:
             if isinstance(child, Component):
@@ -100,14 +93,11 @@ def _collect_unknown_props_dict(node: dict, problems: list[str]) -> None:
     schema-carrying class (``Component.__init_subclass__`` registers them)."""
     schema = _SCHEMAS_BY_TAG.get(node.get("tag", ""))
     if schema is not None:
-        known = {prop.name for prop in _settable(schema)}
         bindings = node.get("bindings") or {}
         bound = [n for n, b in bindings.items() if b.get("mode") != "two-way" and not n.startswith(_ROOT_PREFIXES)]
         for name in list(node.get("props") or {}) + bound:
-            if name in known or name in _GLOBAL_PROPS or name.startswith(_GLOBAL_PREFIXES):
-                continue
-            hint = next((p for p in sorted(known) if _snake_name(p) == name), None)
-            problems.append(f"<{node['tag']}> unknown prop {name!r}" + (f" (did you mean {hint!r}?)" if hint else ""))
+            if problem := _unknown_prop(schema, node["tag"], name):
+                problems.append(problem)
     for children in (node.get("slots") or {}).values():
         for child in children:
             _collect_unknown_props_dict(child, problems)


### PR DESCRIPTION
A generated class forwards any keyword it does not recognize. An unknown name is silently ignored; a name that collides with a real property is *assigned*, and a setter handed the wrong shape throws far from the mistake — a consumer lost a whole page render that way. `validate()` catches both on a built tree; this raises at the call site instead.

```python
from spaday import Component
from spaday_webawesome import WaSelect

Component.set_strict_props()      # every schema-carrying class, catalogs you don't own included
WaSelect.set_strict_props(False)  # ...except one the manifest describes badly
```

**Off by default, deliberately.** A manifest describes an element's inputs approximately: `schema.fields` is filtered out of a class surface that mixes real inputs with plumbing, and that filter is tuned to admit noise rather than drop a real input. Default-on would make an approximate set authoritative at the worst moment — a hard failure for an author whose code is correct. The consumer who asked for this made the same argument from their own catalog, where a correct payload keyword was a false positive one release ago.

**Scope follows the MRO**, which is what makes it usable on catalogs you don't maintain: `set_strict_props` is a classmethod on `Component`, so setting it on the base reaches every generated class, setting it on one package's class covers that package, and setting it on a single class overrides either. A class that sets it explicitly keeps that setting when a base is toggled later, so a per-class opt-out survives turning the catalog strict.

Only constructor keywords are checked. `.prop(name, value)` already documents itself as the escape hatch for attributes a typed class does not expose, so it stays exactly that — the explicit spelling for a name the manifest omits.

`validate()` and the constructor now share one definition of an accepted name (schema attributes + property-only fields + the generic globals), so the two cannot drift and the messages are identical.