### PR TITLE
Escape a summary's closing quote in generated docstrings

### DIFF
--- a/spaday/cem.py
+++ b/spaday/cem.py
@@ -137,6 +137,8 @@ def _render_class(schema: dict) -> _ClassBody:
     # Collapse to a single line so the docstring is stable under `ruff format` (which re-indents
     # multi-line docstrings, an AST-visible change the drift test would otherwise trip over).
     doc = " ".join((schema.get("summary") or "").split()).replace("\\", "\\\\").replace('"""', "'''")
+    if doc.endswith('"'):
+        doc = doc[:-1] + '\\"'  # a quote right before the closing """ would end the string one early
     head = [f"class {name}(Component):"]
     if doc:
         head.append(f'    """{doc}"""')

--- a/spaday/tests/test_cem.py
+++ b/spaday/tests/test_cem.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from spaday import Component, ComponentSchema, PropertySchema, apply, classes, diff, generate, parse_cem, validate
+from spaday.cem import render
 
 FIXTURES = Path(__file__).parent / "fixtures"
 FIXTURE = str(FIXTURES / "webawesome.cem.json")
@@ -197,6 +198,15 @@ def test_typed_signatures_rendered():
     assert 'size: Literal["small", "medium", "large"] | None = None' in code
     assert "name: str | None = None" in code
     assert "checked: bool | None = None" in code
+
+
+def test_a_summary_ending_in_a_quote_still_generates_valid_python():
+    """A summary that ends by quoting something -- one of UI5's ends in a quoted module path -- must
+    not run into the docstring's closing quotes."""
+    schema = {"tag_name": "an-el", "class_name": "AnEl", "summary": 'Built on "base.js"', "props": [], "fields": [], "events": [], "slots": []}
+    ns: dict = {}
+    exec(render([schema]), ns)  # noqa: S102
+    assert ns["AnEl"].__doc__ == 'Built on "base.js"'
 
 
 def test_python_keyword_attribute_is_escaped():


### PR DESCRIPTION
A generated class's docstring is the element's summary between triple quotes. A summary ending in a double quote — UI5's `ui5-suggestion-item-custom` ends in a quoted module path — produced four quotes in a row, so the string closed a character early and the generated module did not parse. The final quote is now escaped; backslashes and embedded triple quotes were already handled.

Found generating a catalog for UI5 Web Components, which needs this to regenerate cleanly.
