### PR TITLE
Record and reconcile the JS library versions component packages serve

### DIFF
--- a/docs/src/customizing.md
+++ b/docs/src/customizing.md
@@ -183,8 +183,35 @@ preference:
    keeps the page alive; it does not make two copies agree, and two copies at different versions is
    still a bug to fix rather than a state to ship.
 
-`spaday-webawesome` publishes the version it bundles as `globalThis.__spadayWebawesome.version`, so
-a page holding a second copy can compare and refuse rather than half-work.
+### Record the versions, and let spaday reconcile them
+
+A package also records which library versions it serves, and which it imports but leaves to the page's
+copy, with the range it was built against:
+
+```python
+ComponentPackage(
+    name="webawesome",
+    ...,
+    provides={"@awesome.me/webawesome": "3.1.0"},  # written by the package's JS build
+)
+ComponentPackage(
+    name="my-widgets",
+    ...,
+    requires={"@awesome.me/webawesome": "^3.1.0"},  # imported, not shipped
+)
+```
+
+`serve()` and `bootstrap()` check the selected packages before they build a page. Two packages serving
+one library at different versions is an error naming both packages and both versions, and so is a
+`requires` whose range the served version misses, or that no selected package serves: the page would
+otherwise load a copy that half-works. Two packages serving the *same* version may both publish it in
+their import maps; the page imports the first. Ranges use npm's syntax — `^3.1.0`, `~25.2`, `1.x`,
+`>=1.2 <2`, `||` — so a range can be copied from a `package.json`.
+
+That covers the copies spaday serves. A copy it does not — one inside your own bundle — is the
+define-guard's case above: the first registration wins, and the losing package logs which elements it
+found already registered, with the library and version it serves. Each bundle also publishes the
+version it serves on a global (`globalThis.__spadayWebawesome.version`, and so on).
 
 ### Third-party bundles cannot blank your page
 

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from typing import Literal, Union
 
 from .component import Component
-from .packages import ComponentPackage, PackageRef, package_url_prefix, resolve_component_packages
+from .packages import ComponentPackage, PackageRef, npm_package, package_url_prefix, resolve_component_packages
 from .spaday import encode_frame  # compiled core (always available); used by tree_frame
 
 #: A page is a built :class:`~spaday.component.Component`, or a zero-arg callable returning one (called
@@ -197,22 +197,27 @@ def _importmap(packages: Sequence[ComponentPackage], base: str, nonce: str | Non
     Must precede every module script on the page, which is why it is emitted first -- a map that
     arrives after the first module load is ignored by the browser, silently. Two packages publishing
     the same specifier at different URLs is an error naming both, since picking one silently is the
-    ambiguity ``imports`` exists to remove; publishing the same specifier at the same URL is fine.
+    ambiguity ``imports`` exists to remove -- unless both declare they serve the same version of the
+    library it belongs to, in which case the two copies are interchangeable and the first is used.
+    Publishing the same specifier at the same URL is fine.
     """
     resolved: dict[str, str] = {}
-    owners: dict[str, str] = {}
+    owners: dict[str, ComponentPackage] = {}
     for package in packages:
         prefix = package_url_prefix(package, base)
         for specifier, path in package.imports:
             url = f"{prefix}/{path}"
             if specifier in resolved and resolved[specifier] != url:
+                version = dict(package.provides).get(npm_package(specifier))
+                if version is not None and version == dict(owners[specifier].provides).get(npm_package(specifier)):
+                    continue  # the same version of the library: serve the first copy
                 raise ValueError(
-                    f"component packages {owners[specifier]!r} and {package.name!r} both publish the import "
+                    f"component packages {owners[specifier].name!r} and {package.name!r} both publish the import "
                     f"{specifier!r} at different URLs ({resolved[specifier]} and {url}); select only one of them, "
                     f"or override the packages so a single copy is published"
                 )
             resolved[specifier] = url
-            owners[specifier] = package.name
+            owners[specifier] = package
     if not resolved:
         return ""
     n = f' nonce="{nonce}"' if nonce else ""

--- a/spaday/packages.py
+++ b/spaday/packages.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from importlib import import_module
 from importlib.metadata import entry_points
@@ -11,9 +11,11 @@ from pathlib import Path, PurePosixPath
 
 from .catalog import ComponentSchema
 from .component import Component
+from .semver import parse_range, parse_version, satisfies
 
 ENTRY_POINT_GROUP = "spaday.component_packages"
 _PACKAGE_NAME = re.compile(r"[a-z0-9][a-z0-9._-]*\Z")
+_NPM_NAME = re.compile(r"(?:@[a-z0-9][a-z0-9._~-]*/)?[a-z0-9][a-z0-9._~-]*\Z")
 
 
 @dataclass(frozen=True)
@@ -38,6 +40,18 @@ class ComponentPackage:
     collision. A specifier ending in ``/`` maps a whole subtree, per the import-map
     spec. Two packages publishing the same specifier at different paths is an
     error: it is the ambiguity the feature exists to remove.
+
+    ``provides`` records the JS libraries the package puts on the page, by npm
+    name, with the exact version it serves (``{"@awesome.me/webawesome": "3.1.0"}``);
+    a package's build writes them, so the Python side knows what the browser gets.
+    ``requires`` records libraries the package's own bundle imports without
+    shipping, with the npm version range it was built against
+    (``{"@awesome.me/webawesome": "^3.1.0"}``). :func:`resolve_component_packages`
+    reconciles them across the packages selected for a page: a page holds one copy
+    of a library, so two packages serving it at different versions, or a
+    requirement no selected package satisfies, is an error naming the packages and
+    versions, where the second copy would otherwise half-work. Packages serving the
+    same version of a library may both publish it; the page imports the first.
     """
 
     name: str
@@ -45,6 +59,8 @@ class ComponentPackage:
     assets: Sequence[tuple[str, str]]
     components: Sequence[type[Component]] = ()
     imports: Sequence[tuple[str, str]] = ()
+    provides: Mapping[str, str] | Sequence[tuple[str, str]] = ()
+    requires: Mapping[str, str] | Sequence[tuple[str, str]] = ()
 
     def __post_init__(self) -> None:
         if not _PACKAGE_NAME.fullmatch(self.name):
@@ -71,6 +87,8 @@ class ComponentPackage:
                 raise ValueError(f"component package import {specifier!r} and its path must either both end in '/' or neither")
             imports.append((specifier, import_path.as_posix() + ("/" if path.endswith("/") else "")))
         object.__setattr__(self, "imports", tuple(imports))
+        object.__setattr__(self, "provides", _libraries(self.provides, "provides", parse_version))
+        object.__setattr__(self, "requires", _libraries(self.requires, "requires", parse_range))
         components = tuple(self.components)
         seen: set[str] = set()
         for component in components:
@@ -91,6 +109,57 @@ class ComponentPackage:
         return tuple(
             component.schema.model_copy(update={"class_name": component.__name__}) for component in self.components if component.schema is not None
         )
+
+
+def _libraries(value: Mapping[str, str] | Sequence[tuple[str, str]], field: str, parse) -> tuple[tuple[str, str], ...]:
+    """Normalize ``provides`` / ``requires`` to sorted ``(npm name, version or range)`` pairs, rejecting
+    a name npm would not accept, a version or range that does not parse, and a library named twice."""
+    pairs = tuple(value.items() if isinstance(value, Mapping) else value)
+    for name, spec in pairs:
+        if not isinstance(name, str) or not _NPM_NAME.fullmatch(name):
+            raise ValueError(f"component package {field} names {name!r}, which is not an npm package name")
+        if not isinstance(spec, str):
+            raise ValueError(f"component package {field} gives {name!r} a {type(spec).__name__}, not a version string")
+        try:
+            parse(spec)
+        except ValueError as error:
+            raise ValueError(f"component package {field} gives {name!r} {spec!r}: {error}") from None
+    names = [name for name, _ in pairs]
+    duplicate = next((name for name in names if names.count(name) > 1), None)
+    if duplicate is not None:
+        raise ValueError(f"component package {field} names {duplicate!r} more than once")
+    return tuple(sorted(pairs))
+
+
+def npm_package(specifier: str) -> str:
+    """The npm package a bare import specifier belongs to: ``@scope/name/dist/x.js`` → ``@scope/name``."""
+    parts = specifier.split("/")
+    return "/".join(parts[:2] if specifier.startswith("@") else parts[:1])
+
+
+def _reconcile(packages: Sequence[ComponentPackage]) -> None:
+    """Reject a page whose packages disagree about a JS library: served at two versions, or required at
+    a version no selected package serves."""
+    served: dict[str, tuple[str, str]] = {}
+    for package in packages:
+        for library, version in package.provides:
+            if library in served and served[library][0] != version:
+                other, owner = served[library]
+                raise ValueError(
+                    f"component packages {owner!r} and {package.name!r} serve different versions of {library} "
+                    f"({other} and {version}); a page can hold only one copy, so select one of them or align their versions"
+                )
+            served.setdefault(library, (version, package.name))
+    for package in packages:
+        for library, range_ in package.requires:
+            if library not in served:
+                raise ValueError(
+                    f"component package {package.name!r} requires {library} {range_}, which no selected package serves; "
+                    "select the package that provides it"
+                )
+            version, owner = served[library]
+            if not satisfies(version, range_):
+                raise ValueError(f"component package {package.name!r} requires {library} {range_}, but {owner!r} serves {version}")
 
 
 PackageRef = ComponentPackage | str
@@ -153,6 +222,7 @@ def resolve_component_packages(packages: PackageRef | Sequence[PackageRef] = ())
     duplicate = next((name for name in names if names.count(name) > 1), None)
     if duplicate is not None:
         raise ValueError(f"component package {duplicate!r} was selected more than once")
+    _reconcile(resolved)
     return resolved
 
 

--- a/spaday/semver.py
+++ b/spaday/semver.py
@@ -1,0 +1,189 @@
+"""npm-style semantic versions and version ranges, for reconciling the JS libraries component packages
+serve (:attr:`~spaday.packages.ComponentPackage.provides`) with the ones they were built against
+(:attr:`~spaday.packages.ComponentPackage.requires`).
+
+Ranges follow node-semver, the syntax a ``package.json`` uses: exact versions, comparators
+(``>=1.2.3 <2``), ``^`` and ``~``, x-ranges (``1.x``, ``1.2.*``, ``*``), hyphen ranges
+(``1.2.3 - 2.3``) and ``||``. A prerelease version satisfies a range only through a comparator that
+names a prerelease of the same ``major.minor.patch``, as in npm.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import total_ordering
+
+__all__ = ["Version", "parse_range", "parse_version", "satisfies"]
+
+_NUMBER = r"0|[1-9]\d*"
+_IDENTIFIER = r"(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+_VERSION = re.compile(rf"({_NUMBER})\.({_NUMBER})\.({_NUMBER})(?:-({_IDENTIFIER}(?:\.{_IDENTIFIER})*))?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?\Z")
+_WILD = r"x|X|\*"
+_PARTIAL = re.compile(
+    rf"(?P<major>{_NUMBER}|{_WILD})(?:\.(?P<minor>{_NUMBER}|{_WILD})(?:\.(?P<patch>{_NUMBER}|{_WILD})"
+    rf"(?:-(?P<pre>{_IDENTIFIER}(?:\.{_IDENTIFIER})*))?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?)?)?\Z"
+)
+_SIMPLE = re.compile(r"(?P<op>\^|~|>=|<=|>|<|=)?\s*(?P<partial>\S+)\Z")
+
+
+@total_ordering
+class Version:
+    """A semantic version, ordered by semver precedence (build metadata is ignored)."""
+
+    __slots__ = ("major", "minor", "patch", "prerelease")
+
+    def __init__(self, major: int, minor: int, patch: int, prerelease: tuple[int | str, ...] = ()) -> None:
+        self.major, self.minor, self.patch, self.prerelease = major, minor, patch, prerelease
+
+    @property
+    def release(self) -> tuple[int, int, int]:
+        return (self.major, self.minor, self.patch)
+
+    def _key(self) -> tuple:
+        # a release sorts after its prereleases; numeric identifiers sort before alphanumeric ones
+        pre = tuple((0, part, "") if isinstance(part, int) else (1, 0, part) for part in self.prerelease)
+        return (self.release, not self.prerelease, pre)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Version) and self._key() == other._key()
+
+    def __lt__(self, other: Version) -> bool:
+        return self._key() < other._key()
+
+    def __hash__(self) -> int:
+        return hash(self._key())
+
+    def __str__(self) -> str:
+        pre = "-" + ".".join(str(part) for part in self.prerelease) if self.prerelease else ""
+        return f"{self.major}.{self.minor}.{self.patch}{pre}"
+
+    def __repr__(self) -> str:
+        return f"Version({str(self)!r})"
+
+
+def _prerelease(text: str | None) -> tuple[int | str, ...]:
+    return tuple(int(part) if part.isdigit() else part for part in text.split(".")) if text else ()
+
+
+def parse_version(text: str) -> Version:
+    """Parse an exact version such as ``3.1.0`` or ``1.0.0-alpha.24``; anything else is a ``ValueError``."""
+    match = _VERSION.match(text.strip())
+    if match is None:
+        raise ValueError(f"{text!r} is not a semantic version like '3.1.0'")
+    major, minor, patch, pre = match.groups()
+    return Version(int(major), int(minor), int(patch), _prerelease(pre))
+
+
+# a comparator: (operator, version), the operator one of "<", "<=", ">", ">=", "="
+Comparator = tuple[str, Version]
+
+
+def _floor(major: int, minor: int = 0, patch: int = 0) -> Version:
+    """The lowest version of a release line, prereleases included (``2.0.0-0``)."""
+    return Version(major, minor, patch, (0,))
+
+
+def _partial(text: str) -> tuple[int | None, int | None, int | None, tuple[int | str, ...]]:
+    match = _PARTIAL.match(text)
+    if match is None:
+        raise ValueError(f"{text!r} is not a version or partial version")
+
+    def number(key: str) -> int | None:
+        value = match.group(key)
+        return None if value is None or value in ("x", "X", "*") else int(value)
+
+    major, minor, patch = number("major"), number("minor"), number("patch")
+    # a wildcard swallows everything after it: 1.x.3 means 1.x
+    if major is None:
+        minor = patch = None
+    elif minor is None:
+        patch = None
+    return major, minor, patch, _prerelease(match.group("pre")) if patch is not None else ()
+
+
+def _simple(token: str) -> list[Comparator]:
+    """Desugar one range token (``^1.2``, ``>=1.2.3``, ``1.x``) into comparators."""
+    match = _SIMPLE.match(token)
+    if match is None:
+        raise ValueError(f"{token!r} is not a version range")
+    op, (major, minor, patch, pre) = match.group("op") or "", _partial(match.group("partial"))
+    if major is None:
+        # "*", "x", ">=*": any version; "<*" and ">*" match nothing
+        return [("<", _floor(0))] if op in ("<", ">") else []
+    if op == "^":
+        if minor is None:
+            return [(">=", Version(major, 0, 0)), ("<", _floor(major + 1))]
+        low = Version(major, minor, patch or 0, pre)
+        if major > 0:
+            return [(">=", low), ("<", _floor(major + 1))]
+        if patch is None or minor > 0:
+            return [(">=", low), ("<", _floor(0, minor + 1))]
+        return [(">=", low), ("<", _floor(0, 0, patch + 1))]
+    if op == "~":
+        if minor is None:
+            return [(">=", Version(major, 0, 0)), ("<", _floor(major + 1))]
+        return [(">=", Version(major, minor, patch or 0, pre)), ("<", _floor(major, minor + 1))]
+    if patch is not None:
+        return [(op or "=", Version(major, minor, patch, pre))]
+    # a partial version: the whole release line it names
+    low = Version(major, minor or 0, 0)
+    high = _floor(major + 1) if minor is None else _floor(major, minor + 1)
+    if op in ("", "="):
+        return [(">=", low), ("<", high)]
+    if op == ">":
+        return [(">=", Version(*high.release))]
+    if op == ">=":
+        return [(">=", low)]
+    if op == "<":
+        return [("<", _floor(*low.release))]
+    return [("<", high)]  # "<="
+
+
+def _hyphen(low: str, high: str) -> list[Comparator]:
+    lmajor, lminor, lpatch, lpre = _partial(low)
+    hmajor, hminor, hpatch, hpre = _partial(high)
+    comparators = [] if lmajor is None else [(">=", Version(lmajor, lminor or 0, lpatch or 0, lpre))]
+    if hmajor is None:
+        return comparators
+    if hminor is None:
+        return [*comparators, ("<", _floor(hmajor + 1))]
+    if hpatch is None:
+        return [*comparators, ("<", _floor(hmajor, hminor + 1))]
+    return [*comparators, ("<=", Version(hmajor, hminor, hpatch, hpre))]
+
+
+def parse_range(text: str) -> list[list[Comparator]]:
+    """Parse an npm version range into alternatives (``||``), each a list of comparators that must all
+    hold. An unparseable range is a ``ValueError``."""
+    alternatives = []
+    for part in text.split("||"):
+        part = re.sub(r"(\^|~|>=|<=|>|<|=)\s+", r"\1", part.strip())  # ">= 1.2" means ">=1.2"
+        hyphen = re.fullmatch(r"(\S+)\s+-\s+(\S+)", part)
+        if hyphen:
+            alternatives.append(_hyphen(*hyphen.groups()))
+        else:
+            alternatives.append([comparator for token in part.split() for comparator in _simple(token)])
+    return alternatives
+
+
+def _holds(version: Version, comparator: Comparator) -> bool:
+    op, bound = comparator
+    return {
+        "<": version < bound,
+        "<=": version <= bound,
+        ">": version > bound,
+        ">=": version >= bound,
+        "=": version == bound,
+    }[op]
+
+
+def satisfies(version: str | Version, range_: str) -> bool:
+    """Whether ``version`` falls within the npm range ``range_``."""
+    version = parse_version(version) if isinstance(version, str) else version
+    for comparators in parse_range(range_):
+        if not all(_holds(version, comparator) for comparator in comparators):
+            continue
+        if version.prerelease and not any(bound.prerelease and bound.release == version.release for _, bound in comparators):
+            continue  # a prerelease only matches a range that names one of its own release
+        return True
+    return False

--- a/spaday/semver.py
+++ b/spaday/semver.py
@@ -50,9 +50,6 @@ class Version:
     def __lt__(self, other: Version) -> bool:
         return self._key() < other._key()
 
-    def __hash__(self) -> int:
-        return hash(self._key())
-
     def __str__(self) -> str:
         pre = "-" + ".".join(str(part) for part in self.prerelease) if self.prerelease else ""
         return f"{self.major}.{self.minor}.{self.patch}{pre}"
@@ -103,9 +100,7 @@ def _partial(text: str) -> tuple[int | None, int | None, int | None, tuple[int |
 
 def _simple(token: str) -> list[Comparator]:
     """Desugar one range token (``^1.2``, ``>=1.2.3``, ``1.x``) into comparators."""
-    match = _SIMPLE.match(token)
-    if match is None:
-        raise ValueError(f"{token!r} is not a version range")
+    match = _SIMPLE.match(token)  # any token matches; its partial version is checked below
     op, (major, minor, patch, pre) = match.group("op") or "", _partial(match.group("partial"))
     if major is None:
         # "*", "x", ">=*": any version; "<*" and ">*" match nothing

--- a/spaday/tests/test_packages.py
+++ b/spaday/tests/test_packages.py
@@ -230,3 +230,64 @@ def test_a_subtree_specifier_must_map_to_a_subtree():
         _vendored("p", (("@scope/", "vendor/file.js"),))
     with pytest.raises(ValueError, match="both end in '/'"):
         _vendored("p", (("@scope/thing", "vendor/"),))
+
+
+def _serving(name: str, provides=(), requires=(), imports=()) -> ComponentPackage:
+    return ComponentPackage(name=name, assets_dir=".", assets=(("js", "cdn/index.js"),), imports=imports, provides=provides, requires=requires)
+
+
+def test_a_package_records_the_libraries_it_serves_and_needs():
+    package = _serving("wa", provides={"@awesome.me/webawesome": "3.1.0"}, requires=[("lit", "^3.0.0")])
+    assert package.provides == (("@awesome.me/webawesome", "3.1.0"),)
+    assert package.requires == (("lit", "^3.0.0"),)
+
+
+def test_library_names_versions_and_ranges_are_validated():
+    with pytest.raises(ValueError, match="not an npm package name"):
+        _serving("p", provides={"Not A Name": "1.0.0"})
+    with pytest.raises(ValueError, match="'lit' '3.1': '3.1' is not a semantic version"):
+        _serving("p", provides={"lit": "3.1"})  # what is served is one exact version
+    with pytest.raises(ValueError, match="requires gives 'lit' '>=banana'"):
+        _serving("p", requires={"lit": ">=banana"})
+    with pytest.raises(ValueError, match="names 'lit' more than once"):
+        _serving("p", provides=[("lit", "3.1.0"), ("lit", "3.2.0")])
+
+
+def test_two_packages_serving_one_library_at_different_versions_is_an_error():
+    """A page holds one copy of an element library; the second would register nothing and half-work."""
+    first, second = _serving("webawesome", {"@awesome.me/webawesome": "3.1.0"}), _serving("theirs", {"@awesome.me/webawesome": "3.2.0"})
+    with pytest.raises(ValueError, match=r"'webawesome' and 'theirs' serve different versions of @awesome.me/webawesome \(3.1.0 and 3.2.0\)"):
+        resolve_component_packages((first, second))
+    same = _serving("mirror", {"@awesome.me/webawesome": "3.1.0"})
+    assert resolve_component_packages((first, same)) == (first, same)
+
+
+def test_a_requirement_must_be_served_at_a_version_inside_its_range():
+    provider = _serving("webawesome", {"@awesome.me/webawesome": "3.1.0"})
+    assert resolve_component_packages((provider, _serving("downstream", requires={"@awesome.me/webawesome": "^3.0.0"})))
+    with pytest.raises(ValueError, match=r"'downstream' requires @awesome.me/webawesome \^2.0.0, but 'webawesome' serves 3.1.0"):
+        resolve_component_packages((provider, _serving("downstream", requires={"@awesome.me/webawesome": "^2.0.0"})))
+    with pytest.raises(ValueError, match="which no selected package serves"):
+        resolve_component_packages((_serving("downstream", requires={"@awesome.me/webawesome": "^3.0.0"}),))
+
+
+def test_bootstrap_rejects_a_page_whose_packages_disagree():
+    with pytest.raises(ValueError, match="serve different versions"):
+        bootstrap(packages=[_serving("one", {"lit": "3.1.0"}), _serving("two", {"lit": "3.2.0"})], fragment=True)
+
+
+def test_two_copies_of_the_same_version_share_one_import():
+    """Interchangeable copies are not the ambiguity the import-map check guards against: the first wins."""
+    one = _serving("one", {"regular-table": "0.6.0"}, imports=(("regular-table", "vendor/rt.js"),))
+    two = _serving("two", {"regular-table": "0.6.0"}, imports=(("regular-table", "vendor/rt.js"),))
+    html = bootstrap(packages=[one, two], fragment=True)
+    assert '"regular-table": "/components/one/vendor/rt.js"' in html
+    assert "/components/two/vendor/rt.js" not in html
+
+
+def test_npm_package_names_the_library_a_specifier_belongs_to():
+    from spaday.packages import npm_package
+
+    assert npm_package("@awesome.me/webawesome/dist/components/button/button.js") == "@awesome.me/webawesome"
+    assert npm_package("@vaadin/grid/") == "@vaadin/grid"
+    assert npm_package("regular-table/dist/esm/index.js") == "regular-table"

--- a/spaday/tests/test_packages.py
+++ b/spaday/tests/test_packages.py
@@ -249,6 +249,8 @@ def test_library_names_versions_and_ranges_are_validated():
         _serving("p", provides={"lit": "3.1"})  # what is served is one exact version
     with pytest.raises(ValueError, match="requires gives 'lit' '>=banana'"):
         _serving("p", requires={"lit": ">=banana"})
+    with pytest.raises(ValueError, match="gives 'lit' a int, not a version string"):
+        _serving("p", provides={"lit": 3})
     with pytest.raises(ValueError, match="names 'lit' more than once"):
         _serving("p", provides=[("lit", "3.1.0"), ("lit", "3.2.0")])
 

--- a/spaday/tests/test_semver.py
+++ b/spaday/tests/test_semver.py
@@ -1,0 +1,87 @@
+import pytest
+
+from spaday.semver import parse_range, parse_version, satisfies
+
+
+@pytest.mark.parametrize(
+    ("version", "range_"),
+    [
+        ("1.2.3", "1.2.3"),
+        ("1.2.3", "=1.2.3"),
+        ("1.9.0", "^1.2.3"),
+        ("0.2.9", "^0.2.3"),
+        ("0.0.3", "^0.0.3"),
+        ("1.2.9", "~1.2.3"),
+        ("1.9.9", "~1"),
+        ("25.2.10", "~25.2"),
+        ("1.5.0", "1.x"),
+        ("1.2.7", "1.2.*"),
+        ("5.0.0", "*"),
+        ("5.0.0", ""),
+        ("1.5.0", ">=1.2.3 <2"),
+        ("3.1.0", ">= 3.0"),
+        ("1.3.0", ">1.2"),
+        ("1.2.9", "<=1.2"),
+        ("1.1.9", "<1.2"),
+        ("3.1.0", "<1.2 || >=3"),
+        ("2.3.4", "1.2.3 - 2.3.4"),
+        ("2.3.9", "1.2.3 - 2.3"),
+        ("1.0.0-alpha.24", "^1.0.0-alpha.20"),
+        ("1.2.3-beta", "1.2.3-beta"),
+        ("1.0.0", "^1.0.0-alpha"),
+    ],
+)
+def test_versions_inside_a_range(version, range_):
+    assert satisfies(version, range_)
+
+
+@pytest.mark.parametrize(
+    ("version", "range_"),
+    [
+        ("1.2.4", "1.2.3"),
+        ("2.0.0", "^1.2.3"),
+        ("1.2.2", "^1.2.3"),
+        ("0.3.0", "^0.2.3"),
+        ("0.0.4", "^0.0.3"),
+        ("1.3.0", "~1.2.3"),
+        ("25.3.0", "~25.2"),
+        ("2.0.0", "1.x"),
+        ("1.3.0", "1.2"),
+        ("2.0.0", ">=1.2.3 <2"),
+        ("1.2.9", ">1.2"),
+        ("1.3.0", "<=1.2"),
+        ("2.0.0", "<1.2 || >=3"),
+        ("2.3.5", "1.2.3 - 2.3.4"),
+        ("2.4.0", "1.2.3 - 2.3"),
+        ("1.0.0-alpha.10", "^1.0.0-alpha.20"),
+    ],
+)
+def test_versions_outside_a_range(version, range_):
+    assert not satisfies(version, range_)
+
+
+def test_a_prerelease_only_matches_a_range_naming_its_own_release():
+    """npm's rule: ^1.2.3 does not admit 1.5.0-beta, and >1.2 does not admit 1.3.0-beta."""
+    assert not satisfies("1.5.0-beta", "^1.2.3")
+    assert not satisfies("1.3.0-beta", ">1.2")
+    assert not satisfies("3.0.0-beta.1", ">=2")
+    assert not satisfies("1.0.0-rc.1", "<1.0.0")
+    assert satisfies("1.5.0-beta", ">=1.5.0-alpha")
+
+
+def test_versions_order_by_semver_precedence():
+    ordered = ["1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta", "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11", "1.0.0-rc.1", "1.0.0"]
+    assert [str(v) for v in sorted(parse_version(v) for v in reversed(ordered))] == ordered
+    assert parse_version("1.0.0+build.5") == parse_version("1.0.0")
+
+
+@pytest.mark.parametrize("text", ["1.2", "v1.2.3", "01.2.3", "1.2.3-", "x", ""])
+def test_an_exact_version_must_be_complete(text):
+    with pytest.raises(ValueError, match="not a semantic version"):
+        parse_version(text)
+
+
+@pytest.mark.parametrize("text", ["^^1", "1.2.3.4", ">=abc"])
+def test_an_unparseable_range_is_an_error(text):
+    with pytest.raises(ValueError):
+        parse_range(text)

--- a/spaday/tests/test_semver.py
+++ b/spaday/tests/test_semver.py
@@ -29,6 +29,10 @@ from spaday.semver import parse_range, parse_version, satisfies
         ("1.0.0-alpha.24", "^1.0.0-alpha.20"),
         ("1.2.3-beta", "1.2.3-beta"),
         ("1.0.0", "^1.0.0-alpha"),
+        ("1.9.0", "^1"),
+        ("2.9.9", "1.2.3 - 2"),
+        ("9.0.0", "1.2.3 - x"),
+        ("0.5.0", "* - 1.0.0"),
     ],
 )
 def test_versions_inside_a_range(version, range_):
@@ -54,6 +58,10 @@ def test_versions_inside_a_range(version, range_):
         ("2.3.5", "1.2.3 - 2.3.4"),
         ("2.4.0", "1.2.3 - 2.3"),
         ("1.0.0-alpha.10", "^1.0.0-alpha.20"),
+        ("2.0.0", "^1"),
+        ("3.0.0", "1.2.3 - 2"),
+        ("1.2.2", "1.2.3 - x"),
+        ("1.0.0", "<*"),
     ],
 )
 def test_versions_outside_a_range(version, range_):
@@ -73,6 +81,7 @@ def test_versions_order_by_semver_precedence():
     ordered = ["1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta", "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11", "1.0.0-rc.1", "1.0.0"]
     assert [str(v) for v in sorted(parse_version(v) for v in reversed(ordered))] == ordered
     assert parse_version("1.0.0+build.5") == parse_version("1.0.0")
+    assert repr(parse_version("1.0.0-rc.1")) == "Version('1.0.0-rc.1')"
 
 
 @pytest.mark.parametrize("text", ["1.2", "v1.2.3", "01.2.3", "1.2.3-", "x", ""])


### PR DESCRIPTION
Component packages can now say which JS library versions they serve and which they need, and spaday reconciles them across the packages selected for a page before it builds it.

- `ComponentPackage.provides`: npm name → exact version the package serves (`{"@awesome.me/webawesome": "3.1.0"}`). A package's JS build is meant to write these, so the Python side knows what the browser gets.
- `ComponentPackage.requires`: npm name → npm range for a library the package's bundle imports but leaves to the page's copy (`{"@awesome.me/webawesome": "^3.1.0"}`).
- `resolve_component_packages` — which `bootstrap` and every backend's `serve` go through, so this runs at startup — rejects two packages serving one library at different versions, and a `requires` whose range the served version misses or that no selected package serves. Each error names the packages and versions.
- The import-map check no longer rejects two packages publishing the same specifier at different URLs when both declare the same version of that library: the copies are interchangeable, and the page imports the first. Without matching `provides` it still errors as before.
- `spaday/semver.py` parses versions and npm ranges (`^`, `~`, x-ranges, hyphen ranges, `||`) with npm's prerelease rule, so a range can be copied from a `package.json`.

Both fields default to empty, so existing packages are unaffected. The customizing guide's section on sharing one engine documents the fields and how the define-guards cover copies spaday doesn't serve; the component packages will record their versions and warn from their guards in follow-ups.
