### PR TITLE
Add a conformance check for substitute bundles

### DIFF
--- a/docs/src/customizing.md
+++ b/docs/src/customizing.md
@@ -101,9 +101,22 @@ mine = dataclasses.replace(
 bootstrap(packages=[mine], ...)
 ```
 
-Your bundle must register the tags the schemas name, with the attributes they declare — that is the
-whole contract. Nothing checks it for you, so a browser test asserting the tags are defined is worth
-writing.
+Your bundle must register the tags the schemas name — that is the contract, and breaking it fails
+silently: an unregistered tag renders an inert element and nothing reports it. `check_script` builds
+a browser-side check from the schemas your package already carries, so test it:
+
+```python
+from spaday import check_script
+
+problems = page.evaluate(check_script([mine]))   # any browser driver
+assert problems == []
+```
+
+It verifies that every declared tag is a defined custom element, and that every `json`-kind prop is
+exposed as a DOM property — the runtime falls back to an attribute when an element has no property,
+and an attribute can only carry a string, so an attribute-only `json` prop would stringify your
+object to `"[object Object]"`. String, number, boolean and enum props survive that fallback, so they
+are not required to be properties.
 
 Two packages with the same `name` are rejected, which is the point: an app gets the peer's bundle or
 yours, never both. That also means substitution is the simplest fix for the collision in

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -43,6 +43,7 @@ from .bootstrap import Js, Wire
 from .catalog import ComponentSchema, PropertyKind, PropertySchema
 from .cem import classes, generate
 from .component import Component, Paragraph, Strong, Text, element
+from .conformance import check_script
 from .packages import ComponentPackage, discover_component_package_names, discover_component_packages, resolve_component_packages
 from .render import render_html
 from .spaday import apply, decode_frame, diff, encode_frame, parse_cem  # compiled Rust extension (rust/python)
@@ -53,6 +54,7 @@ from .worker import WorkerApp
 __version__ = "0.7.13"
 
 __all__ = [
+    "check_script",
     # theming token reference (css custom properties are set via Component.css)
     "SHELL_TOKENS",
     "CallEndpoint",

--- a/spaday/conformance.py
+++ b/spaday/conformance.py
@@ -1,0 +1,72 @@
+"""Check that a substitute bundle really implements the components a package declares.
+
+An application can keep a component package's Python surface and serve its own JS bundle (see the
+customization guide). The contract between the two halves is implicit -- the bundle must register
+the tags the schemas name -- and breaking it fails silently: an unregistered tag renders an inert
+element, and nothing reports it.
+
+This produces a browser-side check from the schemas the package already carries, so a substitute
+bundle can be tested against the surface it claims to implement:
+
+.. code-block:: python
+
+    problems = page.evaluate(check_script([my_package]))
+    assert problems == []
+
+What it checks is deliberately narrow -- only what the runtime genuinely requires, so a passing
+bundle is really usable and a reported problem is really a defect:
+
+* **Every declared tag is a defined custom element.** An undefined tag is the silent no-render.
+* **Every ``json``-kind prop is exposed as a DOM property.** :func:`setProp` in the runtime sets a
+  DOM property when the element has one and falls back to an attribute otherwise, and an attribute
+  can only carry a string -- so a ``json`` prop that is attribute-only turns an object into
+  ``"[object Object]"``. Other kinds (string, enum, number, boolean) survive that fallback, so
+  requiring properties for them would report defects that are not defects.
+
+Slots and events are not checked: neither can be verified without rendering and dispatching, and a
+guess either way would be noise.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+from .packages import ComponentPackage
+
+__all__ = ["CHECKER_JS", "check_script", "expectations"]
+
+#: The JS half: takes the expectations and returns an array of problem strings, empty when the
+#: bundle conforms. Kept as source so any browser driver can evaluate it.
+CHECKER_JS = """(expectations) => {
+  const problems = [];
+  for (const { tag, jsonProps } of expectations) {
+    if (!customElements.get(tag)) {
+      problems.push(`<${tag}> is not a defined custom element`);
+      continue;
+    }
+    const element = document.createElement(tag);
+    for (const name of jsonProps) {
+      if (!(name in element)) {
+        problems.push(
+          `<${tag}> has no ${name} DOM property, so its object value would be set as an attribute and stringify to "[object Object]"`
+        );
+      }
+    }
+  }
+  return problems;
+}"""
+
+
+def expectations(packages: Sequence[ComponentPackage]) -> tuple[dict, ...]:
+    """Per component: the tag that must be defined, and the ``json`` props that must be properties."""
+    out = []
+    for package in packages:
+        for schema in package.catalog:
+            out.append({"tag": schema.tag, "jsonProps": [prop.name for prop in schema.props if prop.kind == "json"]})
+    return tuple(out)
+
+
+def check_script(packages: Sequence[ComponentPackage]) -> str:
+    """A self-contained JS expression evaluating to an array of problems (empty when conforming)."""
+    return f"({CHECKER_JS})({json.dumps(expectations(packages))})"

--- a/spaday/tests/test_conformance.py
+++ b/spaday/tests/test_conformance.py
@@ -1,0 +1,84 @@
+"""The conformance check for a substitute bundle, run in a real browser.
+
+The check exists to catch bundles that break the implicit contract silently, so the test drives a
+conforming bundle and a broken one and asserts it distinguishes them.
+"""
+
+import pytest
+
+from spaday import Component, ComponentPackage, ComponentSchema, PropertySchema
+from spaday.conformance import check_script, expectations
+
+
+def _package(name: str = "demo") -> ComponentPackage:
+    class Chart(Component):
+        tag = "demo-chart"
+        schema = ComponentSchema(
+            tag="demo-chart",
+            class_name="Chart",
+            props=(
+                PropertySchema(name="series", kind="json"),
+                PropertySchema(name="title", kind="string"),
+                PropertySchema(name="height", kind="number"),
+            ),
+        )
+
+    return ComponentPackage(name=name, assets_dir=".", assets=(("js", "cdn/index.js"),), components=(Chart,))
+
+
+def test_expectations_name_the_tag_and_only_its_json_props():
+    """Only json props are required to be DOM properties; the rest survive the attribute fallback."""
+    assert expectations([_package()]) == ({"tag": "demo-chart", "jsonProps": ["series"]},)
+
+
+def test_the_script_is_self_contained():
+    script = check_script([_package()])
+    assert script.startswith("((expectations)")
+    assert '"demo-chart"' in script
+
+
+@pytest.fixture
+def browser_page():
+    playwright = pytest.importorskip("playwright.sync_api", reason="needs the [develop] extra")
+    with playwright.sync_playwright() as p:
+        try:
+            browser = p.chromium.launch(headless=True)
+        except Exception as error:  # no browser binary installed
+            pytest.skip(f"no chromium available: {error}")
+        page = browser.new_page()
+        yield page
+        browser.close()
+
+
+CONFORMING = """
+class Chart extends HTMLElement {
+  set series(value) { this._series = value; }
+  get series() { return this._series; }
+}
+customElements.define('demo-chart', Chart);
+"""
+
+ATTRIBUTE_ONLY = """
+class Chart extends HTMLElement {}
+customElements.define('demo-chart', Chart);
+"""
+
+
+def test_a_conforming_bundle_reports_no_problems(browser_page):
+    browser_page.add_script_tag(content=CONFORMING)
+    assert browser_page.evaluate(check_script([_package()])) == []
+
+
+def test_an_unregistered_tag_is_reported(browser_page):
+    """The silent no-render: the Python surface is fine, the element was never defined."""
+    problems = browser_page.evaluate(check_script([_package()]))
+    assert len(problems) == 1
+    assert "<demo-chart> is not a defined custom element" in problems[0]
+
+
+def test_a_json_prop_with_no_dom_property_is_reported(browser_page):
+    """setProp would fall back to an attribute, stringifying the object to "[object Object]"."""
+    browser_page.add_script_tag(content=ATTRIBUTE_ONLY)
+    problems = browser_page.evaluate(check_script([_package()]))
+    assert len(problems) == 1
+    assert "has no series DOM property" in problems[0]


### PR DESCRIPTION
## Description

Makes "bring your own frontend" a contract that is checked rather than a trick that happens to work.

An application can keep a component package's Python surface and serve its own JS bundle. The
contract between the halves is implicit — the bundle must register the tags the schemas name — and
breaking it fails *silently*: an unregistered tag renders an inert element, and nothing reports it.

`check_script(packages)` builds a browser-side check from the schemas the package already carries,
returning a self-contained JS expression that evaluates to a list of problems:

```python
from spaday import check_script

problems = page.evaluate(check_script([mine]))   # any browser driver
assert problems == []
```

**What it checks is deliberately narrow, so a pass means usable and a report means a real defect:**

- Every declared tag is a defined custom element — the silent no-render.
- Every `json`-kind prop is exposed as a DOM property. The runtime's `setProp` sets a DOM property
  when the element has one and falls back to an attribute otherwise; an attribute can only carry a
  string, so an attribute-only `json` prop stringifies an object to `"[object Object]"`. String,
  number, boolean and enum props survive that fallback, so requiring properties for them would
  report defects that are not defects.

Slots and events are left out: neither can be verified without rendering and dispatching, and a
guess either way is noise.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)

237 Python tests pass. The check is driven in a real browser against a conforming bundle, an
unregistered tag, and an attribute-only `json` prop, so it is shown to distinguish them rather than
just to run.

**Stacked on 1kbgz/spaday#184** — the diff shown here is only this commit once that merges; review
#184 first.
