### PR TITLE
Carry a json prop's declared type and check its shape

### DIFF
--- a/docs/src/behavior.md
+++ b/docs/src/behavior.md
@@ -316,7 +316,8 @@ contradicts its declared catalog kind — a `str` for a `number` prop, a number 
 a `TypeError` naming the component tag, the prop, and the offending value, instead of surfacing later
 as an opaque component error in the browser. Two limits: reactive bindings and computed values are
 dynamic and stay unvalidated, and `json`-kind props (lists, objects, mixed unions, untyped props all
-map to that kind) are type-opaque, so no literal shape can be ruled out for them.
+map to that kind) are type-opaque, so no literal shape can be ruled out for them by kind alone — see
+`set_strict_props` below for the check that reads their declared type instead.
 
 Prop *names* are checked too. A schema-carrying component's constructor accepts the snake_case
 spelling of each camelCase CEM prop and normalizes it to the canonical name —
@@ -347,5 +348,19 @@ WaSelect.set_strict_props(False)  # ...except one the manifest describes badly
 ```
 
 An unknown keyword then raises `TypeError` at construction, naming every unknown name at once in the
-same words `validate` uses. A class that sets it explicitly keeps that setting when a base class is
+same words `validate` uses. Strict components also check the *shape* of a `json` prop against the type
+its manifest declares — `schema.type_text`, carried for exactly the kind that says nothing else about
+shape:
+
+```python
+Heatmap(data=[[1, 2], [3, 4]])
+# TypeError: <spa-heatmap> prop 'data' expects { rows: string[]; cols: string[]; values: number[][] },
+#            got [[1, 2], [3, 4]] (list)
+```
+
+That is the mistake worth catching early: the name is right, the shape is wrong, and the browser reports
+it as a setter throwing far from the call that caused it. Only the spellings that can mean nothing else
+are read — an array (`T[]`, `Array<T>`) and an object (`{…}`, `Record<…>`). A named type like
+`HeatmapData` is deliberately not read, because an alias can name either shape; the declared text is on
+the schema, so an author who knows their own types can assert on it. A class that sets it explicitly keeps that setting when a base class is
 toggled later, so the opt-out above survives. Only constructor keywords are checked — `.prop(name, value)` stays the explicit way to set an attribute the manifest does not describe.

--- a/docs/src/cem.md
+++ b/docs/src/cem.md
@@ -34,6 +34,11 @@ manifest's `members` describe the element's whole class surface, so only what su
 callbacks are all dropped) is carried. Both kinds accept the snake_case spelling and both are checked
 by `spaday.validate`.
 
+A `json` prop or field also carries `type_text`, the manifest's declared type — `{ rows: string[]; … }`,
+`SeriesPoint[]`, `HeatmapData`. It is kept only for that kind, since `string`, `boolean`, `number` and
+`enum` already describe their own shape, and it is what lets a wrong payload shape be caught before the
+browser (see [strict components](behavior.md)).
+
 ## Build classes at runtime
 
 For a one-off or experimental manifest, `spaday.classes` builds the classes in memory instead — no file

--- a/rust/src/cem.rs
+++ b/rust/src/cem.rs
@@ -115,6 +115,11 @@ pub struct PropSchema {
     /// The attribute name as it appears on the element (the wire key), e.g. `"checked"`.
     pub name: String,
     pub ty: PropType,
+    /// The manifest's declared type, carried only for [`PropType::Any`] — the kind that says nothing
+    /// about shape. `Bool`, `Str`, `Number` and `Enum` already describe themselves, so repeating their
+    /// type text would bloat every catalog to say what the kind says.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_text: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -155,11 +160,15 @@ pub fn parse_manifest(json: &str) -> Result<Vec<ComponentSchema>, serde_json::Er
             let props = decl
                 .attributes
                 .iter()
-                .map(|a| PropSchema {
-                    name: a.name.clone(),
-                    ty: parse_type(a.ty.as_ref().and_then(|t| t.text.as_deref())),
-                    default: clean_default(a.default.as_deref()),
-                    doc: a.description.clone(),
+                .map(|a| {
+                    let text = a.ty.as_ref().and_then(|t| t.text.as_deref());
+                    PropSchema {
+                        name: a.name.clone(),
+                        ty: parse_type(text),
+                        type_text: opaque_type_text(text),
+                        default: clean_default(a.default.as_deref()),
+                        doc: a.description.clone(),
+                    }
                 })
                 .collect();
             let attribute_names: Vec<&str> =
@@ -168,11 +177,15 @@ pub fn parse_manifest(json: &str) -> Result<Vec<ComponentSchema>, serde_json::Er
                 .members
                 .iter()
                 .filter(|m| is_authorable_field(m, &attribute_names))
-                .map(|m| PropSchema {
-                    name: m.name.clone(),
-                    ty: parse_type(m.ty.as_ref().and_then(|t| t.text.as_deref())),
-                    default: clean_default(m.default.as_deref()),
-                    doc: m.description.clone(),
+                .map(|m| {
+                    let text = m.ty.as_ref().and_then(|t| t.text.as_deref());
+                    PropSchema {
+                        name: m.name.clone(),
+                        ty: parse_type(text),
+                        type_text: opaque_type_text(text),
+                        default: clean_default(m.default.as_deref()),
+                        doc: m.description.clone(),
+                    }
                 })
                 .collect();
             out.push(ComponentSchema {
@@ -192,6 +205,20 @@ pub fn parse_manifest(json: &str) -> Result<Vec<ComponentSchema>, serde_json::Er
 /// String-in/string-out facade for the bindings: manifest JSON → schemas JSON.
 pub fn parse_cem(json: &str) -> Result<String, serde_json::Error> {
     serde_json::to_string(&parse_manifest(json)?)
+}
+
+/// The declared type text to carry for a prop, or `None` when the normalized kind already says it.
+///
+/// An object payload normalizes to [`PropType::Any`], which is where an author most needs to know the
+/// shape and where spaday can say least — so that is the one case the text is worth keeping. Manifests
+/// wrap long unions across lines; collapse the whitespace so a generated catalog stays stable.
+fn opaque_type_text(text: Option<&str>) -> Option<String> {
+    let text = text?;
+    if parse_type(Some(text)) != PropType::Any {
+        return None;
+    }
+    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!collapsed.is_empty()).then_some(collapsed)
 }
 
 /// Whether a manifest member is a property-only input an author can set.
@@ -370,6 +397,34 @@ mod cem_tests {
         assert_eq!(by("name").ty, PropType::Optional(Box::new(PropType::Str)));
         assert_eq!(by("name").default, None); // `null` ⇒ no default
         assert_eq!(by("css").ty, PropType::Any); // unmodeled type
+    }
+
+    #[test]
+    fn test_type_text_is_carried_only_where_the_kind_says_nothing() {
+        let s = &parse_manifest(MANIFEST).unwrap()[0];
+        let by = |n: &str| s.props.iter().find(|p| p.name == n).unwrap();
+        // an unmodeled type is the one case an author cannot infer the shape from the kind
+        assert_eq!(
+            by("css").type_text.as_deref(),
+            Some("CSSResultGroup | undefined")
+        );
+        // the kinds that describe themselves carry nothing, so catalogs do not restate them
+        assert_eq!(by("checked").type_text, None);
+        assert_eq!(by("size").type_text, None);
+        assert_eq!(by("name").type_text, None);
+    }
+
+    #[test]
+    fn test_type_text_collapses_the_whitespace_a_manifest_wraps_with() {
+        let manifest = r#"{"modules":[{"declarations":[{
+          "kind":"class","name":"El","customElement":true,"tagName":"an-el",
+          "attributes":[{"name":"data","type":{"text":"{\n  rows: string[];\n  values: number[][];\n}"}}]
+        }]}]}"#;
+        let s = &parse_manifest(manifest).unwrap()[0];
+        assert_eq!(
+            s.props[0].type_text.as_deref(),
+            Some("{ rows: string[]; values: number[][]; }")
+        );
     }
 
     #[test]

--- a/spaday/catalog.py
+++ b/spaday/catalog.py
@@ -17,14 +17,25 @@ class PropertySchema(BaseModel):
     name: str
     kind: PropertyKind
     choices: tuple[str, ...] = ()
+    #: The manifest's declared type, carried only for ``json`` props — the kind that says nothing about
+    #: shape. An author cannot tell ``{rows, cols, values}`` from a matrix without it, and the browser
+    #: reports the difference as a setter throwing far from the mistake.
+    type_text: str | None = None
     default: str | None = None
     description: str | None = None
+
+    def __repr_args__(self) -> Any:
+        """Drop an absent ``type_text``, so the kinds that describe themselves — every prop but the
+        ``json`` ones — generate exactly as they did before it existed."""
+        return [(name, value) for name, value in super().__repr_args__() if name != "type_text" or value]
 
     def to_dict(self) -> dict[str, Any]:
         """Return JSON-serializable catalog data."""
         value: dict[str, Any] = {"name": self.name, "kind": self.kind}
         if self.choices:
             value["choices"] = list(self.choices)
+        if self.type_text is not None:
+            value["type_text"] = self.type_text
         if self.default is not None:
             value["default"] = self.default
         if self.description is not None:
@@ -83,6 +94,7 @@ def _property_from_cem(prop: Mapping[str, Any]) -> PropertySchema:
         name=prop["name"],
         kind=kind,
         choices=choices,
+        type_text=prop.get("type_text"),
         default=prop.get("default"),
         description=prop.get("doc"),
     )

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -113,6 +113,25 @@ _KIND_TYPES: dict[str, type | tuple[type, ...]] = {
 }
 
 
+def _declared_container(type_text: str | None) -> type | None:
+    """The Python container a declared type unambiguously calls for, or ``None`` when it is not obvious.
+
+    A `json` prop's declared type is the only description of its shape, and the two mistakes worth
+    catching are a matrix where an object belongs and the reverse — the browser reports those as a
+    setter throwing far from the mistake. Only the spellings that can mean nothing else are read: an
+    array (`T[]`, `Array<T>`) and an object (`{…}`, `Record<…>`). A named type is deliberately not read:
+    an alias can name either, so `HeatmapData` says nothing a check could rely on — the name is carried
+    in the schema so an author who knows their own types can assert on it.
+    """
+    if not type_text or "|" in type_text:  # a union may accept several shapes
+        return None
+    if type_text.endswith("[]") or type_text.startswith(("Array<", "ReadonlyArray<")):
+        return list
+    if type_text.startswith(("{", "Record<")):
+        return dict
+    return None
+
+
 def _css_name(name: str) -> str:
     """A Python kwarg → its CSS name: drop one trailing ``_``, then ``_`` → ``-`` (``font_size`` → ``font-size``)."""
     name = name.removesuffix("_")
@@ -160,6 +179,7 @@ class Component:
         if type(self).schema is not None:
             if type(self).strict_props:
                 self._check_prop_names()
+                self._check_prop_shapes()
             self._check_prop_kinds()
         self._slots: dict[str, list[Child]] = {}
         self._events: dict[str, dict] = {}
@@ -195,6 +215,18 @@ class Component:
         problems = [problem for name in self._props if (problem := _unknown_prop(self.schema, self.tag, name))]
         if problems:
             raise TypeError("; ".join(problems))
+
+    def _check_prop_shapes(self) -> None:
+        """Reject a ``json`` prop whose literal contradicts its declared type (opt-in; see
+        :meth:`set_strict_props`). The shape half of :meth:`_check_prop_kinds`: a `json` kind rules out
+        no Python value, but a type declared as an array or an object rules out the other one."""
+        declared = {prop.name: prop.type_text for prop in _settable(self.schema) if prop.kind == "json"}
+        for name, value in self._props.items():
+            expected = _declared_container(declared.get(name))
+            if expected is None:
+                continue
+            if not isinstance(value, expected) and not (expected is list and isinstance(value, tuple)):
+                raise TypeError(f"<{self.tag}> prop {name!r} expects {declared[name]}, got {value!r} ({type(value).__name__})")
 
     def _check_prop_kinds(self) -> None:
         """Reject a literal prop value that contradicts the class's catalog ``schema`` kind.

--- a/spaday/tests/test_cem.py
+++ b/spaday/tests/test_cem.py
@@ -234,7 +234,8 @@ def test_schema_carries_property_only_fields():
     data = schema.fields[0]
     assert data.kind == "json"  # an object type, like a `json` attribute
     assert data.description == "An object payload no attribute can express."
-    assert schema.to_dict()["fields"] == [{"name": "data", "kind": "json", "description": data.description}]
+    assert data.type_text == "CardData"  # the shape a `json` kind cannot express
+    assert schema.to_dict()["fields"] == [{"name": "data", "kind": "json", "type_text": "CardData", "description": data.description}]
     assert "fields" not in _module()["WaSwitch"].schema.to_dict()  # omitted when the element declares none
 
 

--- a/spaday/tests/test_validate.py
+++ b/spaday/tests/test_validate.py
@@ -138,6 +138,37 @@ def test_a_dict_child_nested_in_a_component_is_checked():
     assert "<spa-dagre> unknown prop 'mystery'" in str(excinfo.value)
 
 
+class Heatmap(Component):
+    """A data component: its payload is an object, described only by the manifest's type text."""
+
+    tag = "spa-heatmap"
+    schema = ComponentSchema.from_cem(
+        {
+            "tag_name": "spa-heatmap",
+            "class_name": "Heatmap",
+            "props": [
+                {"name": "values", "ty": "Any", "type_text": "{ rows: string[]; values: number[][] }"},
+                {"name": "series", "ty": "Any", "type_text": "SeriesPoint[]"},
+                {"name": "config", "ty": "Any", "type_text": "HeatmapConfig"},
+            ],
+        }
+    )
+
+
+def test_strict_props_rejects_a_literal_that_contradicts_its_declared_shape():
+    assert Heatmap(values=[[1]]).to_node()["props"]  # off by default, as the name check is
+    Heatmap.set_strict_props()
+    try:
+        with pytest.raises(TypeError, match=r"prop 'values' expects \{ rows.*got \[\[1\]\] \(list\)"):
+            Heatmap(values=[[1]])  # a matrix where an object belongs: the browser would throw inside a setter
+        with pytest.raises(TypeError, match=r"prop 'series' expects SeriesPoint\[\]"):
+            Heatmap(series={"x": 1})
+        Heatmap(values={"rows": [], "values": []}, series=[{"x": 1}])  # the declared shapes pass
+        Heatmap(config=[1])  # a named type may alias either shape, so it stays unchecked
+    finally:
+        del Heatmap.strict_props
+
+
 def test_strict_props_is_opt_in_and_reports_what_validate_reports():
     assert Dagre(mystery=1).to_node()["props"] == {"mystery": {"Int": 1}}  # off by default
     Dagre.set_strict_props()


### PR DESCRIPTION
Stacked on #178

A `json` kind rules out no Python value, so the mistake it cannot catch is the one that hurts most: the name is right and the shape is wrong. A matrix passed where an object belongs reaches a real setter, throws inside the component, and takes down the render far from the call that caused it. That is the bug a consumer reported originally, and the half of it that name checking never addressed.

**Carrying the type.** `PropSchema`/`PropertySchema` gain `type_text`, the manifest's declared type, kept for `json` props and fields only — `string`, `boolean`, `number` and `enum` already describe their own shape, so repeating their type text would rewrite every entry in every catalog to restate the kind. It is dropped from the repr when absent, so catalogs change only where something is now described: 38 of 816 entries in the WebAwesome catalog.

**Reading it.** Strict components (#178) check the shape too:

```
<spa-heatmap> prop 'data' expects { rows: string[]; cols: string[]; values: number[][] },
              got [[1, 2], [3, 4]] (list)
```

Only the spellings that can mean nothing else are read — an array (`T[]`, `Array<T>`, `ReadonlyArray<T>`) and an object (`{…}`, `Record<…>`). A named type like `HeatmapData` is deliberately **not** read: an alias can name either shape, so a check on it would reject correct code. The declared text is on the schema either way, so an author who knows their own types can assert what spaday will not.

Unions are skipped for the same reason — a declared union may accept several shapes.
