### PR TITLE
Add browser-hosted Pyodide examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,14 @@ jupyterlite:  ## build the JupyterLite demo site into dist/lite (needs the Pyodi
 	rm -rf examples/lite/pypi examples/lite/.cache dist/lite
 	mkdir -p examples/lite/pypi
 	cp dist/pyodide/*.whl examples/lite/pypi/
+	python -m pip download --no-deps --only-binary=:all: --dest examples/lite/pypi "spaday-webawesome==0.4.0" "spaday-lightweight-charts==0.2.1"
+	python -m pip download --no-deps --only-binary=:all: --platform pyemscripten_2026_0_wasm32 --python-version 314 --implementation cp --abi cp314 --dest examples/lite/pypi "transports==0.8.0"
 	uvx --with jupyterlite-pyodide-kernel==0.8.3 --with jupyter-server --with jupyterlab-widgets==3.0.15 --with anywidget --from jupyterlite-core==0.8.2 jupyter lite build --lite-dir examples/lite --output-dir $(CURDIR)/dist/lite
+	mkdir -p dist/lite/js/examples dist/lite/js/dist/esm dist/lite/js/dist/pkg
+	python tools/copy_example_assets.py dist/lite/pypi dist/lite/components
+	cp js/examples/pyodide.html js/examples/pyodide-worker.js js/examples/standalone.html js/examples/standalone-worker.js js/examples/standalone-examples.js dist/lite/js/examples/
+	cp js/dist/esm/index.js dist/lite/js/dist/esm/
+	cp js/dist/pkg/spaday_bg.wasm dist/lite/js/dist/pkg/
 test-jupyterlite: jupyterlite  ## drive the JupyterLite demo in a browser
 	rm -rf js/dist/lite
 	cp -r dist/lite js/dist/lite

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 Reactive web-component UIs **configured in Python, executed in the browser**.
 
+**[Browse the standalone examples](https://1kbgz.github.io/spaday/lite/js/examples/standalone.html)**
+or [open the interactive notebook](https://1kbgz.github.io/spaday/lite/lab/index.html?path=spaday-demo.ipynb).
+Python runs in Pyodide, so nothing needs to be installed locally.
+
 ## Overview
 
 Construct a UI as a tree of typed Python components from opt-in packages or any library that ships a

--- a/docs/src/pyodide.md
+++ b/docs/src/pyodide.md
@@ -85,19 +85,50 @@ Run the focused Playwright test against the wheel already in `dist/pyodide/`:
 make test-pyodide-browser
 ```
 
-## Run it all in JupyterLite
+## Browse the standalone examples
+
+[Open the standalone gallery](https://1kbgz.github.io/spaday/lite/js/examples/standalone.html) to run
+the focused examples without installing Python. Use the picker to switch among seven core examples.
+Peer packages host their own standalone examples; for example, [open spaday-trees in Pyodide](https://1kbgz.github.io/spaday-trees/lite/).
+
+The page installs the Python wheels in a Pyodide Web Worker and loads each wheel's browser assets on
+the main thread. When an example exports a transports `Server`, the runner detects it and uses
+`postMessage` as an in-browser wire:
+
+```text
+browser Store → transports JS Client → Web Worker → Python Server/Session
+              ← authoritative accepted patch ←
+```
+
+This preserves Python model validation, background updates, and server-authoritative edits. No HTTP
+or WebSocket server is created.
+
+Use the deployed server examples for behavior that inherently crosses browser processes: shared state
+between tabs or users, clustering, SSR, host-framework mounting, and external services. When Pyodide
+does connect to a deployed service, transports already detects `sys.platform == "emscripten"` and
+implements `Client.connect()` with the browser's native `WebSocket` or `EventSource`.
+
+## Run the notebook examples in JupyterLite
 
 Both ends WebAssembly: the Pyodide kernel runs your Python, and the [notebook widget](notebook.md)
 (which bundles the spaday runtime and wasm core) renders the tree in the notebook frontend — no
-server. A hosted build publishes with these docs at
-[/spaday/lite/](https://1kbgz.github.io/spaday/lite/) — open `lab/index.html` → `spaday-demo.ipynb`.
+server. [Open the interactive examples](https://1kbgz.github.io/spaday/lite/lab/index.html?path=spaday-demo.ipynb)
+and run all cells. The notebook runs these packaged examples directly:
+
+- [`widget.py`](../../spaday/examples/widget.py) for rendering and client-side actions;
+- [`devices.py`](../../spaday/examples/devices.py) for reactive device controls;
+
+The [standalone worker example](https://1kbgz.github.io/spaday/lite/js/examples/pyodide.html) runs
+[`pyodide.py`](../../spaday/examples/pyodide.py) with fully interactive Python-owned state and
+rendering. Its worker loads the Pyodide wheel published with the documentation site.
 
 ```bash
 make jupyterlite        # builds the site into dist/lite (wheel + demo notebook included)
 make test-jupyterlite   # or: drive the site's REPL in Chromium end-to-end
 ```
 
-Serve `dist/lite` from any static host. The spaday wheel installs from the site's own wheel index
+Serve `dist/lite` from any static host. The build copies the core wheel, dependency wheels and browser
+assets, standalone runner, and notebook into the site. The spaday wheel installs from the site's own wheel index
 (`%pip install spaday anywidget`); `anywidget` and `pydantic` come from PyPI. Widget **frontend**
 extensions cannot be `%pip install`ed at runtime — the site build bundles them (`jupyterlab_widgets`
 for the ipywidgets manager plus `anywidget`; see the `jupyterlite` Make target). A Lite site built

--- a/examples/lite/files/spaday-demo.ipynb
+++ b/examples/lite/files/spaday-demo.ipynb
@@ -8,8 +8,8 @@
     "# spaday in JupyterLite\n",
     "\n",
     "The kernel is Python compiled to WebAssembly (Pyodide), and the widget bundles the spaday\n",
-    "runtime and its wasm core — a spaday UI renders in the notebook with no server. Run the\n",
-    "cells in order."
+    "runtime and its wasm core. These are the real examples shipped in `spaday.examples`, running\n",
+    "with no application server and nothing installed on your computer. Choose **Run → Run All Cells**."
    ]
   },
   {
@@ -21,25 +21,14 @@
    "source": ["%pip install -q spaday anywidget"]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "cell-2",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from spaday import Widget, element\n",
-    "from spaday.components.shell import Row, Stack\n",
+    "## Client-side actions and Python intents\n",
     "\n",
-    "\n",
-    "def tree(count):\n",
-    "    return Stack(\n",
-    "        element(\"h2\").text(\"spaday in JupyterLite\"),\n",
-    "        Row(element(\"strong\").text(str(count)), element(\"em\").text(\"clicks\")),\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "w = Widget(tree(0))\n",
-    "w  # display it: the tree renders as live spa-* web components"
+    "**Toggle panel** runs entirely in the browser. The standalone worker linked below is the reliable\n",
+    "demo for Python round-trips; JupyterLite does not consistently deliver custom widget messages."
    ]
   },
   {
@@ -49,8 +38,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# replace the tree; the browser applies a minimal diff to the live DOM\n",
-    "w.update(tree(1))"
+    "from spaday.examples.widget import demo as widget_demo\n",
+    "\n",
+    "actions = widget_demo()\n",
+    "actions"
    ]
   },
   {
@@ -58,9 +49,33 @@
    "id": "cell-4",
    "metadata": {},
    "source": [
-    "Bindings, two-way state, and `SendPatch` intents round-trip with the kernel too — see the\n",
-    "[notebook guide](https://1kbgz.github.io/spaday/notebook.html) for `Widget(state=...)`,\n",
-    "`on_state`, and `on_intent`."
+    "## Two-way state\n",
+    "\n",
+    "The device cards use switches two-way-bound to widget state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from spaday.examples.devices import demo as devices_demo\n",
+    "\n",
+    "devices = devices_demo()\n",
+    "devices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-6",
+   "metadata": {},
+   "source": [
+    "Run the [standalone Pyodide worker example](https://1kbgz.github.io/spaday/lite/js/examples/pyodide.html)\n",
+    "to see fully interactive Python-owned state and rendering. Continue with the\n",
+    "[notebook guide](https://1kbgz.github.io/spaday/notebook.html) for the complete `Widget`, state,\n",
+    "and intent APIs."
    ]
   }
  ],

--- a/js/examples/pyodide-worker.js
+++ b/js/examples/pyodide-worker.js
@@ -1,5 +1,22 @@
 const PYODIDE_VERSION = "314.0.4";
-const wheel = new URL(self.location.href).searchParams.get("wheel") || "spaday";
+const wheelOverride = new URL(self.location.href).searchParams.get("wheel");
+
+async function resolveWheel() {
+  if (wheelOverride) return wheelOverride;
+  try {
+    const indexUrl = new URL("../../pypi/all.json", self.location.href);
+    const response = await fetch(indexUrl);
+    if (!response.ok)
+      throw new Error(`wheel index returned ${response.status}`);
+    const index = await response.json();
+    const files = Object.values(index.spaday.releases).flat();
+    const wheel = files.find((file) => file.filename.endsWith(".whl"));
+    if (!wheel) throw new Error("wheel index contains no spaday wheel");
+    return new URL(`../../pypi/${wheel.filename}`, self.location.href).href;
+  } catch {
+    return "spaday";
+  }
+}
 
 const ready = (async () => {
   self.postMessage({ type: "status", message: "Loading Pyodide…" });
@@ -9,6 +26,7 @@ const ready = (async () => {
   const pyodide = await loadPyodide();
   self.postMessage({ type: "status", message: "Installing spaday…" });
   await pyodide.loadPackage("micropip");
+  const wheel = await resolveWheel();
   pyodide.globals.set("wheel", wheel);
   await pyodide.runPythonAsync(`
 import micropip
@@ -28,7 +46,9 @@ self.addEventListener("message", async (event) => {
       return;
     }
     pyodide.globals.set("intent_json", JSON.stringify(event.data));
-    self.postMessage(JSON.parse(pyodide.runPython("app.dispatch_json(intent_json)")));
+    self.postMessage(
+      JSON.parse(pyodide.runPython("app.dispatch_json(intent_json)")),
+    );
   } catch (error) {
     self.postMessage({ type: "error", message: String(error) });
   }

--- a/js/examples/standalone-examples.js
+++ b/js/examples/standalone-examples.js
@@ -1,0 +1,63 @@
+export const EXAMPLES = {
+  "webawesome-forms": {
+    title: "WebAwesome settings form",
+    module: "spaday.examples.webawesome_forms",
+    stateAttribute: "INITIAL_STATE",
+    distributions: ["spaday-webawesome"],
+    assets: ["webawesome"],
+    note: "Save settings needs the server endpoint; local controls, validation, and reset run in this preview.",
+  },
+  "webawesome-navigation": {
+    title: "WebAwesome navigation",
+    module: "spaday.examples.webawesome_navigation",
+    stateAttribute: "INITIAL_STATE",
+    distributions: ["spaday-webawesome"],
+    assets: ["webawesome"],
+  },
+  "webawesome-feedback": {
+    title: "WebAwesome feedback",
+    module: "spaday.examples.webawesome_feedback",
+    stateAttribute: "INITIAL_STATE",
+    distributions: ["spaday-webawesome"],
+    assets: ["webawesome"],
+  },
+  "webawesome-content": {
+    title: "WebAwesome content",
+    module: "spaday.examples.webawesome_content",
+    distributions: ["spaday-webawesome"],
+    assets: ["webawesome"],
+  },
+  "webawesome-observers": {
+    title: "WebAwesome observers",
+    module: "spaday.examples.webawesome_observers",
+    stateAttribute: "INITIAL_STATE",
+    distributions: ["spaday-webawesome"],
+    assets: ["webawesome"],
+    note: "The include component's /partial.html endpoint is unavailable on the static site.",
+  },
+  "data-dashboard": {
+    title: "Local data dashboard",
+    module: "spaday.examples.data_dashboard",
+    stateAttribute: "INITIAL_STATE",
+    distributions: ["spaday-webawesome", "spaday-lightweight-charts"],
+    assets: ["webawesome", "lightweight-charts"],
+  },
+  reactive: {
+    title: "Reactive transports binding",
+    module: "spaday.examples.reactive",
+    treeAttribute: "page",
+    requirements: ["transports==0.8.0", "starlette", "uvicorn"],
+    assets: [],
+  },
+};
+
+export const ASSETS = {
+  webawesome: [
+    { type: "css", path: "../../components/webawesome/css/webawesome.css" },
+    { type: "js", path: "../../components/webawesome/cdn/index.js" },
+  ],
+  "lightweight-charts": [
+    { type: "css", path: "../../components/lightweight-charts/css/index.css" },
+    { type: "js", path: "../../components/lightweight-charts/cdn/index.js" },
+  ],
+};

--- a/js/examples/standalone-worker.js
+++ b/js/examples/standalone-worker.js
@@ -1,0 +1,111 @@
+import { EXAMPLES } from "./standalone-examples.js";
+
+const params = new URL(self.location.href).searchParams;
+const exampleName = params.get("example") || "webawesome-navigation";
+const config = EXAMPLES[exampleName];
+const PYODIDE_VERSION = "314.0.4";
+let pyodide;
+
+async function wheelIndex() {
+  const response = await fetch(
+    new URL("../../pypi/all.json", self.location.href),
+  );
+  if (!response.ok) throw new Error(`wheel index returned ${response.status}`);
+  return response.json();
+}
+
+function wheelUrl(index, name) {
+  const distribution = index[name] || index[name.replaceAll("-", "_")];
+  if (!distribution) return name;
+  const wheel = Object.values(distribution.releases)
+    .flat()
+    .find((file) => file.filename.endsWith(".whl"));
+  if (!wheel) return name;
+  return new URL(`../../pypi/${wheel.filename}`, self.location.href).href;
+}
+
+const ready = (async () => {
+  if (!config) throw new Error(`unknown example: ${exampleName}`);
+  self.postMessage({ type: "status", message: "Loading Pyodide…" });
+  const { loadPyodide } = await import(
+    `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/pyodide.mjs`
+  );
+  pyodide = await loadPyodide();
+  await pyodide.loadPackage(["micropip", "anyio"]);
+
+  self.postMessage({ type: "status", message: "Installing example…" });
+  const index = await wheelIndex();
+  const wheels = [wheelUrl(index, "spaday")];
+  for (const distribution of config.distributions || []) {
+    wheels.push(wheelUrl(index, distribution));
+  }
+  wheels.push(...(config.requirements || []));
+  pyodide.globals.set("requirements_json", JSON.stringify(wheels));
+  pyodide.globals.set("config_json", JSON.stringify(config));
+  return pyodide.runPythonAsync(`
+import json
+import micropip
+from importlib import import_module
+
+await micropip.install(json.loads(requirements_json))
+config = json.loads(config_json)
+module = import_module(config["module"])
+tree = getattr(module, config.get("treeAttribute", "build_page"))
+if callable(tree):
+    tree = tree()
+
+state = dict(config.get("state", {}))
+state_attribute = config.get("stateAttribute")
+if state_attribute:
+    state.update(getattr(module, state_attribute))
+
+style = getattr(module, config.get("styleAttribute", "STYLE"), "")
+server = getattr(module, "server", None)
+connection = "browser"
+
+def local_wires(messages):
+    if server is None:
+        return []
+    return list(messages.get(connection, []))
+
+def receive_wire(frame):
+    return json.dumps(local_wires(server.recv(connection, frame)))
+
+def flush_server():
+    return json.dumps(local_wires(server.flush()))
+
+opening = server.open(connection, "json") if server is not None else []
+
+json.dumps({
+    "tree": tree.to_node(),
+    "state": state,
+    "style": style,
+    "wires": opening,
+    "localServer": server is not None,
+})
+`);
+})();
+
+let queue = Promise.resolve();
+
+async function handle(message) {
+  const snapshot = await ready;
+  if (message.type === "start") {
+    self.postMessage({ type: "snapshot", payload: JSON.parse(snapshot) });
+  } else if (message.type === "wire") {
+    pyodide.globals.set("wire_frame", message.frame);
+    const wires = JSON.parse(pyodide.runPython("receive_wire(wire_frame)"));
+    if (wires.length) self.postMessage({ type: "wires", wires });
+  } else if (message.type === "flush") {
+    const wires = JSON.parse(pyodide.runPython("flush_server()"));
+    if (wires.length) self.postMessage({ type: "wires", wires });
+  }
+}
+
+self.addEventListener("message", (event) => {
+  queue = queue
+    .then(() => handle(event.data))
+    .catch((error) => {
+      self.postMessage({ type: "error", message: String(error) });
+    });
+});

--- a/js/examples/standalone.html
+++ b/js/examples/standalone.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>spaday browser examples</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "@awesome.me/webawesome": "../../components/webawesome/vendor/@awesome.me/webawesome/dist/webawesome.js",
+          "@awesome.me/webawesome/dist/": "../../components/webawesome/vendor/@awesome.me/webawesome/dist/"
+        }
+      }
+    </script>
+    <style>
+      #demo-toolbar {
+        position: sticky;
+        z-index: 10000;
+        top: 0;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        box-sizing: border-box;
+        min-height: 3rem;
+        padding: 0.55rem 0.85rem;
+        border-bottom: 1px solid #cbd5e1;
+        color: #172033;
+        background: #fffffff2;
+        font:
+          14px/1.4 system-ui,
+          sans-serif;
+        backdrop-filter: blur(12px);
+      }
+      #demo-toolbar label {
+        font-weight: 700;
+      }
+      #demo-toolbar select {
+        max-width: min(28rem, 48vw);
+        padding: 0.35rem;
+        font: inherit;
+      }
+      #demo-status {
+        margin-left: auto;
+        color: #475569;
+      }
+      #demo-note {
+        padding: 0.55rem 0.85rem;
+        color: #92400e;
+        background: #fffbeb;
+        font:
+          13px/1.4 system-ui,
+          sans-serif;
+      }
+      #demo-error {
+        margin: 1rem;
+        color: #b91c1c;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <nav id="demo-toolbar">
+      <label for="demo-picker">Example</label>
+      <select id="demo-picker"></select>
+      <span id="demo-status">Starting…</span>
+    </nav>
+    <aside id="demo-note" hidden></aside>
+    <div id="demo-root"></div>
+    <pre id="demo-error" hidden></pre>
+    <script type="module">
+      import { connectStore, init, mount, Store } from "../dist/esm/index.js";
+      import { ASSETS, EXAMPLES } from "./standalone-examples.js";
+
+      const params = new URLSearchParams(location.search);
+      const exampleName = params.get("example") || "webawesome-navigation";
+      const config = EXAMPLES[exampleName];
+      const picker = document.querySelector("#demo-picker");
+      const status = document.querySelector("#demo-status");
+      const note = document.querySelector("#demo-note");
+      let receiveWires = () => {};
+
+      for (const [name, example] of Object.entries(EXAMPLES)) {
+        picker.add(
+          new Option(example.title, name, false, name === exampleName),
+        );
+      }
+      picker.addEventListener("change", () => {
+        const next = new URL(location.href);
+        next.searchParams.set("example", picker.value);
+        location.href = next;
+      });
+
+      async function loadAsset(asset) {
+        const url = new URL(asset.path, import.meta.url);
+        if (asset.type === "js") {
+          await import(url.href);
+          return;
+        }
+        await new Promise((resolve, reject) => {
+          const link = document.createElement("link");
+          link.rel = "stylesheet";
+          link.href = url.href;
+          link.onload = resolve;
+          link.onerror = reject;
+          document.head.appendChild(link);
+        });
+      }
+
+      try {
+        if (!config) throw new Error(`Unknown example: ${exampleName}`);
+        document.title = `${config.title} — spaday`;
+        if (config.note) {
+          note.textContent = config.note;
+          note.hidden = false;
+        }
+
+        const assets = config.assets.flatMap((name) => ASSETS[name]);
+        await Promise.all([
+          init({ module_or_path: "../dist/pkg/spaday_bg.wasm" }),
+          ...assets.map(loadAsset),
+        ]);
+
+        const workerUrl = new URL("./standalone-worker.js", location.href);
+        workerUrl.searchParams.set("example", exampleName);
+        const worker = new Worker(workerUrl, { type: "module" });
+
+        worker.addEventListener("message", (event) => {
+          if (event.data.type === "status")
+            status.textContent = event.data.message;
+          if (event.data.type === "error") {
+            status.textContent = "Unable to start";
+            const output = document.querySelector("#demo-error");
+            output.hidden = false;
+            output.textContent = event.data.message;
+          }
+          if (event.data.type === "wires") receiveWires(event.data.wires);
+          if (event.data.type === "snapshot") {
+            const { tree, state, style, wires, localServer } =
+              event.data.payload;
+            if (style) document.head.insertAdjacentHTML("beforeend", style);
+            const store = new Store(state);
+            const start = async () => {
+              if (localServer) {
+                status.textContent = "Connecting in-browser model…";
+                const transports =
+                  await import("../../components/transports/cdn/index.js");
+                await transports.wasm.default({
+                  module_or_path:
+                    "../../components/transports/pkg/transports_bg.wasm",
+                });
+                const client = new transports.Client();
+                const link = connectStore(
+                  store,
+                  client,
+                  (frame) => worker.postMessage({ type: "wire", frame }),
+                  transports,
+                );
+                receiveWires = (frames) => {
+                  for (const frame of frames) link.receive(frame);
+                  const received = Number(
+                    document.documentElement.dataset.transportMessages || 0,
+                  );
+                  document.documentElement.dataset.transportMessages = String(
+                    received + frames.length,
+                  );
+                };
+                receiveWires(wires);
+                window.setInterval(
+                  () => worker.postMessage({ type: "flush" }),
+                  100,
+                );
+              }
+              mount(document.querySelector("#demo-root"), tree, store);
+              status.textContent = localServer
+                ? "Ready · Python model in browser"
+                : "Ready";
+              document.documentElement.dataset.ready = "true";
+            };
+            start().catch((error) => {
+              status.textContent = "Unable to start";
+              const output = document.querySelector("#demo-error");
+              output.hidden = false;
+              output.textContent = String(error);
+            });
+          }
+        });
+        worker.postMessage({ type: "start" });
+      } catch (error) {
+        status.textContent = "Unable to start";
+        const output = document.querySelector("#demo-error");
+        output.hidden = false;
+        output.textContent = String(error);
+      }
+    </script>
+  </body>
+</html>

--- a/js/tests/jupyterlite.test.js
+++ b/js/tests/jupyterlite.test.js
@@ -22,22 +22,92 @@ test("JupyterLite pyodide kernel installs the wheel and renders the widget", asy
     "code",
     [
       "import spaday",
-      "from spaday import Widget, element",
-      "from spaday.components.shell import Stack",
-      // "hello " + "spaday" keeps the rendered text out of the echoed source, so the
-      // visibility assertion below can only be satisfied by the widget's live DOM
-      'w = Widget(Stack(element("h1").text("hello " + "spaday")))',
+      "from spaday.examples.widget import demo as widget_demo",
+      "from spaday.examples.devices import demo as devices_demo",
+      "actions = widget_demo()",
+      "devices = devices_demo()",
       "print('lite-ok', spaday.__version__)",
     ].join("\n"),
   );
-  // displaying the widget must render the tree as live elements, not the text/plain repr —
-  // this is what breaks when the lite build lacks the ipywidgets/anywidget frontends
-  url.searchParams.append("code", "w");
+  // Each expression displays one real packaged example through the widget frontend.
+  url.searchParams.append("code", "actions");
+  url.searchParams.append("code", "devices");
   await page.goto(url.toString());
   await expect(page.getByText(`lite-ok ${version}`)).toBeVisible({
     timeout: 240_000,
   });
-  await expect(page.locator("h1", { hasText: "hello spaday" })).toBeVisible({
+  await expect(page.getByRole("button", { name: "Toggle panel" })).toBeVisible({
     timeout: 60_000,
   });
+  await expect(page.getByText("Living room", { exact: true })).toBeVisible();
+});
+
+test("published Pyodide worker example uses the site's wheel", async ({
+  page,
+}) => {
+  const example = "dist/lite/js/examples/pyodide.html";
+  test.skip(!fs.existsSync(example), "run `make jupyterlite` first");
+  test.setTimeout(180_000);
+
+  await page.goto(new URL(`/${example}`, "http://127.0.0.1:3000").toString());
+  await expect(page.locator("html")).toHaveAttribute("data-ready", "true", {
+    timeout: 150_000,
+  });
+  await expect(page.locator("#count")).toHaveText("0");
+  await page.getByRole("button", { name: "Increment in Python" }).click();
+  await expect(page.locator("#count")).toHaveText("1");
+});
+
+test("standalone gallery runs core examples in Pyodide", async ({ page }) => {
+  const example = "dist/lite/js/examples/standalone.html";
+  test.skip(!fs.existsSync(example), "run `make jupyterlite` first");
+  test.setTimeout(600_000);
+
+  const cases = [
+    ["webawesome-forms", "Account settings"],
+    ["webawesome-navigation", "Workspace overview"],
+    ["webawesome-feedback", "Operations status"],
+    ["webawesome-content", "Atlas product update"],
+    ["webawesome-observers", "Browser utility components"],
+    ["data-dashboard", "Trading dashboard"],
+    ["reactive", "Reactive controls over transports — bindings, no glue"],
+  ];
+
+  for (const [name, visibleText] of cases) {
+    const url = new URL(`/${example}`, "http://127.0.0.1:3000");
+    url.searchParams.set("example", name);
+    await page.goto(url.toString());
+    try {
+      await page.waitForFunction(
+        () =>
+          document.documentElement.dataset.ready === "true" ||
+          document.querySelector("#demo-status")?.textContent ===
+            "Unable to start",
+        undefined,
+        { timeout: 180_000 },
+      );
+      await expect(page.locator("html")).toHaveAttribute("data-ready", "true");
+    } catch (error) {
+      throw new Error(
+        `${name}: ${error}\nStatus: ${await page.locator("#demo-status").textContent()}\n${await page.locator("#demo-error").textContent()}`,
+      );
+    }
+    await expect(page.getByText(visibleText, { exact: true })).toBeVisible();
+    if (name === "reactive") {
+      const before = Number(
+        await page.locator("html").getAttribute("data-transport-messages"),
+      );
+      await page.locator('input[type="text"]').fill("browser round-trip");
+      await expect(
+        page.getByText("browser round-trip", { exact: true }),
+      ).toBeVisible();
+      await expect
+        .poll(async () =>
+          Number(
+            await page.locator("html").getAttribute("data-transport-messages"),
+          ),
+        )
+        .toBeGreaterThan(before);
+    }
+  }
 });

--- a/spaday/examples/README.md
+++ b/spaday/examples/README.md
@@ -32,6 +32,9 @@ pip install -e ".[widget]"
 The [Pyodide example](../../js/examples/pyodide.html) runs
 [`pyodide.py`](./pyodide.py) inside a Web Worker. Follow
 [Run a spaday app in Pyodide](../../docs/src/pyodide.md) to build its wheel and browser runtime.
+The [hosted standalone gallery](https://1kbgz.github.io/spaday/lite/js/examples/standalone.html) runs
+the focused component examples without a local install. Peer packages host their own examples; open
+the [spaday-trees example](https://1kbgz.github.io/spaday-trees/lite/) directly.
 
 ## Omnibus: the complete application
 

--- a/spaday/examples/data_dashboard.py
+++ b/spaday/examples/data_dashboard.py
@@ -28,6 +28,14 @@ SERIES = [
     {"time": "2026-07-22", "value": 110.4},
 ]
 
+INITIAL_STATE = {
+    "chart_type": "area",
+    "show_chart": True,
+    "dark": False,
+    "orders": ORDERS,
+    "series": SERIES,
+}
+
 
 def build_page():
     """Return a dashboard whose chart and table are driven by local reactive state."""
@@ -101,13 +109,7 @@ def create_app():
     return serve(
         build_page,
         packages=["webawesome", "lightweight-charts"],
-        store={
-            "chart_type": "area",
-            "show_chart": True,
-            "dark": False,
-            "orders": ORDERS,
-            "series": SERIES,
-        },
+        store=INITIAL_STATE,
         title="spaday — data dashboard",
         head=STYLE,
     )

--- a/spaday/examples/reactive.py
+++ b/spaday/examples/reactive.py
@@ -36,6 +36,7 @@ session = transports.Session()
 controls = Controls()
 session.host(controls)
 server = transports.Server(session)
+STYLE = "<style>body { font-family: system-ui, sans-serif; margin: 2rem; } label { font-weight: 600; margin-right: 0.5rem; }</style>"
 
 
 def page():
@@ -57,7 +58,7 @@ app = serve(
     routes=[WebSocketRoute("/ws", transports.ws_endpoint(server))],
     background=[transports.autosync(server)],
     title="spaday × transports — reactive bindings",
-    head="<style>body { font-family: system-ui, sans-serif; margin: 2rem; } label { font-weight: 600; margin-right: 0.5rem; }</style>",
+    head=STYLE,
 )
 
 

--- a/spaday/examples/webawesome_feedback.py
+++ b/spaday/examples/webawesome_feedback.py
@@ -28,6 +28,8 @@ body { margin: 0; font-family: system-ui, sans-serif; }
 .status-card { border: 1px solid var(--wa-color-neutral-border-normal); border-radius: .6rem; padding: 1rem; }
 </style>"""
 
+INITIAL_STATE = {"busy": True, "progress": 64}
+
 
 def build_page():
     """Return a status center driven by a local reactive store."""
@@ -111,7 +113,7 @@ def create_app():
     return serve(
         build_page,
         packages=["webawesome"],
-        store={"busy": True, "progress": 64},
+        store=INITIAL_STATE,
         title="spaday — status and feedback",
         head=STYLE,
     )

--- a/spaday/examples/webawesome_forms.py
+++ b/spaday/examples/webawesome_forms.py
@@ -31,6 +31,24 @@ body { margin: 0; font-family: system-ui, sans-serif; }
 .settings-grid > * { min-width: 0; }
 </style>"""
 
+INITIAL_STATE = {
+    "name": "Ada Lovelace",
+    "email": "ada@example.com",
+    "role": "engineer",
+    "bio": "",
+    "dark": False,
+    "notifications": ["email"],
+    "density": "comfortable",
+    "accent": "#2563eb",
+    "start_date": "2026-08-01",
+    "reminder": "09:30",
+    "seats": 8,
+    "digest": 8,
+    "rating": 4,
+    "save_result": None,
+    "form_error": None,
+}
+
 
 def build_page() -> App:
     """Return a local-state settings form with reset and save actions."""
@@ -173,23 +191,7 @@ def create_app():
     return serve(
         build_page,
         packages=["webawesome"],
-        store={
-            "name": "Ada Lovelace",
-            "email": "ada@example.com",
-            "role": "engineer",
-            "bio": "",
-            "dark": False,
-            "notifications": ["email"],
-            "density": "comfortable",
-            "accent": "#2563eb",
-            "start_date": "2026-08-01",
-            "reminder": "09:30",
-            "seats": 8,
-            "digest": 8,
-            "rating": 4,
-            "save_result": None,
-            "form_error": None,
-        },
+        store=INITIAL_STATE,
         routes=[Route("/api/settings", save_settings, methods=["POST"])],
         title="spaday — settings form",
         head=STYLE,

--- a/spaday/examples/webawesome_navigation.py
+++ b/spaday/examples/webawesome_navigation.py
@@ -44,6 +44,8 @@ wa-page { min-height: 100vh; }
 }
 </style>"""
 
+INITIAL_STATE = {"section": "overview"}
+
 
 def _navigation_button(label: str, section: str) -> WaButton:
     active = eq(field("section"), section)
@@ -218,7 +220,7 @@ def create_app():
     return serve(
         build_page,
         packages=["webawesome"],
-        store={"section": "overview"},
+        store=INITIAL_STATE,
         title="spaday — application navigation",
         head=STYLE,
     )

--- a/spaday/examples/webawesome_observers.py
+++ b/spaday/examples/webawesome_observers.py
@@ -25,6 +25,8 @@ body { margin: 0; font-family: system-ui, sans-serif; }
 .visible { outline: 3px solid #22c55e; }
 </style>"""
 
+INITIAL_STATE = {"resize_wide": False}
+
 
 def build_page() -> App:
     """Return a browser-utility page whose behavior stays inside custom elements."""
@@ -124,7 +126,7 @@ def create_app():
     return serve(
         build_page,
         packages=["webawesome"],
-        store={"resize_wide": False},
+        store=INITIAL_STATE,
         routes=[Route("/partial.html", partial)],
         title="spaday — browser observers",
         head=STYLE,

--- a/tools/copy_example_assets.py
+++ b/tools/copy_example_assets.py
@@ -1,0 +1,31 @@
+"""Copy browser assets from dependency wheels into a static documentation site."""
+
+import sys
+import zipfile
+from pathlib import Path
+
+PACKAGES = (
+    ("transports", "transports", "transports"),
+    ("spaday-webawesome", "spaday_webawesome", "webawesome"),
+    ("spaday-lightweight-charts", "spaday_lightweight_charts", "lightweight-charts"),
+)
+
+
+def main(wheel_dir: Path, output_dir: Path) -> None:
+    for distribution, package, asset_name in PACKAGES:
+        wheels = sorted(wheel_dir.glob(f"{distribution.replace('-', '_')}-*.whl"))
+        if len(wheels) != 1:
+            raise RuntimeError(f"expected one {distribution} wheel in {wheel_dir}, found {len(wheels)}")
+        prefix = f"{package}/extension/"
+        with zipfile.ZipFile(wheels[0]) as wheel:
+            assets = [name for name in wheel.namelist() if name.startswith(prefix) and not name.endswith("/")]
+            if not assets:
+                raise RuntimeError(f"{wheels[0].name} contains no browser assets")
+            for name in assets:
+                target = output_dir / asset_name / name.removeprefix(prefix)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(wheel.read(name))
+
+
+if __name__ == "__main__":
+    main(Path(sys.argv[1]), Path(sys.argv[2]))


### PR DESCRIPTION
## Description

Publish a standalone Pyodide gallery for seven core examples and run packaged examples in JupyterLite. Transports Server round-trips use a page-local postMessage wire, keeping Python model validation inside the browser. Peer-owned previews remain linked from core documentation instead of being hosted here.

Validated with the Pyodide wheel build, the full JupyterLite browser suite, focused Python example tests, lint, and documentation build.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup
- [x] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [ ] Tests pass (`make test`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)