### PR TITLE
Let a component package publish vendored modules as an import map

### DIFF
--- a/docs/src/customizing.md
+++ b/docs/src/customizing.md
@@ -138,9 +138,30 @@ Libraries that bundle an engine registering global custom element names (Perspec
 cannot load twice on a page: the second copy throws from `customElements.define`. In order of
 preference:
 
+1. **Publish one copy behind an import map** — a package can publish its vendored modules under
+   their bare specifiers, and `bootstrap` emits them as an import map ahead of every module script:
+
+   ```python
+   ComponentPackage(
+       name="perspective",
+       assets_dir=DIST,
+       assets=(("js", "cdn/index.js"),),
+       imports=(("@perspective-dev/", "vendor/"),),   # → /components/perspective/vendor/
+   )
+   ```
+
+   Any other library on the page then resolves `@perspective-dev/client` to that one copy and needs
+   no API at all. A specifier ending in `/` maps a whole subtree. Two packages publishing the same
+   specifier at different URLs is an error naming both, because silently picking one is the
+   ambiguity this removes. The map must precede the first module load — `bootstrap` handles the
+   ordering, but if you are embedding a `fragment=True` snippet, put it in the page before any
+   other module script, since a late map is ignored silently.
+
 1. **Substitute** — if you have your own wrapper, serve one bundle (above). One copy, no collision.
+
 1. **Reuse the object** — where the engine hands out a client, lend it rather than importing a
    second copy.
+
 1. **Survive the collision** — packages that register elements install a define-guard, so the
    losing bundle skips names already taken instead of throwing and taking the page with it. This
    keeps the page alive; it does not make two copies agree, and two copies at different versions is

--- a/js/tests/importmap.spec.js
+++ b/js/tests/importmap.spec.js
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+/* The Python side emits the import map; these check the browser behavior that emission relies on.
+ * `bootstrap` puts the map ahead of every module script — including the component packages' own —
+ * because a map that arrives after the first module load is ignored, and ignored silently. */
+
+const VENDOR = 'export const marker = "the-one-copy";';
+
+async function serveVendor(page) {
+  await page.route("**/components/demo/vendor/engine.js", (route) =>
+    route.fulfill({ contentType: "text/javascript", body: VENDOR }),
+  );
+  // setContent keeps the current URL, and an `about:blank` page has no base for a root-relative
+  // specifier to resolve against, so land on the test origin first
+  await page.goto("/tests/runtime.html");
+}
+
+test("a bare specifier resolves through the emitted map", async ({ page }) => {
+  await serveVendor(page);
+  await page.setContent(`
+    <script type="importmap">
+    {"imports": {"@demo/engine": "/components/demo/vendor/engine.js"}}
+    </script>
+    <script type="module">
+      import { marker } from "@demo/engine";
+      window.resolved = marker;
+    </script>
+  `);
+  await expect
+    .poll(() => page.evaluate(() => window.resolved))
+    .toBe("the-one-copy");
+});
+
+test("a trailing-slash specifier resolves a subtree", async ({ page }) => {
+  await serveVendor(page);
+  await page.setContent(`
+    <script type="importmap">
+    {"imports": {"@demo/": "/components/demo/vendor/"}}
+    </script>
+    <script type="module">
+      import { marker } from "@demo/engine.js";
+      window.resolved = marker;
+    </script>
+  `);
+  await expect
+    .poll(() => page.evaluate(() => window.resolved))
+    .toBe("the-one-copy");
+});
+
+test("a map placed after a module script is ignored", async ({ page }) => {
+  // this is why bootstrap emits the map first: get the order wrong and nothing reports it
+  await serveVendor(page);
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.setContent(`
+    <script type="module">
+      import { marker } from "@demo/engine";
+      window.resolved = marker;
+    </script>
+    <script type="importmap">
+    {"imports": {"@demo/engine": "/components/demo/vendor/engine.js"}}
+    </script>
+  `);
+  await expect.poll(() => errors.length).toBeGreaterThan(0);
+  expect(await page.evaluate(() => window.resolved)).toBeUndefined();
+});
+
+test("two libraries importing one specifier get the same module instance", async ({
+  page,
+}) => {
+  // the point of the feature: one copy of an engine that registers global element names
+  await serveVendor(page);
+  await page.setContent(`
+    <script type="importmap">
+    {"imports": {"@demo/engine": "/components/demo/vendor/engine.js"}}
+    </script>
+    <script type="module">
+      const a = await import("@demo/engine");
+      const b = await import("/components/demo/vendor/engine.js");
+      window.sameInstance = a === b;
+    </script>
+  `);
+  await expect.poll(() => page.evaluate(() => window.sameInstance)).toBe(true);
+});

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -190,6 +190,36 @@ def _package_head(packages: Sequence[ComponentPackage], base: str, nonce: str | 
     return "\n    ".join(tags)
 
 
+def _importmap(packages: Sequence[ComponentPackage], base: str, nonce: str | None = None) -> str:
+    """The page's import map: every specifier a selected package publishes, resolved to the URL that
+    package is served from.
+
+    Must precede every module script on the page, which is why it is emitted first -- a map that
+    arrives after the first module load is ignored by the browser, silently. Two packages publishing
+    the same specifier at different URLs is an error naming both, since picking one silently is the
+    ambiguity ``imports`` exists to remove; publishing the same specifier at the same URL is fine.
+    """
+    resolved: dict[str, str] = {}
+    owners: dict[str, str] = {}
+    for package in packages:
+        prefix = package_url_prefix(package, base)
+        for specifier, path in package.imports:
+            url = f"{prefix}/{path}"
+            if specifier in resolved and resolved[specifier] != url:
+                raise ValueError(
+                    f"component packages {owners[specifier]!r} and {package.name!r} both publish the import "
+                    f"{specifier!r} at different URLs ({resolved[specifier]} and {url}); select only one of them, "
+                    f"or override the packages so a single copy is published"
+                )
+            resolved[specifier] = url
+            owners[specifier] = package.name
+    if not resolved:
+        return ""
+    n = f' nonce="{nonce}"' if nonce else ""
+    body = json.dumps({"imports": resolved}, indent=2, sort_keys=True)
+    return f'<script type="importmap"{n}>\n{body}\n</script>'
+
+
 def _wire_block(spec: dict, base: str, idx: int) -> list:
     """The generated JS for ONE wire spec in a multi-model page: a transports ``Client``, a namespaced
     ``connectStore`` into the shared ``store``, the ``WebSocket`` feeding it, and a ``<namespace>.connected``
@@ -402,7 +432,10 @@ def bootstrap(
     component_packages = resolve_component_packages(packages)
     style_tags = [f'<link rel="stylesheet"{n} href="{url}" />' for url in stylesheets]
     style_tags += [f"<style{n}>{css}</style>" for css in styles]
-    head_markup = "\n    ".join(p for p in (_package_head(component_packages, base, nonce), *style_tags, head) if p)
+    # the import map must come before any module script, including the packages' own
+    head_markup = "\n    ".join(
+        p for p in (_importmap(component_packages, base, nonce), _package_head(component_packages, base, nonce), *style_tags, head) if p
+    )
     script = _script(base, wire, scripts, ws, tree, reconnect, store, target, layout, persist, url)
     if fragment:
         head_block = f"{head_markup}\n" if head_markup else ""

--- a/spaday/packages.py
+++ b/spaday/packages.py
@@ -27,12 +27,24 @@ class ComponentPackage:
     :class:`~spaday.component.Component` subclasses. Generated CEM classes
     already carry schemas; hand-authored classes set ``Component.schema``.
     ``catalog`` returns those schemas without constructing components.
+
+    ``imports`` publishes vendored modules under their bare specifiers as
+    ``(specifier, relative_path)`` pairs, which :func:`~spaday.bootstrap.bootstrap`
+    emits as an import map. It exists for engines that register global custom
+    element names -- Perspective, a design system -- where a second copy on the
+    page throws from ``customElements.define`` and the two cannot coexist. A
+    package that publishes its copy this way lets every other library on the page
+    resolve the same bare specifier to it, so there is one copy rather than a
+    collision. A specifier ending in ``/`` maps a whole subtree, per the import-map
+    spec. Two packages publishing the same specifier at different paths is an
+    error: it is the ambiguity the feature exists to remove.
     """
 
     name: str
     assets_dir: Path
     assets: Sequence[tuple[str, str]]
     components: Sequence[type[Component]] = ()
+    imports: Sequence[tuple[str, str]] = ()
 
     def __post_init__(self) -> None:
         if not _PACKAGE_NAME.fullmatch(self.name):
@@ -47,6 +59,18 @@ class ComponentPackage:
             normalized.append((kind, asset_path.as_posix()))
         object.__setattr__(self, "assets_dir", Path(self.assets_dir))
         object.__setattr__(self, "assets", tuple(normalized))
+        imports = []
+        for specifier, path in self.imports:
+            if not specifier or specifier.strip() != specifier or any(c.isspace() for c in specifier):
+                raise ValueError(f"component package import specifier {specifier!r} must be a bare specifier with no whitespace")
+            import_path = PurePosixPath(path)
+            if import_path.is_absolute() or not path or ".." in import_path.parts:
+                raise ValueError("component package import paths must be relative and cannot contain '..'")
+            # a specifier mapping a subtree must map to one, per the import-map spec
+            if specifier.endswith("/") != path.endswith("/"):
+                raise ValueError(f"component package import {specifier!r} and its path must either both end in '/' or neither")
+            imports.append((specifier, import_path.as_posix() + ("/" if path.endswith("/") else "")))
+        object.__setattr__(self, "imports", tuple(imports))
         components = tuple(self.components)
         seen: set[str] = set()
         for component in components:

--- a/spaday/tests/test_packages.py
+++ b/spaday/tests/test_packages.py
@@ -174,3 +174,59 @@ def test_retag_requires_a_tag():
 
     with pytest.raises(ValueError, match="retag requires a tag"):
         Anon.retag("")
+
+
+def _vendored(name: str, imports: tuple[tuple[str, str], ...]) -> ComponentPackage:
+    return ComponentPackage(name=name, assets_dir=".", assets=(("js", "cdn/index.js"),), imports=imports)
+
+
+def test_a_package_publishes_its_vendored_modules_as_an_import_map():
+    html = bootstrap(packages=[_vendored("perspective", (("@perspective-dev/client", "vendor/client.js"),))], fragment=True)
+    assert '"@perspective-dev/client": "/components/perspective/vendor/client.js"' in html
+    assert '<script type="importmap">' in html
+
+
+def test_the_import_map_precedes_every_module_script():
+    """A map that arrives after the first module load is ignored by the browser, silently."""
+    html = bootstrap(packages=[_vendored("perspective", (("@perspective-dev/client", "vendor/client.js"),))], fragment=True)
+    assert html.index('type="importmap"') < html.index('type="module"')
+
+
+def test_the_import_map_is_nonce_stamped():
+    html = bootstrap(packages=[_vendored("perspective", (("x", "vendor/x.js"),))], fragment=True, nonce="abc123")
+    assert '<script type="importmap" nonce="abc123">' in html
+
+
+def test_a_trailing_slash_specifier_maps_a_subtree():
+    html = bootstrap(packages=[_vendored("perspective", (("@perspective-dev/", "vendor/"),))], fragment=True)
+    assert '"@perspective-dev/": "/components/perspective/vendor/"' in html
+
+
+def test_two_packages_publishing_one_specifier_differently_is_an_error():
+    """Picking one silently is the ambiguity `imports` exists to remove."""
+    packages = [_vendored("one", (("regular-table", "vendor/rt.js"),)), _vendored("two", (("regular-table", "vendor/rt.js"),))]
+    with pytest.raises(ValueError, match="both publish the import 'regular-table'"):
+        bootstrap(packages=packages, fragment=True)
+
+
+def test_the_same_specifier_at_the_same_url_is_not_a_conflict():
+    package = _vendored("perspective", (("@perspective-dev/client", "vendor/client.js"),))
+    html = bootstrap(packages=[package], fragment=True)
+    assert html.count('"@perspective-dev/client"') == 1
+
+
+def test_no_import_map_is_emitted_when_no_package_publishes_one():
+    assert "importmap" not in bootstrap(packages=[_vendored("plain", ())], fragment=True)
+
+
+def test_import_paths_are_validated_like_asset_paths():
+    for bad in (("@x", "/absolute.js"), ("@x", "../escape.js"), ("bad specifier", "x.js")):
+        with pytest.raises(ValueError):
+            _vendored("p", (bad,))
+
+
+def test_a_subtree_specifier_must_map_to_a_subtree():
+    with pytest.raises(ValueError, match="both end in '/'"):
+        _vendored("p", (("@scope/", "vendor/file.js"),))
+    with pytest.raises(ValueError, match="both end in '/'"):
+        _vendored("p", (("@scope/thing", "vendor/"),))


### PR DESCRIPTION
## Description

The general fix for two copies of one engine on a page, and the only one that works when the engine
has no client to lend.

An engine that registers global custom element names cannot load twice: the second copy throws from
`customElements.define`. Lending a client works where the engine hands one out (Perspective —
1kbgz/spaday-perspective#46), but a design system registers its elements as a *side effect of being
imported*. There is no object to lend, and the only thing that makes two libraries agree on one copy
is **module identity**.

`ComponentPackage.imports` publishes vendored modules under their bare specifiers as
`(specifier, relative_path)` pairs:

```python
ComponentPackage(
    name="perspective",
    assets_dir=DIST,
    assets=(("js", "cdn/index.js"),),
    imports=(("@perspective-dev/", "vendor/"),),
)
```

`bootstrap` merges every selected package's declarations into one import map, resolved against the
URL each package is served from. Any other library on the page then resolves the same bare specifier
to that one copy and needs no API at all. A specifier ending in `/` maps a subtree, per the spec.

**Two packages publishing the same specifier at different URLs raises, naming both** — picking one
silently is precisely the ambiguity this exists to remove. The same specifier at the same URL is
fine.

**Ordering is the subtle part.** The map is emitted ahead of every module script, the packages' own
included, because a map that arrives after the first module load is ignored — and ignored silently,
with no error to debug. There is a browser test for that browser behavior specifically, so the
reason for the ordering cannot quietly stop being true.

Peers that vendor engines still need unbundled ESM output to publish anything through this; that is
per-package work on top of the surface, not part of it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)

232 Python tests pass, plus 4 new browser tests covering bare-specifier resolution, subtree
resolution, one module instance shared by two importers, and a late map being ignored.

**Stacked:** 1kbgz/spaday#185 (conformance check) is branched off this one; review this first.
