### PR TITLE
Apply props to custom elements defined after they mount

### DIFF
--- a/docs/src/customizing.md
+++ b/docs/src/customizing.md
@@ -102,7 +102,9 @@ bootstrap(packages=[mine], ...)
 ```
 
 Your bundle must register the tags the schemas name — that is the contract, and breaking it fails
-silently: an unregistered tag renders an inert element and nothing reports it. `check_script` builds
+silently: an unregistered tag renders an inert element and nothing reports it. It may register them
+late, after the page has mounted: props written to an element before its tag is defined are set
+through its properties once it is. `check_script` builds
 a browser-side check from the schemas your package already carries, so test it:
 
 ```python

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -986,7 +986,50 @@ export function setProp(el: Element, name: string, value: unknown): void {
     (el as unknown as Record<string, unknown>)[name] = value;
     return;
   }
+  if (el.localName.includes("-") && !el.matches(":defined")) {
+    deferProp(el, name, value);
+    if (typeof value === "object" && value !== null) return; // no attribute can carry it
+  }
   setAttr(el, name, value);
+}
+
+/* Props written to a custom element before its class has upgraded it, re-applied once it has.
+ *
+ * Until then the element has none of its class's properties, so setProp would fall back to an
+ * attribute: an object stringifies to "[object Object]", and an element that never reads its
+ * attributes loses even a primitive. A bundle that defines its elements after the page mounts (one
+ * that awaits at the top level, or loads lazily) hits exactly that. So the last value written under
+ * each name is kept and set through the property when the tag is defined. A primitive still goes to
+ * the attribute at once, which keeps a never-defined tag working as a styling hook; an object waits.
+ * Elements are tracked per tag through WeakRefs, so a tag that is never defined holds no element. */
+const deferredProps = new WeakMap<Element, Map<string, unknown>>();
+const awaitingTag = new Map<string, WeakRef<Element>[]>();
+
+function deferProp(el: Element, name: string, value: unknown): void {
+  const props = deferredProps.get(el);
+  if (props) {
+    props.set(name, value);
+    return;
+  }
+  deferredProps.set(el, new Map([[name, value]]));
+  const tag = el.localName;
+  let waiting = awaitingTag.get(tag);
+  if (!waiting) {
+    const refs: WeakRef<Element>[] = (waiting = []);
+    awaitingTag.set(tag, refs);
+    void customElements.whenDefined(tag).then(() => {
+      awaitingTag.delete(tag);
+      for (const ref of refs) {
+        const target = ref.deref();
+        const pending = target && deferredProps.get(target);
+        if (!target || !pending) continue;
+        deferredProps.delete(target);
+        customElements.upgrade(target); // the definition upgrades only elements in the document
+        for (const [prop, v] of pending) setProp(target, prop, v);
+      }
+    });
+  }
+  waiting.push(new WeakRef(el));
 }
 
 /** Write `value` as an attribute: `false`/`null`/`undefined` remove it, `true` gives the bare form. */
@@ -999,6 +1042,7 @@ function setAttr(el: Element, name: string, value: unknown): void {
 }
 
 function removeProp(el: Element, name: string): void {
+  deferredProps.get(el)?.delete(name);
   if (name in el) {
     setProp(el, name, undefined);
   }

--- a/js/tests/runtime.spec.js
+++ b/js/tests/runtime.spec.js
@@ -43,6 +43,98 @@ test("SetProp updates a live element via its DOM property", async ({
   expect(value).toBe("abc");
 });
 
+test("props reach an element whose class is defined after it mounts", async ({
+  page,
+}) => {
+  // a package whose bundle defines its elements late -- one that awaits at the top level, or loads
+  // lazily -- must still get every prop, through the property its class declares
+  const r = await page.evaluate(async () => {
+    const c = document.createElement("div");
+    document.body.appendChild(c);
+    const el = window.__spaday.mount(c, {
+      tag: "late-grid",
+      props: {
+        rows: { List: [{ Int: 1 }, { Int: 2 }] },
+        theme: { Str: "dark" },
+      },
+    });
+    const before = {
+      rows: el.getAttribute("rows"),
+      theme: el.getAttribute("theme"),
+    };
+    customElements.define(
+      "late-grid",
+      class extends HTMLElement {
+        #theme = "light";
+        rows = null;
+        // property-only, like a hand-written element that never reads its attributes
+        get theme() {
+          return this.#theme;
+        }
+        set theme(value) {
+          this.#theme = value;
+        }
+      },
+    );
+    await customElements.whenDefined("late-grid");
+    return { before, rows: el.rows, theme: el.theme };
+  });
+  // an object waits rather than stringifying into an attribute...
+  expect(r.before.rows).toBeNull();
+  // ...while a primitive also lands as an attribute straight away, as it always has
+  expect(r.before.theme).toBe("dark");
+  expect(r.rows).toEqual([1, 2]);
+  expect(r.theme).toBe("dark");
+});
+
+test("writes before the definition collapse to the last, and a removal cancels one", async ({
+  page,
+}) => {
+  const r = await page.evaluate(async () => {
+    const { mount, applyPatch } = window.__spaday;
+    // detached: the definition upgrades only elements in the document, so this one must be upgraded
+    const el = mount(document.createElement("div"), {
+      tag: "late-panel",
+      props: {
+        config: { Map: { layout: { Int: 1 } } },
+        extra: { Map: { x: { Int: 1 } } },
+      },
+    });
+    applyPatch(el, {
+      ops: [
+        {
+          SetProp: {
+            path: [],
+            name: "config",
+            value: { Map: { layout: { Int: 2 } } },
+          },
+        },
+        { RemoveProp: { path: [], name: "extra" } },
+      ],
+    });
+    let writes = 0;
+    customElements.define(
+      "late-panel",
+      class extends HTMLElement {
+        #config = null;
+        extra = "untouched";
+        get config() {
+          return this.#config;
+        }
+        set config(value) {
+          writes += 1;
+          this.#config = value;
+        }
+      },
+    );
+    await customElements.whenDefined("late-panel");
+    return { config: el.config, writes, extra: el.extra };
+  });
+  expect(r.config).toEqual({ layout: 2 });
+  expect(r.writes).toBe(1);
+  expect(r.extra).toBe("untouched");
+});
+
 test("named slots route children via the slot attribute", async ({ page }) => {
   const html = await page.evaluate(() => {
     const c = document.createElement("div");

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "isolatedModules": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "ES2021.WeakRef", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "noUnusedLocals": true,


### PR DESCRIPTION
`setProp` sets a DOM property when the element has one and falls back to an attribute otherwise. A custom element whose class hasn't been defined yet has none of its properties, so every prop written to it took the attribute path: an object stringified to `"[object Object]"`, and an element that never reads its attributes lost even a primitive. Any package whose bundle defines its elements after the page mounts — one that awaits at the top level (Perspective's viewer build does), or loads lazily — hit this, and whether it did depended on which script won the race.

Now a write to an un-upgraded custom element is also remembered (last value per name) and set through the property once the tag is defined, upgrading the element first if it is detached from the document. A primitive still goes to the attribute immediately, so a tag that is never defined keeps working as a styling hook; an object waits instead of stringifying. A removal before the definition cancels the pending write. Build, hydrate, bindings, patches and actions all write through `setProp`, so every path gets it. Pending elements are tracked per tag through `WeakRef`s (hence `ES2021.WeakRef` in the TS lib; the bundle already targets es2022), so a tag that is never defined holds on to no element.

Two browser tests cover it: an object and a property-only primitive reaching an element defined after mount, and several writes plus a removal collapsing to one property write on a detached element. Checked end to end against spaday-perspective with its viewer imported statically again, which reliably broke its downstream integration page before: every spaday-mounted test passes. Code that assigns a property directly to an element before its class exists is outside this; that is the usual custom-element upgrade problem, and packages should still define their elements promptly.
