### PR TITLE
Skip type text that says nothing

### DIFF
--- a/rust/src/cem.rs
+++ b/rust/src/cem.rs
@@ -218,8 +218,15 @@ fn opaque_type_text(text: Option<&str>) -> Option<String> {
         return None;
     }
     let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    (!collapsed.is_empty()).then_some(collapsed)
+    if collapsed.is_empty() || UNINFORMATIVE_TYPES.contains(&collapsed.as_str()) {
+        return None; // a declared `unknown` says exactly what the `json` kind already said
+    }
+    Some(collapsed)
 }
+
+/// TypeScript spellings for "no information". Carrying one would add a line to every catalog that
+/// declares it, to repeat what [`PropType::Any`] already says.
+const UNINFORMATIVE_TYPES: &[&str] = &["any", "unknown", "unknown | undefined", "any | undefined"];
 
 /// Whether a manifest member is a property-only input an author can set.
 ///
@@ -504,6 +511,23 @@ mod cem_tests {
         assert_eq!(by("checked").type_text, None);
         assert_eq!(by("size").type_text, None);
         assert_eq!(by("name").type_text, None);
+    }
+
+    #[test]
+    fn test_type_text_skips_the_spellings_that_say_nothing() {
+        let manifest = r#"{"modules":[{"declarations":[{
+          "kind":"class","name":"El","customElement":true,"tagName":"an-el",
+          "attributes":[
+            {"name":"opaque","type":{"text":"unknown"}},
+            {"name":"loose","type":{"text":"any"}},
+            {"name":"rows","type":{"text":"string[]"}}
+          ]
+        }]}]}"#;
+        let s = &parse_manifest(manifest).unwrap()[0];
+        let by = |n: &str| s.props.iter().find(|p| p.name == n).unwrap();
+        assert_eq!(by("opaque").type_text, None); // the kind already says "unmodeled"
+        assert_eq!(by("loose").type_text, None);
+        assert_eq!(by("rows").type_text.as_deref(), Some("string[]"));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #179, found while the weekly copier PRs became the first CI runs against 0.7.11.

A prop declared `unknown` or `any` normalizes to the `json` kind, and carrying its declared type repeats what the kind already said. That is not free: every catalog declaring one gains a `type_text="unknown"` line, and the longer entry reflows across several lines, so a catalog that learned nothing still drifts and has to be regenerated.

Measured against the peer catalogs, that is most of what type text touched:

```
                          drift on 0.7.11   with this branch
spaday-lightweight-charts   1 line            none
spaday-regular-layout       6 lines           none
spaday-perspective          3 lines           none
spaday-regular-table       23 lines           none
spaday-trees                5 lines           3 lines — a real `string[]`
spaday-dagre                none              3 lines — drops an `unknown` already committed
```

Four of six drifted only by an `unknown` and stop drifting once it is skipped. What remains is exactly the catalogs that gain or lose real information: `spaday-trees` records a `string[]`, and `spaday-dagre` — regenerated against 0.7.11 already — drops the noise it picked up.

This is the same rule the schema follows elsewhere: `fields` is omitted when empty, and type text is kept only for the kind that says nothing about shape. `unknown` and `any` are that kind's own spelling, so they belong on the same side of the line.

Additive and behavior-preserving: the shape check never read a bare name like `unknown` anyway, so nothing that constructs today changes.

Tests: rust 66, python 217.
