### PR TITLE
Add theme tokens, retag, and a customization guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Select an installed integration by its entry-point name, for example `serve(page
 - **How-to guides** — [author a component tree](docs/src/components.md),
   [add behavior and reactivity](docs/src/behavior.md),
   [serve and embed an app](docs/src/serving.md),
+  [theme it and ship your own variant](docs/src/customizing.md),
   [use it in a notebook](docs/src/notebook.md),
   [run Python UI logic in Pyodide](docs/src/pyodide.md),
   [sync to a server over transports](docs/src/transports.md),

--- a/docs/src/customizing.md
+++ b/docs/src/customizing.md
@@ -1,0 +1,156 @@
+# Ship your own variant
+
+spaday's component packages are two halves bolted together: a **Python authoring surface** (typed
+component classes, catalog schemas, actions, bindings) and a **JS implementation** (the bundle that
+registers the custom elements). The bolt is meant to come out. This guide covers the four things
+people want when they build on spaday rather than just using it:
+
+1. [Theme a package from Python](#theme-a-package-from-python), without writing a stylesheet.
+1. [Serve your own bundle](#serve-your-own-bundle) behind a package's Python surface.
+1. [Point a component at your own element](#point-a-component-at-your-own-element) with a different tag.
+1. [Share one engine](#share-one-engine-between-two-libraries) between two libraries on a page.
+
+## Theme a package from Python
+
+`css()` sets **CSS custom properties** — any of them, not a fixed list — so a design system's own
+tokens are authored from Python with no stylesheet at all:
+
+```python
+from spaday.components.shell import App
+
+App().css(spa_surface="#0C4253", wa_color_brand_fill_loud="#FC6B47")
+# → --spa-surface: #0C4253; --wa-color-brand-fill-loud: #FC6B47
+```
+
+Kwargs are kebab-cased and `--`-prefixed (`spa_surface_2` → `--spa-surface-2`). Custom properties
+inherit through shadow boundaries, so setting them on the `App` root reaches every component in the
+tree.
+
+### Three layers, in order
+
+A color in any spaday component package resolves through three layers:
+
+```css
+var(--spa-dagre-node-fill,       /* 1. the package's own token   */
+var(--spa-surface-2,             /* 2. the shell token it belongs to */
+#fafafa))                        /* 3. a literal, for a standalone page */
+```
+
+So there are two ways to theme, and you pick by how wide you want the change:
+
+```python
+App().css(spa_surface_2="#1a2028")          # every package's panels follow
+Dagre(graph=g).css(spa_dagre_node_fill="#1a2028")   # only the graph
+```
+
+`spaday.theme.SHELL_TOKENS` lists the shell palette (`--spa-surface`, `--spa-surface-2`,
+`--spa-border`, `--spa-muted`, `--spa-accent`, `--spa-info`, `--spa-success`, `--spa-warning`,
+`--spa-danger`, plus layout tokens). Each package publishes its own `TOKENS` mapping in the same
+shape:
+
+```python
+from spaday_dagre import TOKENS
+
+for kwarg, (prop, what) in TOKENS.items():
+    print(f"{kwarg:<28} {prop:<34} {what}")
+```
+
+Package tokens are named `--spa-<package>-<thing>`, where `<package>` is the name you pass to
+`packages=[...]`. They are only ever *read* by the package's stylesheet, never defined by it — that
+is what lets a token set on an ancestor (an app-level theme) win over the package's default.
+
+### Page mode
+
+The dark palette is keyed off WebAwesome's `wa-dark` class, so one binding re-themes everything:
+
+```python
+App(...).bind_root_class("wa-dark", "dark")
+```
+
+`wa-light` on a subtree flips a nested island back. Both palettes are emitted at zero specificity,
+so your own rules always win.
+
+### When the design system should drive
+
+`spaday-webawesome` maps WebAwesome's tokens *onto* the shell palette rather than the other way
+round, so restyling WebAwesome carries the shell, the graphs, the tables and the trees with it:
+
+```python
+App().css(wa_color_brand_fill_loud="#0C4253")  # → --spa-accent, --spa-info, and everything downstream
+```
+
+A canvas component cannot read CSS, so `spaday-lightweight-charts` samples the resolved value of its
+tokens and hands them to the chart. Theming it looks identical from Python.
+
+## Serve your own bundle
+
+A `ComponentPackage` is a frozen dataclass of `(name, assets_dir, assets, components)`, and
+`bootstrap(packages=[...])` takes descriptors directly. Keep the generated component classes and
+their schemas, and serve your own JS:
+
+```python
+import dataclasses
+from spaday.bootstrap import bootstrap
+from spaday_webawesome import package as webawesome
+
+mine = dataclasses.replace(
+    webawesome,
+    assets_dir=MY_DIST,                       # your built bundle
+    assets=(("css", "my.css"), ("js", "my-wa.js")),
+)
+bootstrap(packages=[mine], ...)
+```
+
+Your bundle must register the tags the schemas name, with the attributes they declare — that is the
+whole contract. Nothing checks it for you, so a browser test asserting the tags are defined is worth
+writing.
+
+Two packages with the same `name` are rejected, which is the point: an app gets the peer's bundle or
+yours, never both. That also means substitution is the simplest fix for the collision in
+[Share one engine](#share-one-engine-between-two-libraries) — with one copy on the page, there is
+nothing to collide.
+
+## Point a component at your own element
+
+If your element implements the same contract under a different tag, `retag()` gives you the Python
+surface pointed at it:
+
+```python
+from spaday_perspective import PerspectivePanel, package
+
+MyGrid = PerspectivePanel.retag("my-data-grid")
+mine = dataclasses.replace(package, assets_dir=MY_DIST, assets=(("js", "grid.js"),), components=(MyGrid,))
+```
+
+`retag()` carries the tag into the class's `schema` too — `ComponentPackage` requires the two to
+agree — and the new tag registers for dict-tree validation like any other schema-carrying class.
+
+### You may not need the Python surface at all
+
+Some packages contribute no server code. `spaday-perspective` is only `PerspectivePanel` plus the
+package descriptor: the websocket is perspective-python's own `Server()` and handler, wired by your
+application. If you have your own grid element and just want it fed by the same data, point it at
+the same URL — neither side needs to know about the other.
+
+## Share one engine between two libraries
+
+Libraries that bundle an engine registering global custom element names (Perspective, WebAwesome)
+cannot load twice on a page: the second copy throws from `customElements.define`. In order of
+preference:
+
+1. **Substitute** — if you have your own wrapper, serve one bundle (above). One copy, no collision.
+1. **Reuse the object** — where the engine hands out a client, lend it rather than importing a
+   second copy.
+1. **Survive the collision** — packages that register elements install a define-guard, so the
+   losing bundle skips names already taken instead of throwing and taking the page with it. This
+   keeps the page alive; it does not make two copies agree, and two copies at different versions is
+   still a bug to fix rather than a state to ship.
+
+`spaday-webawesome` publishes the version it bundles as `globalThis.__spadayWebawesome.version`, so
+a page holding a second copy can compare and refuse rather than half-work.
+
+### Third-party bundles cannot blank your page
+
+`bootstrap(scripts=[...])` loads extra ES modules before the tree mounts. A failure in one is caught
+and logged with the URL rather than aborting the page, so a third-party bundle that throws while
+registering costs you that script, not every component on the page.

--- a/js/src/ts/shell.ts
+++ b/js/src/ts/shell.ts
@@ -24,8 +24,10 @@ const THEME_CSS = `:where(.wa-dark) {
   --spa-surface-2: #1d232b;
   --spa-border: #333b45;
   --spa-muted: #9aa3ad;
+  --spa-accent: #8fb4dd;
   --spa-info: #5b9dd9;
   --spa-success: #58a765;
+  --spa-warning: #d29922;
   --spa-danger: #d9636a;
 }
 :where(.wa-light) {
@@ -33,12 +35,17 @@ const THEME_CSS = `:where(.wa-dark) {
   --spa-surface-2: #fafafa;
   --spa-border: #e6e6e6;
   --spa-muted: #666;
+  --spa-accent: #4a90d9;
   --spa-info: #1565c0;
   --spa-success: #2e7d32;
+  --spa-warning: #9a6700;
   --spa-danger: #c62828;
 }`;
 
 // Tone accents for notification surfaces (light defaults; the dark palette overrides above).
+// `--spa-accent` and `--spa-warning` are part of the same palette but unused by the shell itself:
+// they are the shared vocabulary component packages chain their own tokens to (an emphasis color
+// and a fourth tone), so an app that re-themes the shell re-themes them too.
 const INFO = "var(--spa-info, #1565c0)";
 const SUCCESS = "var(--spa-success, #2e7d32)";
 const DANGER = "var(--spa-danger, #c62828)";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,6 +289,7 @@ pages = [
     "docs/src/behavior.md",
     "docs/src/components.md",
     "docs/src/serving.md",
+    "docs/src/customizing.md",
     "docs/src/transports.md",
     "docs/src/notebook.md",
     "docs/src/pyodide.md",

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -287,7 +287,9 @@ def _script(
         # `mount`, and the page renders nothing at all. Awaited here, so handlers are still
         # registered before the tree mounts; a failure costs that one script, not the page.
         urls = ", ".join(json.dumps(script) for script in scripts)
-        lines.append(f"await Promise.all([{urls}].map((u) => import(u).catch((e) => console.error(`spaday: extra script ${{u}} failed to load`, e))));")
+        lines.append(
+            f"await Promise.all([{urls}].map((u) => import(u).catch((e) => console.error(`spaday: extra script ${{u}} failed to load`, e))));"
+        )
     lines.append(f'await init({{ module_or_path: "{js}{assets["wasm"]}" }});')
     if wired:
         lines.append(f'await wasm.default({{ module_or_path: "{js}{assets["transports_wasm"]}" }});')

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -281,7 +281,13 @@ def _script(
     lines = [f'import {{ {", ".join(runtime_names)} }} from "{js}{assets["runtime"]}";']
     if wired:
         lines.append(f'import {{ Client, fromValue, toValue, wasm }} from "{js}{assets["transports"]}";')
-    lines.extend(f'import "{s}";' for s in scripts)
+    if scripts:
+        # dynamic + caught, not `import "…"`: a static import of a third-party bundle that throws
+        # while registering (two copies of one custom element, say) aborts this module before
+        # `mount`, and the page renders nothing at all. Awaited here, so handlers are still
+        # registered before the tree mounts; a failure costs that one script, not the page.
+        urls = ", ".join(json.dumps(script) for script in scripts)
+        lines.append(f"await Promise.all([{urls}].map((u) => import(u).catch((e) => console.error(`spaday: extra script ${{u}} failed to load`, e))));")
     lines.append(f'await init({{ module_or_path: "{js}{assets["wasm"]}" }});')
     if wired:
         lines.append(f'await wasm.default({{ module_or_path: "{js}{assets["transports_wasm"]}" }});')

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -208,6 +208,26 @@ class Component:
         """
         cls.strict_props = strict
 
+    @classmethod
+    def retag(cls, tag: str) -> type["Component"]:
+        """A subclass of this component bound to a different custom element name.
+
+        Use it when an application ships its own element implementing the same contract and wants
+        this class's authoring surface — props, bindings, actions, catalog schema — pointed at that
+        element instead::
+
+            MyGrid = PerspectivePanel.retag("my-data-grid")
+
+        The tag is carried into the class's ``schema`` as well, which
+        :class:`~spaday.packages.ComponentPackage` requires to agree with ``tag``, so the result can
+        go straight into a package descriptor. The new tag registers for dict-tree validation like
+        any other schema-carrying class.
+        """
+        if not tag:
+            raise ValueError("retag requires a tag")
+        schema = cls.schema.model_copy(update={"tag": tag}) if cls.schema is not None else None
+        return type(cls.__name__, (cls,), {"tag": tag, "schema": schema})
+
     def _check_prop_names(self) -> None:
         """Reject keywords the class's catalog ``schema`` does not describe (opt-in; see
         :meth:`set_strict_props`). Reports every unknown name at once, by the same rules and in the

--- a/spaday/examples/__main__.py
+++ b/spaday/examples/__main__.py
@@ -161,13 +161,10 @@ form_server = host(Device())
 # can PUSH at any time. Two pushable presets — a flat live blotter and a by-category rollup — flip
 # server-side, and every connected workspace re-restores ("push a new view at any time").
 def _layout(viewer: dict) -> dict:
-    """A single-viewer perspective-workspace layout (the shape ``<perspective-workspace>.restore`` wants)."""
+    """A single-viewer Perspective 5 layout: a ``regular-layout`` tree plus per-panel viewer configs."""
     return {
-        "sizes": [1],
-        "detail": {"main": {"type": "tab-area", "widgets": ["view"], "currentIndex": 0}},
-        "master": {"sizes": [], "widgets": []},
-        "mode": "globalFilters",
-        "viewers": {"view": {"table": "orders", "plugin": "Datagrid", "theme": "Pro Light", **viewer}},
+        "layout": {"type": "tab-layout", "tabs": ["view"], "currentIndex": 0},
+        "panels": {"view": {"table": "orders", "plugin": "Datagrid", "theme": "Pro Light", **viewer}},
     }
 
 
@@ -211,9 +208,9 @@ class Blotter:
     async def relayout(self, request) -> JSONResponse:
         """Flip the shared layout between the flat blotter and the by-category rollup; transports fans the
         change so every connected workspace re-restores."""
-        grouped = self.config.layout.get("viewers", {}).get("view", {}).get("group_by")
+        grouped = self.config.layout.get("panels", {}).get("view", {}).get("group_by")
         self.config.layout = dict(BLOTTER_VIEW) if grouped else dict(BY_CATEGORY_VIEW)
-        return JSONResponse({"view": self.config.layout["viewers"]["view"]["title"]})
+        return JSONResponse({"view": self.config.layout["panels"]["view"]["title"]})
 
 
 blotter = Blotter()

--- a/spaday/examples/gateway.py
+++ b/spaday/examples/gateway.py
@@ -119,13 +119,13 @@ THEME_CSS = """<style>
 
 
 def _layout(extra: dict) -> dict:
-    """A Perspective workspace layout showing the 'orders' table in a single datagrid viewer."""
+    """A Perspective workspace layout showing the 'orders' table in a single datagrid viewer.
+
+    Perspective 5's shape: a ``regular-layout`` tree plus per-panel viewer configs. ``tab-layout``
+    names its tabs as plain strings (``split-layout`` nests ``children`` instead)."""
     return {
-        "sizes": [1],
-        "detail": {"main": {"type": "tab-area", "widgets": ["orders"], "currentIndex": 0}},
-        "master": {"sizes": [], "widgets": []},
-        "mode": "globalFilters",
-        "viewers": {"orders": {"table": "orders", "plugin": "Datagrid", **extra}},
+        "layout": {"type": "tab-layout", "tabs": ["orders"], "currentIndex": 0},
+        "panels": {"orders": {"table": "orders", "plugin": "Datagrid", **extra}},
     }
 
 

--- a/spaday/tests/test_bootstrap.py
+++ b/spaday/tests/test_bootstrap.py
@@ -42,7 +42,19 @@ def test_reconnect_bootstrap_reopens_the_socket():
 
 
 def test_scripts_are_injected():
-    assert 'import "/static/handlers.js";' in bootstrap(scripts=["/static/handlers.js"])
+    html = bootstrap(scripts=["/static/handlers.js"])
+    assert '"/static/handlers.js"' in html and "import(u)" in html
+
+
+def test_a_failing_extra_script_cannot_abort_the_page():
+    """A third-party bundle that throws while loading (two copies of one custom element, say) must
+    cost that script only — a static import would abort the module before `mount` and render
+    nothing at all."""
+    html = bootstrap(scripts=["/static/handlers.js"])
+    assert 'import "/static/handlers.js";' not in html  # not a static import
+    scripts = html[html.index("await Promise.all([") :]
+    assert ".catch(" in scripts[: scripts.index("\n")]  # the rejection is caught
+    assert html.index("await Promise.all([") < html.index("mount(")  # still awaited before mount
 
 
 def test_stylesheets_and_styles_are_injected_with_the_nonce():

--- a/spaday/tests/test_packages.py
+++ b/spaday/tests/test_packages.py
@@ -140,3 +140,35 @@ def test_rejects_invalid_python_paths_and_entry_points(monkeypatch, python_path_
     monkeypatch.setattr(package_registry, "entry_points", lambda **_kwargs: duplicates)
     with pytest.raises(ValueError, match="multiple .* entry points"):
         resolve_component_packages("duplicate")
+
+
+def test_retag_points_a_components_authoring_surface_at_another_element():
+    """An app shipping its own element implementing the same contract keeps the Python surface."""
+    class TheirGrid(Component):
+        tag = "their-grid"
+        schema = ComponentSchema(tag="their-grid", class_name="TheirGrid", props=(PropertySchema(name="rows", kind="json"),))
+
+    Mine = TheirGrid.retag("my-grid")
+    assert Mine.tag == "my-grid"
+    assert Mine.schema.tag == "my-grid"  # ComponentPackage requires the two to agree
+    assert Mine(rows=[1]).to_node()["tag"] == "my-grid"
+    assert TheirGrid.tag == "their-grid"  # the original is untouched
+
+
+def test_a_retagged_component_goes_into_a_package_descriptor():
+    """The point of retag: substitute your own element behind a peer's authoring surface."""
+    class TheirGrid(Component):
+        tag = "their-grid"
+        schema = ComponentSchema(tag="their-grid", class_name="TheirGrid")
+
+    package = ComponentPackage(name="mine", assets_dir=".", assets=(("js", "mine.js"),), components=(TheirGrid.retag("my-grid"),))
+    assert [component.tag for component in package.components] == ["my-grid"]
+    assert package.catalog[0].tag == "my-grid"
+
+
+def test_retag_requires_a_tag():
+    class Anon(Component):
+        tag = "anon"
+
+    with pytest.raises(ValueError, match="retag requires a tag"):
+        Anon.retag("")

--- a/spaday/tests/test_packages.py
+++ b/spaday/tests/test_packages.py
@@ -144,6 +144,7 @@ def test_rejects_invalid_python_paths_and_entry_points(monkeypatch, python_path_
 
 def test_retag_points_a_components_authoring_surface_at_another_element():
     """An app shipping its own element implementing the same contract keeps the Python surface."""
+
     class TheirGrid(Component):
         tag = "their-grid"
         schema = ComponentSchema(tag="their-grid", class_name="TheirGrid", props=(PropertySchema(name="rows", kind="json"),))
@@ -157,6 +158,7 @@ def test_retag_points_a_components_authoring_surface_at_another_element():
 
 def test_a_retagged_component_goes_into_a_package_descriptor():
     """The point of retag: substitute your own element behind a peer's authoring surface."""
+
     class TheirGrid(Component):
         tag = "their-grid"
         schema = ComponentSchema(tag="their-grid", class_name="TheirGrid")

--- a/spaday/tests/test_theme.py
+++ b/spaday/tests/test_theme.py
@@ -1,6 +1,12 @@
 """Per-component theming: CSS custom properties, inline declarations, and classes from Python."""
 
+import re
+from pathlib import Path
+
+import pytest
+
 from spaday import SHELL_TOKENS, element
+from spaday.theme import package_token
 
 
 def test_css_sets_custom_properties():
@@ -35,3 +41,48 @@ def test_unthemed_component_stays_prop_free():
 
 def test_shell_tokens_reference_is_exposed():
     assert SHELL_TOKENS["spa_surface"][0] == "--spa-surface"  # css(spa_surface=...) drives this property
+
+
+def test_shell_tokens_documents_every_token_the_shell_palette_defines():
+    """SHELL_TOKENS is what a Python author discovers; the palette in shell.ts is what actually
+    renders. They drifted once — the palette gained the tone colors and the reference didn't, so
+    component packages hardcoded their own instead of chaining to them."""
+    palette = Path(__file__).parents[2] / "js" / "src" / "ts" / "shell.ts"
+    theme_css = palette.read_text().split("const THEME_CSS = `", 1)[1].split("`;", 1)[0]
+    defined = set(re.findall(r"(--spa-[a-z0-9-]+):", theme_css))
+    documented = {prop for prop, _ in SHELL_TOKENS.values()}
+    assert defined - documented == set(), "shell.ts defines tokens SHELL_TOKENS does not document"
+
+
+def test_package_token_spells_the_component_package_convention():
+    assert package_token("dagre", "node-fill") == "--spa-dagre-node-fill"
+
+
+def test_installed_component_packages_follow_the_token_convention():
+    """Every component package publishes a TOKENS mapping shaped like SHELL_TOKENS, naming
+    properties `--spa-<package>-*`, with a css() kwarg that actually produces that property.
+
+    `spaday-webawesome` is the documented exception: it maps a design system's own tokens onto the
+    shell palette instead of exposing tokens of its own, so its kwargs are `--wa-*`.
+    """
+    import importlib
+
+    from spaday.packages import discover_component_packages
+
+    checked = 0
+    for package in discover_component_packages():
+        module = importlib.import_module(package.components[0].__module__.split(".")[0])
+        tokens = getattr(module, "TOKENS", None)
+        if tokens is None:
+            continue
+        checked += 1
+        for kwarg, entry in tokens.items():
+            prop, description = entry  # (property, what it controls), like SHELL_TOKENS
+            assert description, f"{package.name}: {prop} has no description"
+            assert element("div").css(**{kwarg: "x"}).to_node()["props"]["style"]["Str"] == f"{prop}: x", (
+                f"{package.name}: css({kwarg}=…) does not produce {prop}"
+            )
+            if package.name != "webawesome":
+                assert prop.startswith(f"--spa-{package.name}-"), f"{package.name}: {prop} does not follow --spa-<package>-*"
+    if not checked:
+        pytest.skip("no component packages with TOKENS installed")

--- a/spaday/theme.py
+++ b/spaday/theme.py
@@ -15,6 +15,24 @@ mapping its own theme onto these variables::
 
     from spaday.components.shell import App
     App().css(spa_surface="#111", spa_border="#333", spa_muted="#999")  # retheme the whole shell
+
+Component packages
+------------------
+
+Every token of every component is set the same way — ``css()`` takes **arbitrary** custom properties,
+so a third-party design system's own tokens are authored from Python without a stylesheet::
+
+    App().css(wa_color_surface_default="#111")  # --wa-color-surface-default
+
+A spaday component package names its own tokens ``--spa-<package>-<thing>`` (see
+:func:`package_token`) and chains each one to the shell token it belongs to, so three layers apply in
+order — the package's token, then the shell's, then a literal that keeps a standalone page coherent::
+
+    fill: var(--spa-dagre-node-fill, var(--spa-surface-2, #fafafa));
+
+An app therefore re-themes every package at once by setting the shell tokens, or re-themes one
+package without touching the others by setting its ``--spa-<package>-*`` tokens. Each package
+publishes a ``TOKENS`` mapping in this module's :data:`SHELL_TOKENS` shape listing what it exposes.
 """
 
 #: ``css()`` kwarg → (CSS custom property, what it controls). The shell reads these (see ``js shell.ts``).
@@ -23,8 +41,26 @@ SHELL_TOKENS = {
     "spa_surface_2": ("--spa-surface-2", "gutter / toolbar surface color"),
     "spa_border": ("--spa-border", "shell border color"),
     "spa_muted": ("--spa-muted", "footer / muted text color"),
+    "spa_accent": ("--spa-accent", "emphasis / hover / selection color"),
+    "spa_info": ("--spa-info", "info tone (Toast, component packages)"),
+    "spa_success": ("--spa-success", "success tone (Toast, component packages)"),
+    "spa_warning": ("--spa-warning", "warning tone (component packages)"),
+    "spa_danger": ("--spa-danger", "danger tone (Toast, component packages)"),
     "spa_gap": ("--spa-gap", "default gap between shell children"),
     "spa_align": ("--spa-align", "cross-axis alignment for Stack / Row / Toolbar"),
     "spa_justify": ("--spa-justify", "main-axis justification for Row"),
     "spa_gutter_width": ("--spa-gutter-width", "Gutter width"),
 }
+
+#: The prefix a component package's own tokens use: ``--spa-<package>-<thing>``.
+PACKAGE_TOKEN_PREFIX = "--spa-"
+
+
+def package_token(package: str, name: str) -> str:
+    """The CSS custom property a component package exposes for one themeable thing.
+
+    ``package_token("dagre", "node-fill")`` → ``"--spa-dagre-node-fill"``. Packages publish their
+    own ``TOKENS`` mapping in the same shape as :data:`SHELL_TOKENS`; this is the naming rule those
+    mappings follow.
+    """
+    return f"{PACKAGE_TOKEN_PREFIX}{package}-{name}"


### PR DESCRIPTION
## Description

Makes theming and frontend substitution a supported, documented contract, and fixes the two
diagnosability bugs found on the way.

**Theme tokens.** The shell palette defined `--spa-info`, `--spa-success` and `--spa-danger`, but
`SHELL_TOKENS` — what a Python author actually discovers — documented none of them. That drift is
why component packages hardcoded their own colors instead of chaining to the shell. Those three are
now documented, `--spa-accent` is added (spaday-dagre already read it and nothing defined it) along
with `--spa-warning`, and a test asserts the palette in `shell.ts` and the reference in `theme.py`
cannot drift apart again. `theme.py` also documents the convention component packages follow:
`--spa-<package>-<thing>`, chaining to the shell token it belongs to.

**`Component.retag()`.** Points a component's authoring surface — props, bindings, actions, catalog
schema — at a different custom element, for an application shipping its own implementation of the
same contract. It carries the tag into the class's schema, which `ComponentPackage` requires to
agree with `tag`, so the result drops straight into a package descriptor.

**A failing extra script can no longer blank the page.** `scripts=[...]` entries were static imports
in the generated module script, so a third-party bundle that threw while loading (two copies of one
custom element, say) aborted the module before `mount()` and the page rendered *nothing at all*.
They are now dynamic imports with the rejection caught and the URL named, still awaited so handlers
register before the tree mounts.

**Perspective 5 layouts.** Both examples still passed Perspective 4's
`{sizes, detail, master, mode, viewers}`. 5.x rejects it with a console message and an empty panel
rather than an exception, so it reads like a data problem.

**Docs.** A new guide, *Ship your own variant*, covering the four things people want when building
on spaday rather than just using it: theme a package from Python, serve your own bundle behind a
package's Python surface, point a component at your own element, and share one engine between two
libraries. Two of those already worked and were simply undocumented, which is why they kept being
asked for. Every code sample in the guide is executed by a test.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)

Peer PRs adopting the token convention: spaday-dagre, spaday-trees, spaday-webawesome,
spaday-regular-layout, spaday-regular-table, spaday-lightweight-charts, spaday-perspective.
