### PR TITLE
Stop check_script reporting props no bundle can fix

### DIFF
--- a/docs/src/customizing.md
+++ b/docs/src/customizing.md
@@ -116,7 +116,8 @@ It verifies that every declared tag is a defined custom element, and that every 
 exposed as a DOM property — the runtime falls back to an attribute when an element has no property,
 and an attribute can only carry a string, so an attribute-only `json` prop would stringify your
 object to `"[object Object]"`. String, number, boolean and enum props survive that fallback, so they
-are not required to be properties.
+are not required to be properties. Neither are props named with a hyphen: no element has a property
+by that name, so they are carried as attributes whichever bundle implements the element.
 
 Two packages with the same `name` are rejected, which is the point: an app gets the peer's bundle or
 yours, never both. That also means substitution is the simplest fix for the collision in

--- a/rust/src/cem.rs
+++ b/rust/src/cem.rs
@@ -412,6 +412,10 @@ fn base_type(members: &[&str]) -> PropType {
     if members.iter().all(|m| is_quoted(m)) {
         return PropType::Enum(members.iter().map(|m| unquote(m).to_string()).collect());
     }
+    // `'_self' | '_blank' | string`: the literals only suggest values; `string` admits any of them
+    if members.contains(&"string") && members.iter().all(|m| *m == "string" || is_quoted(m)) {
+        return PropType::Str;
+    }
     if members.len() == 1 {
         return match members[0] {
             "boolean" => PropType::Bool,
@@ -528,6 +532,26 @@ mod cem_tests {
         assert_eq!(by("opaque").type_text, None); // the kind already says "unmodeled"
         assert_eq!(by("loose").type_text, None);
         assert_eq!(by("rows").type_text.as_deref(), Some("string[]"));
+    }
+
+    #[test]
+    fn test_string_literals_alongside_string_are_a_string() {
+        let manifest = r#"{"modules":[{"declarations":[{
+          "kind":"class","name":"El","customElement":true,"tagName":"an-el",
+          "attributes":[
+            {"name":"formtarget","type":{"text":"'_self' | '_blank' | '_parent' | '_top' | string"}},
+            {"name":"target","type":{"text":"string | '_self' | null"}},
+            {"name":"mixed","type":{"text":"'auto' | number"}}
+          ]
+        }]}]}"#;
+        let s = &parse_manifest(manifest).unwrap()[0];
+        let by = |n: &str| s.props.iter().find(|p| p.name == n).unwrap();
+        // the literals only suggest values, so the attribute fallback carries every one of them
+        assert_eq!(by("formtarget").ty, PropType::Str);
+        assert_eq!(by("formtarget").type_text, None);
+        assert_eq!(by("target").ty, PropType::Optional(Box::new(PropType::Str)));
+        // a literal beside anything but `string` is still a mixed union
+        assert_eq!(by("mixed").ty, PropType::Any);
     }
 
     #[test]

--- a/spaday/conformance.py
+++ b/spaday/conformance.py
@@ -21,7 +21,10 @@ bundle is really usable and a reported problem is really a defect:
   DOM property when the element has one and falls back to an attribute otherwise, and an attribute
   can only carry a string -- so a ``json`` prop that is attribute-only turns an object into
   ``"[object Object]"``. Other kinds (string, enum, number, boolean) survive that fallback, so
-  requiring properties for them would report defects that are not defects.
+  requiring properties for them would report defects that are not defects. A prop named with a
+  hyphen (``did-ssr``, ``href-template``) is left out as well: no element has a property by that
+  name, so the runtime carries it as an attribute whichever bundle implements the element, the
+  package's own included -- it is not something a bundle can get wrong.
 
 Slots and events are not checked: neither can be verified without rendering and dispatching, and a
 guess either way would be noise.
@@ -63,7 +66,7 @@ def expectations(packages: Sequence[ComponentPackage]) -> tuple[dict, ...]:
     out = []
     for package in packages:
         for schema in package.catalog:
-            out.append({"tag": schema.tag, "jsonProps": [prop.name for prop in schema.props if prop.kind == "json"]})
+            out.append({"tag": schema.tag, "jsonProps": [prop.name for prop in schema.props if prop.kind == "json" and "-" not in prop.name]})
     return tuple(out)
 
 

--- a/spaday/tests/test_conformance.py
+++ b/spaday/tests/test_conformance.py
@@ -20,6 +20,7 @@ def _package(name: str = "demo") -> ComponentPackage:
                 PropertySchema(name="series", kind="json"),
                 PropertySchema(name="title", kind="string"),
                 PropertySchema(name="height", kind="number"),
+                PropertySchema(name="render-hint", kind="json"),
             ),
         )
 
@@ -29,6 +30,12 @@ def _package(name: str = "demo") -> ComponentPackage:
 def test_expectations_name_the_tag_and_only_its_json_props():
     """Only json props are required to be DOM properties; the rest survive the attribute fallback."""
     assert expectations([_package()]) == ({"tag": "demo-chart", "jsonProps": ["series"]},)
+
+
+def test_a_hyphenated_name_is_not_asked_to_be_a_property():
+    """No element has a ``render-hint`` property, so every bundle -- the package's own too -- carries
+    it as an attribute; requiring the property would fail them all and tell none of them apart."""
+    assert "render-hint" not in expectations([_package()])[0]["jsonProps"]
 
 
 def test_the_script_is_self_contained():


### PR DESCRIPTION
`check_script` (#185) reported 73 problems against spaday-webawesome's own stock bundle, so a substitute bundle could not assert `problems == []` without filtering first. Two causes:

- `'_self' | '_blank' | '_parent' | '_top' | string` (wa-button's `formtarget`) normalized to the `json` kind. A union of string literals plus `string` is a string: the literals only suggest values, and the attribute fallback carries every one of them. The parser now reads it as `Str`, which also types the generated keyword `str` instead of `Any`.
- Every `json` prop had to be a DOM property looked up by the prop's name. For a hyphenated name (`did-ssr` on all 70 WebAwesome elements, `href-template`, `hour-format`) that lookup can never succeed: `setProp` carries it as an attribute whichever bundle implements the element, the package's own included. Those are no longer asked of the bundle.

Typing untyped attributes as strings would also have silenced `did-ssr`, but `wa-select`'s `value` is untyped too and takes an array for multi-select; as a `string` kind, the constructor's kind check would reject that list.

With both changes and a regenerated WebAwesome catalog, the stock bundle reports no problems. A committed catalog that declares such a union changes on regeneration (for spaday-webawesome, only `formtarget`), so its drift test needs a regenerate once this is released.
