### PR TITLE
Add generic controls any design renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ pip install "spaday[widget]"  # + the Jupyter / anywidget host
 Install only the integrations an application uses. Each package provides typed Python components and
 registers its browser assets with spaday:
 
-
 ### Design Systems
 
 - [spaday-blueprint](https://github.com/1kbgz/spaday-blueprint) — [BlueprintUI](https://blueprintui.dev/docs/components).

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -16,6 +16,20 @@ The Python surface of spaday. Peer-package component classes are not listed here
 .. autoclass:: spaday.components.shell.Each
 ```
 
+## Generic controls
+
+Controls any design renders; see [Use generic controls](components.md#use-generic-controls-any-design-renders).
+
+```{eval-rst}
+.. automodule:: spaday.ui.controls
+   :members: Button, TextInput, Checkbox, Switch, Select, Dialog, Control
+
+.. automodule:: spaday.ui.design
+   :members: Design, ControlSpec, Part, Wrap, Options, Value, Open, resolve, select_design
+
+.. autodata:: spaday.ui.native.NATIVE
+```
+
 ## Action DSL
 
 Behavior attached to a component with `Component.on`; see [Add behavior and reactivity](behavior.md).

--- a/docs/src/components.md
+++ b/docs/src/components.md
@@ -75,6 +75,45 @@ Flow regions are `HEADER_LEFT` / `HEADER_CENTER` / `HEADER_RIGHT`, `GUTTER_LEFT`
 Footer only appears when its regions have contributions. `DRAWER_LEFT`, `DRAWER_RIGHT`, `DRAWER_BOTTOM`,
 and `OVERLAY` append directly under `App`, after flow chrome, for top-layer UI.
 
+## Use generic controls any design renders
+
+A typed catalog ties a page to one design system: `WaButton` is a `wa-button`. The generic controls
+in `spaday.ui` are the layer between the shell and a catalog — a button, a text input, a checkbox, a
+switch, a select and a dialog with one vocabulary — and the page's **design** decides what element
+each becomes:
+
+```python
+from spaday import Paragraph, SetField
+from spaday.components.shell import Column
+from spaday.ui import Button, Dialog, Select, Switch, TextInput
+
+page = Column(
+    TextInput(label="Name", help="As on your passport").bind("value", "name", mode="two-way"),
+    Select(label="Plan", options=["basic", "plus"]).bind("value", "plan", mode="two-way"),
+    Switch(label="Dark theme").bind("value", "dark", mode="two-way"),
+    Button(label="Save", intent="primary").on("click", SetField("open", True)),
+    Dialog(Paragraph("Saved."), Button(label="OK").on("click", SetField("open", False)), label="Done")
+    .bind("open", "open", mode="two-way"),
+)
+serve(page, packages=["webawesome"])   # rendered with WebAwesome's design
+serve(page)                            # rendered with the native baseline: plain form elements, themed
+```
+
+The vocabulary is sized to what every design can express: `label` / `help` / `error`, `disabled` /
+`required` / `readonly`, `intent` (`neutral` / `primary` / `info` / `success` / `warning` / `danger`),
+`appearance` (`filled` / `outline` / `plain`) and `size` (`sm` / `md` / `lg`). Bind `value` on every
+control — a string for an input or a select, a boolean for a checkbox or a switch — and `open` on a
+dialog; the binding reaches whatever property and event the design's element uses (`checked`, a Lion
+control's `model-value-changed`, a `<dialog>`'s `showModal()`), and a dialog closing itself writes the
+field back.
+
+A page renders with one design: the one the selected package publishes, or `design=` to choose
+between several (`"native"` is always available). A design that lacks a control renders it with the
+baseline and marks it `data-ui-fallback`; what a design cannot express is dropped rather than
+half-rendered. For the design's own spelling on one control, `for_design("webawesome", pill=True)`
+sets props only that design sees. At the top level the switch is exported as `ToggleSwitch`, beside
+the shell's `Switch` router.
+
 ## Tabs and navigation
 
 `Tabs` builds a WebAwesome `wa-tab-group` from `(label, content)` pairs — no hand-pairing of tab headers

--- a/docs/src/customizing.md
+++ b/docs/src/customizing.md
@@ -82,6 +82,52 @@ App().css(wa_color_brand_fill_loud="#0C4253")  # → --spa-accent, --spa-info, a
 A canvas component cannot read CSS, so `spaday-lightweight-charts` samples the resolved value of its
 tokens and hands them to the chart. Theming it looks identical from Python.
 
+## Render the generic controls with your own design
+
+The generic controls (`spaday.ui`) reach a design system through a `Design`: data mapping each control
+kind to the element that renders it and to where its generic surface lands there. A design-system
+package publishes one on its `ComponentPackage`; an in-house design system publishes its own the same
+way, and needs no Python beyond it:
+
+```python
+from spaday.ui import ControlSpec, Design, Open, Options, Part, Value
+
+DESIGN = Design(
+    name="acme",
+    controls={
+        "button": ControlSpec(
+            tag="acme-button",
+            label=Part(kind="text"),                       # the label is the button's text
+            props={"intent": "tone", "size": "size", "disabled": "disabled"},
+            values={"intent": {"primary": "brand"}},       # the design's word for it
+        ),
+        "input": ControlSpec(
+            tag="acme-field",
+            label=Part(kind="attr", name="label"),
+            help=Part(kind="slot", name="hint"),           # an element in the `hint` slot
+            error=Part(kind="attr", name="error-text"),
+            invalid={"invalid": True},                     # set while an error is shown
+            value=Value(prop="value", event="acme-change"), # written back on the design's event
+        ),
+        "select": ControlSpec(tag="acme-select", options=Options(kind="prop", name="items")),
+        "dialog": ControlSpec(
+            tag="acme-dialog",
+            open=Open(prop="opened", event="acme-closed", methods=("show", "hide")),
+        ),
+    },
+)
+package = ComponentPackage(name="acme", ..., design=DESIGN)
+```
+
+`Part` places a label, help text or error message as an attribute, a slotted element, the control's
+text, a child inside it, or a sibling in a `Wrap` around it (a `bp-field`, a `fluent-field`, a plain
+`<label>`). `Options` renders a select's choices as child elements — optionally inside one wrapper —
+or as a list property. `Value` and `Open` name the state property and its change event, and `Open`'s
+method pair drives an overlay that opens by method. A control the design leaves out renders with the
+native baseline. `python -m spaday.ui.conformance PORT --package acme` serves the conformance page
+with your design, so the same browser checks spaday runs against the baseline (`js/tests/ui.spec.js`)
+run against yours.
+
 ## Serve your own bundle
 
 A `ComponentPackage` is a frozen dataclass of `(name, assets_dir, assets, components)`, and

--- a/js/src/ts/index.ts
+++ b/js/src/ts/index.ts
@@ -77,6 +77,10 @@ export type { WorkerLink } from "./worker";
 // High-level layout/shell primitives — defines the spa-* custom elements on import.
 export { SHELL_TAGS } from "./shell";
 
+// The native baseline for the generic controls (`spaday.ui`): plain form elements styled from the
+// shell palette. Importing installs the stylesheet.
+export { UI_CSS } from "./ui";
+
 // Prop-value (`Value`) encode/decode.
 export { tag, untag } from "./value";
 export type { Value } from "./value";

--- a/js/src/ts/runtime.ts
+++ b/js/src/ts/runtime.ts
@@ -22,6 +22,10 @@ export interface Binding {
   field?: string;
   compute?: unknown;
   mode: string;
+  /** two-way: the event the control's value is written back on, instead of the defaults */
+  event?: string;
+  /** call `[open, close]` on the element as the field turns truthy / falsy, instead of setting the prop */
+  methods?: [string, string];
 }
 
 export interface Node {
@@ -230,9 +234,14 @@ function readProp(el: Element, name: string): unknown {
 // component tree. Authored via `Component.bind_root_class` / `bind_root_attr`. A class is a boolean, so
 // it coerces; an attribute keeps its value, and is written as an attribute even when the name shadows a
 // property of `<html>` (`title`, `lang`, `dir`, …).
-function bindingApply(el: Element, prop: string): (value: unknown) => void {
+function bindingApply(
+  el: Element,
+  prop: string,
+  spec: Binding,
+): (value: unknown) => void {
   const ROOT_CLASS = "root-class:";
   const ROOT_ATTR = "root-attr:";
+  if (spec.methods) return methodApply(el, prop, spec.methods);
   if (prop.startsWith(ROOT_CLASS)) {
     const name = prop.slice(ROOT_CLASS.length);
     return (v) => document.documentElement.classList.toggle(name, !!v);
@@ -244,6 +253,31 @@ function bindingApply(el: Element, prop: string): (value: unknown) => void {
   return (v) => setProp(el, prop, v);
 }
 
+// A prop driven by a method pair (`[open, close]`) rather than assignment — overlays that open
+// through `showModal()` / `show()` / `showPopover()`. The prop names the element's own state, read
+// back so a call is skipped when the element is already there (`showModal()` on an open dialog
+// throws) and so a two-way binding can report a self-close. An element defined after the page mounts
+// gets the call once it is.
+function methodApply(
+  el: Element,
+  prop: string,
+  [open, close]: [string, string],
+): (value: unknown) => void {
+  return (value) => {
+    const want = !!value;
+    const run = () => {
+      if (!!readProp(el, prop) === want) return;
+      const method = (el as unknown as Record<string, unknown>)[
+        want ? open : close
+      ];
+      if (typeof method === "function") method.call(el);
+    };
+    if (el.localName.includes("-") && !customElements.get(el.localName))
+      void customElements.whenDefined(el.localName).then(run);
+    else run();
+  };
+}
+
 function wireBinding(
   el: Element,
   prop: string,
@@ -253,7 +287,7 @@ function wireBinding(
 ): void {
   unwireBinding(el, prop); // replace any prior wiring for this prop
   const teardowns: Array<() => void> = [];
-  const apply = bindingApply(el, prop);
+  const apply = bindingApply(el, prop, spec);
   if (spec.compute !== undefined) {
     // computed (derived) binding: recompute the prop from the expression whenever any field it reads
     // changes. One-way by nature — there is nothing to write back. One settled state change can notify
@@ -289,9 +323,10 @@ function wireBinding(
         if (typeof v.checkValidity === "function" && !v.checkValidity()) return;
         store.set(spec.field!, readProp(el, prop));
       };
-      for (const ev of VALUE_EVENTS) el.addEventListener(ev, onChange);
+      const events = spec.event ? [spec.event] : VALUE_EVENTS;
+      for (const ev of events) el.addEventListener(ev, onChange);
       teardowns.push(() => {
-        for (const ev of VALUE_EVENTS) el.removeEventListener(ev, onChange);
+        for (const ev of events) el.removeEventListener(ev, onChange);
       });
     }
   }

--- a/js/src/ts/ui.ts
+++ b/js/src/ts/ui.ts
@@ -1,0 +1,53 @@
+// The native baseline for spaday's generic controls (`spaday.ui`, resolved by the `native` design):
+// plain `<button>` / `<input>` / `<select>` / `<dialog>` elements marked with `data-ui`, styled from
+// the `--spa-*` shell palette so they follow the page mode and any app-level theme. A design-system
+// package replaces these with its own elements; this is what an app gets with none installed, and
+// the reference every realization is checked against.
+
+const BORDER = "var(--spa-border, #e6e6e6)";
+const SURFACE = "var(--spa-surface, #fff)";
+const MUTED = "var(--spa-muted, #666)";
+
+export const UI_CSS = `[data-ui]{box-sizing:border-box;font:inherit;color:inherit}
+[data-ui=button]{display:inline-flex;align-items:center;justify-content:center;gap:.4rem;padding:.45rem .9rem;border:1px solid ${BORDER};border-radius:8px;background:${SURFACE};cursor:pointer;line-height:1.2}
+[data-ui=button][data-size=sm]{padding:.3rem .6rem;font-size:.85em}
+[data-ui=button][data-size=lg]{padding:.6rem 1.2rem;font-size:1.1em}
+[data-ui=button][data-intent=primary]{--ui-tone:var(--spa-accent, #4a90d9)}
+[data-ui=button][data-intent=info]{--ui-tone:var(--spa-info, #1565c0)}
+[data-ui=button][data-intent=success]{--ui-tone:var(--spa-success, #2e7d32)}
+[data-ui=button][data-intent=warning]{--ui-tone:var(--spa-warning, #9a6700)}
+[data-ui=button][data-intent=danger]{--ui-tone:var(--spa-danger, #c62828)}
+[data-ui=button][data-intent]:not([data-intent=neutral]){background:var(--ui-tone);border-color:var(--ui-tone);color:#fff}
+[data-ui=button][data-appearance=outline]{background:transparent;color:var(--ui-tone, inherit);border-color:var(--ui-tone, ${BORDER})}
+[data-ui=button][data-appearance=plain]{background:transparent;border-color:transparent;color:var(--ui-tone, inherit)}
+[data-ui=button]:hover:not(:disabled){filter:brightness(.95)}
+[data-ui=button]:disabled{opacity:.5;cursor:default}
+[data-ui=field]{display:flex;flex-direction:column;gap:.3rem;font-size:.95rem}
+[data-ui=field][data-inline]{flex-direction:row;align-items:center;gap:.5rem}
+[data-ui=label]{font-weight:600}
+[data-ui=help]{color:${MUTED};font-size:.8rem}
+[data-ui=error]{color:var(--spa-danger, #c62828);font-size:.8rem}
+[data-ui=input],[data-ui=select]{padding:.45rem .6rem;border:1px solid ${BORDER};border-radius:8px;background:${SURFACE}}
+[data-ui=input][data-size=sm],[data-ui=select][data-size=sm]{padding:.3rem .5rem;font-size:.85em}
+[data-ui=input][data-size=lg],[data-ui=select][data-size=lg]{padding:.6rem .8rem;font-size:1.1em}
+[data-ui=input][data-invalid],[data-ui=select][data-invalid]{border-color:var(--spa-danger, #c62828)}
+[data-ui=input]:focus-visible,[data-ui=select]:focus-visible,[data-ui=button]:focus-visible{outline:2px solid var(--spa-accent, #4a90d9);outline-offset:1px}
+[data-ui=checkbox]{width:1rem;height:1rem;margin:0;accent-color:var(--spa-accent, #4a90d9)}
+[data-ui=switch]{appearance:none;width:2.2rem;height:1.2rem;margin:0;border-radius:1rem;background:${BORDER};position:relative;cursor:pointer;transition:background .15s}
+[data-ui=switch]::before{content:"";position:absolute;top:.15rem;left:.15rem;width:.9rem;height:.9rem;border-radius:50%;background:${SURFACE};transition:left .15s}
+[data-ui=switch]:checked{background:var(--spa-accent, #4a90d9)}
+[data-ui=switch]:checked::before{left:1.15rem}
+[data-ui=checkbox]:disabled,[data-ui=switch]:disabled{opacity:.5;cursor:default}
+[data-ui=dialog]{min-width:20rem;max-width:90vw;padding:1.25rem;border:1px solid ${BORDER};border-radius:12px;background:${SURFACE};box-shadow:0 12px 40px rgba(0,0,0,.25)}
+[data-ui=dialog]::backdrop{background:rgba(0,0,0,.4)}
+[data-ui=title]{margin:0 0 .75rem;font-size:1.1rem;font-weight:600}`;
+
+if (
+  typeof document !== "undefined" &&
+  !document.querySelector("style[data-spaday-ui]")
+) {
+  const style = document.createElement("style");
+  style.setAttribute("data-spaday-ui", "");
+  style.textContent = UI_CSS;
+  document.head.append(style);
+}

--- a/js/tests/ui.spec.js
+++ b/js/tests/ui.spec.js
@@ -1,0 +1,173 @@
+import { expect, test } from "@playwright/test";
+import { spawn } from "node:child_process";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+/* The generic controls (spaday.ui): the runtime features their designs rely on, and the
+ * conformance page rendered by the native baseline. A design-system package runs the same page
+ * (`python -m spaday.ui.conformance PORT --package <name>`) against its own design.
+ */
+
+const REPO = fileURLToPath(new URL("../..", import.meta.url));
+
+test.describe("binding features for designs", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/tests/runtime.html");
+    await page.waitForFunction(() => window.__spaday);
+  });
+
+  test("a two-way binding can name the event it writes back on", async ({
+    page,
+  }) => {
+    const r = await page.evaluate(() => {
+      const store = new window.__spaday.Store({ name: "" });
+      const el = window.__spaday.mount(
+        document.body,
+        {
+          tag: "input",
+          bindings: {
+            value: { field: "name", mode: "two-way", event: "x-changed" },
+          },
+        },
+        store,
+      );
+      el.value = "typed";
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+      const afterInput = store.get("name");
+      el.dispatchEvent(new Event("x-changed", { bubbles: true }));
+      return { afterInput, afterCustom: store.get("name") };
+    });
+    expect(r).toEqual({ afterInput: "", afterCustom: "typed" });
+  });
+
+  test("a binding can drive an overlay by its method pair and follow its own close", async ({
+    page,
+  }) => {
+    const r = await page.evaluate(() => {
+      const store = new window.__spaday.Store({ open: false });
+      const el = window.__spaday.mount(
+        document.body,
+        {
+          tag: "dialog",
+          bindings: {
+            open: {
+              field: "open",
+              mode: "two-way",
+              event: "close",
+              methods: ["showModal", "close"],
+            },
+          },
+        },
+        store,
+      );
+      const states = [el.open];
+      store.set("open", true);
+      states.push(el.open);
+      store.set("open", true); // showModal() on an open dialog would throw; the runtime skips it
+      states.push(el.open);
+      store.set("open", false);
+      states.push(el.open);
+      el.showModal();
+      el.close(); // the element closing itself writes the field back
+      return { states, field: store.get("open") };
+    });
+    expect(r).toEqual({ states: [false, true, true, false], field: false });
+  });
+});
+
+test.describe("the conformance page with the native baseline", () => {
+  let child;
+  let url;
+
+  test.beforeAll(async () => {
+    const port = await new Promise((resolve, reject) => {
+      const server = net.createServer();
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address();
+        server.close(() => resolve(port));
+      });
+    });
+    url = `http://127.0.0.1:${port}`;
+    child = spawn(
+      process.env.PYTHON || "python",
+      ["-m", "spaday.ui.conformance", String(port)],
+      { cwd: REPO, stdio: "ignore" },
+    );
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+      try {
+        if ((await fetch(url)).ok) return;
+      } catch {
+        await new Promise((r) => setTimeout(r, 200));
+      }
+    }
+    throw new Error("the conformance server did not start");
+  });
+
+  test.afterAll(() => child?.kill());
+
+  // a control's text input: the host itself, or the input a design's element wraps
+  const input = (page, id) =>
+    page
+      .locator(`#${id}`)
+      .locator("input")
+      .or(page.locator(`#${id}`))
+      .last();
+
+  test("every control round-trips through the store", async ({ page }) => {
+    await page.goto(url);
+    const state = page.locator("#state");
+    await expect(state).toHaveText("|false|false|basic|false|false");
+    await input(page, "name").fill("Ada");
+    await expect(state).toHaveText("Ada|false|false|basic|false|false");
+    await page.locator("#agree").click();
+    await page.locator("#dark").click();
+    await expect(state).toHaveText("Ada|true|true|basic|false|false");
+    await page.locator("#save").click();
+    await expect(state).toHaveText("Ada|true|true|basic|true|false");
+    await page.locator("#reset").click();
+    await expect(state).toHaveText("|true|true|basic|false|false");
+  });
+
+  test("a select changes the bound field", async ({ page }) => {
+    await page.goto(url);
+    const select = page.locator("#plan");
+    if ((await select.evaluate((el) => el.localName)) === "select")
+      await select.selectOption("plus");
+    else {
+      await select.click();
+      await page.getByRole("option", { name: "Plus" }).click();
+    }
+    await expect(page.locator("#state")).toContainText("|plus|");
+  });
+
+  test("the dialog opens from state, closes from a button and reports its own close", async ({
+    page,
+  }) => {
+    await page.goto(url);
+    const dialog = page.locator("#dialog");
+    await expect(dialog).toHaveJSProperty("open", false);
+    await page.locator("#open").click();
+    await expect(dialog).toHaveJSProperty("open", true);
+    await expect(dialog).toContainText("Confirm");
+    await page.locator("#close").click();
+    await expect(dialog).toHaveJSProperty("open", false);
+    await page.locator("#open").click();
+    await expect(dialog).toHaveJSProperty("open", true);
+    await page.keyboard.press("Escape");
+    await expect(dialog).toHaveJSProperty("open", false);
+    await expect(page.locator("#state")).toHaveText(
+      "|false|false|basic|false|false",
+    );
+  });
+
+  test("labels, help, errors and disabled state render", async ({ page }) => {
+    await page.goto(url);
+    await expect(page.getByText("Your name")).toBeVisible();
+    await expect(page.getByText("Required")).toBeVisible();
+    await expect(page.locator("#never")).toHaveJSProperty("disabled", true);
+    await expect(page.locator("#save")).toHaveText("Save");
+    expect(await page.locator("[data-ui-fallback]").count()).toBe(0);
+  });
+});

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -502,8 +502,8 @@ mod diff_tests {
                     field: Some("lit".into()), // field changed
                     compute: None,
                     mode: BindMode::TwoWay,
-                event: None,
-                methods: None,
+                    event: None,
+                    methods: None,
                 },
             )
             .bind(
@@ -512,8 +512,8 @@ mod diff_tests {
                     field: Some("locked".into()), // added
                     compute: None,
                     mode: BindMode::OneWay,
-                event: None,
-                methods: None,
+                    event: None,
+                    methods: None,
                 },
             );
         let patch = assert_round_trip(&old, &new);
@@ -572,8 +572,8 @@ mod diff_tests {
             field: Some(field.into()),
             compute: None,
             mode: BindMode::OneWay,
-                event: None,
-                methods: None,
+            event: None,
+            methods: None,
         };
         let old = Node::new("spa-each")
             .prop("itemKey", "id")

--- a/rust/src/diff.rs
+++ b/rust/src/diff.rs
@@ -491,6 +491,8 @@ mod diff_tests {
                 field: Some("on".into()),
                 compute: None,
                 mode: BindMode::TwoWay,
+                event: None,
+                methods: None,
             },
         );
         let new = Node::new("wa-switch")
@@ -500,6 +502,8 @@ mod diff_tests {
                     field: Some("lit".into()), // field changed
                     compute: None,
                     mode: BindMode::TwoWay,
+                event: None,
+                methods: None,
                 },
             )
             .bind(
@@ -508,6 +512,8 @@ mod diff_tests {
                     field: Some("locked".into()), // added
                     compute: None,
                     mode: BindMode::OneWay,
+                event: None,
+                methods: None,
                 },
             );
         let patch = assert_round_trip(&old, &new);
@@ -525,6 +531,8 @@ mod diff_tests {
                 field: None,
                 compute: Some(expr),
                 mode: BindMode::OneWay,
+                event: None,
+                methods: None,
             },
         );
         let patch = assert_round_trip(&old, &new);
@@ -564,6 +572,8 @@ mod diff_tests {
             field: Some(field.into()),
             compute: None,
             mode: BindMode::OneWay,
+                event: None,
+                methods: None,
         };
         let old = Node::new("spa-each")
             .prop("itemKey", "id")

--- a/rust/src/node.rs
+++ b/rust/src/node.rs
@@ -44,6 +44,17 @@ pub struct Binding {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compute: Option<serde_json::Value>,
     pub mode: BindMode,
+    /// Two-way only: the DOM event on which the control's value is written back to the field, for a
+    /// control whose change event is not `change`/`input` (a Lion control's `model-value-changed`).
+    /// Absent, the runtime listens for its default events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event: Option<EventName>,
+    /// Drive the prop by calling a method pair instead of assigning it: `[open, close]` — the first
+    /// is called when the field turns truthy, the second when it turns falsy. For overlays that open
+    /// through methods (`<dialog>`'s `showModal()`/`close()`, a popover's `showPopover()`); the prop
+    /// itself is then what the runtime reads to know the current state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub methods: Option<[EventName; 2]>,
 }
 
 /// A node in the component tree.

--- a/spaday/__init__.py
+++ b/spaday/__init__.py
@@ -48,6 +48,7 @@ from .packages import ComponentPackage, discover_component_package_names, discov
 from .render import render_html
 from .spaday import apply, decode_frame, diff, encode_frame, parse_cem  # compiled Rust extension (rust/python)
 from .theme import SHELL_TOKENS
+from .ui import Button, Checkbox, Design, Dialog, Select, Switch as ToggleSwitch, TextInput
 from .validate import ValidationError, validate
 from .worker import WorkerApp
 
@@ -79,6 +80,14 @@ __all__ = [
     "Strong",
     "Text",
     "Toggle",
+    # generic controls (spaday.ui) — ToggleSwitch is spaday.ui.Switch, beside the shell's Switch router
+    "Button",
+    "Checkbox",
+    "Design",
+    "Dialog",
+    "Select",
+    "TextInput",
+    "ToggleSwitch",
     "ToggleField",
     "ValidationError",
     "WorkerApp",

--- a/spaday/backends/aiohttp.py
+++ b/spaday/backends/aiohttp.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from ..bootstrap import AssetLayout, Page, bootstrap, bundles_dir, tree_frame, tree_json
 from ..packages import PackageRef, package_url_prefix, resolve_component_packages
+from ..ui.design import Design, select_design
 
 if TYPE_CHECKING:  # annotations only — aiohttp is imported inside the functions (not a spaday dependency)
     from aiohttp import web
@@ -42,6 +43,7 @@ def mount(
     stylesheets: Sequence[str] = (),
     styles: Sequence[str] = (),
     head: str = "",
+    design: Design | str | None = None,
 ) -> web.Application:
     """Add spaday's routes to an existing aiohttp ``app`` under ``prefix``. ``routes`` is a list of
     ``aiohttp.web`` route defs (``web.get(...)`` — including your ``{prefix}/ws`` handler when wiring
@@ -50,6 +52,7 @@ def mount(
 
     asset_layout = layout or ("source" if js is not None else None)
     component_packages = resolve_component_packages(packages)
+    page_design = select_design(design, component_packages)
     body = bootstrap(
         base=prefix,
         packages=component_packages,
@@ -72,13 +75,13 @@ def mount(
     if tree == "frame":
 
         async def tree_handler(_request):
-            return web.Response(body=tree_frame(page), content_type="application/octet-stream")
+            return web.Response(body=tree_frame(page, design=page_design), content_type="application/octet-stream")
 
         tree_route = web.get(f"{prefix}/tree", tree_handler)
     else:
 
         async def tree_handler(_request):
-            return web.Response(text=tree_json(page), content_type="application/json")
+            return web.Response(text=tree_json(page, page_design), content_type="application/json")
 
         tree_route = web.get(f"{prefix}/tree.json", tree_handler)
 

--- a/spaday/backends/flask.py
+++ b/spaday/backends/flask.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from ..bootstrap import AssetLayout, Page, bootstrap, bundles_dir, tree_frame, tree_json
 from ..packages import PackageRef, package_url_prefix, resolve_component_packages
+from ..ui.design import Design, select_design
 
 if TYPE_CHECKING:  # annotations only — flask is imported inside the functions (not a spaday dependency)
     from flask import Flask
@@ -40,6 +41,7 @@ def mount(
     stylesheets: Sequence[str] = (),
     styles: Sequence[str] = (),
     head: str = "",
+    design: Design | str | None = None,
 ) -> Flask:
     """Add spaday's routes to an existing Flask ``app`` under ``prefix``. ``routes`` is a list of
     ``(rule, endpoint, view_func)`` tuples. Endpoints are keyed by ``prefix`` so several spaday pages can
@@ -48,6 +50,7 @@ def mount(
 
     asset_layout = layout or ("source" if js is not None else None)
     component_packages = resolve_component_packages(packages)
+    page_design = select_design(design, component_packages)
     body = bootstrap(
         base=prefix,
         packages=component_packages,
@@ -67,9 +70,11 @@ def mount(
 
     app.add_url_rule(f"{prefix}/", f"spaday_index_{key}", lambda: Response(body, mimetype="text/html"))
     if tree == "frame":
-        app.add_url_rule(f"{prefix}/tree", f"spaday_tree_{key}", lambda: Response(tree_frame(page), mimetype="application/octet-stream"))
+        app.add_url_rule(
+            f"{prefix}/tree", f"spaday_tree_{key}", lambda: Response(tree_frame(page, design=page_design), mimetype="application/octet-stream")
+        )
     else:
-        app.add_url_rule(f"{prefix}/tree.json", f"spaday_tree_{key}", lambda: Response(tree_json(page), mimetype="application/json"))
+        app.add_url_rule(f"{prefix}/tree.json", f"spaday_tree_{key}", lambda: Response(tree_json(page, page_design), mimetype="application/json"))
     app.add_url_rule(f"{prefix}/js/<path:path>", f"spaday_js_{key}", lambda path: send_from_directory(js_dir, path))
     for package in component_packages:
         package_dir = package.assets_dir

--- a/spaday/backends/starlette.py
+++ b/spaday/backends/starlette.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from ..bootstrap import AssetLayout, Page, Wire, bootstrap, bundles_dir, tree_frame, tree_json
 from ..packages import PackageRef, package_url_prefix, resolve_component_packages
+from ..ui.design import Design, select_design
 
 if TYPE_CHECKING:  # annotations only — starlette is imported inside the functions (optional extra)
     from starlette.applications import Starlette
@@ -67,6 +68,7 @@ def mount(
     nonce: str | None = None,
     persist: dict[str, str] | None = None,
     url: dict[str, str] | None = None,
+    design: Design | str | None = None,
 ) -> Starlette:
     """Add spaday's routes (page, tree, ``/js``, plus ``routes``) to an existing Starlette ``app`` under
     ``prefix``. The supplied ``routes`` are **prefixed too** (a ``Route``/``WebSocketRoute`` at ``/ws``
@@ -82,6 +84,7 @@ def mount(
 
     asset_layout = layout or ("source" if js is not None else None)
     component_packages = resolve_component_packages(packages)
+    page_design = select_design(design, component_packages)
     body = bootstrap(
         base=prefix,
         packages=component_packages,
@@ -106,10 +109,10 @@ def mount(
         return FileResponse(html) if html is not None else HTMLResponse(body)
 
     async def tree_route_json(_request):
-        return Response(tree_json(page), media_type="application/json")
+        return Response(tree_json(page, page_design), media_type="application/json")
 
     async def tree_route_frame(_request):
-        return Response(tree_frame(page), media_type="application/octet-stream")
+        return Response(tree_frame(page, design=page_design), media_type="application/octet-stream")
 
     tree_route = Route(f"{prefix}/tree", tree_route_frame) if tree == "frame" else Route(f"{prefix}/tree.json", tree_route_json)
     package_mounts = [Mount(package_url_prefix(package, prefix), StaticFiles(directory=package.assets_dir)) for package in component_packages]

--- a/spaday/backends/tornado.py
+++ b/spaday/backends/tornado.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from ..bootstrap import AssetLayout, Page, bootstrap, bundles_dir, tree_frame, tree_json
 from ..packages import PackageRef, package_url_prefix, resolve_component_packages
+from ..ui.design import Design, select_design
 
 if TYPE_CHECKING:  # annotations only — tornado is imported inside the functions (not a spaday dependency)
     from tornado.web import Application
@@ -43,6 +44,7 @@ def mount(
     stylesheets: Sequence[str] = (),
     styles: Sequence[str] = (),
     head: str = "",
+    design: Design | str | None = None,
 ) -> Application:
     """Add spaday's handlers to an existing Tornado ``app`` under ``prefix``. ``routes`` is a list of
     Tornado handler tuples (``(pattern, Handler[, kwargs])`` — including your ``{prefix}/ws`` handler when
@@ -51,6 +53,7 @@ def mount(
 
     asset_layout = layout or ("source" if js is not None else None)
     component_packages = resolve_component_packages(packages)
+    page_design = select_design(design, component_packages)
     body = bootstrap(
         base=prefix,
         packages=component_packages,
@@ -78,7 +81,7 @@ def mount(
         class _Tree(RequestHandler):
             def get(self):
                 self.set_header("Content-Type", "application/octet-stream")
-                self.write(tree_frame(page))
+                self.write(tree_frame(page, design=page_design))
 
         tree_rule = (rf"{pre}/tree", _Tree)
     else:
@@ -86,7 +89,7 @@ def mount(
         class _Tree(RequestHandler):
             def get(self):
                 self.set_header("Content-Type", "application/json")
-                self.write(tree_json(page))
+                self.write(tree_json(page, page_design))
 
         tree_rule = (rf"{pre}/tree\.json", _Tree)
 

--- a/spaday/bootstrap.py
+++ b/spaday/bootstrap.py
@@ -41,6 +41,7 @@ from typing import Literal, Union
 from .component import Component
 from .packages import ComponentPackage, PackageRef, npm_package, package_url_prefix, resolve_component_packages
 from .spaday import encode_frame  # compiled core (always available); used by tree_frame
+from .ui.design import Design, resolve, select_design
 
 #: A page is a built :class:`~spaday.component.Component`, or a zero-arg callable returning one (called
 #: per request, so the tree can reflect current state).
@@ -167,16 +168,23 @@ def _resolve(page: Page) -> Component:
     return page() if callable(page) else page
 
 
-def tree_json(page: Page) -> str:
+def tree_node(page: Page, design: Design | str | None = None) -> dict:
+    """The authored tree as a node dict, its generic controls (:mod:`spaday.ui`) rendered by
+    ``design`` — a :class:`~spaday.ui.design.Design`, ``"native"``, or ``None`` for the native
+    baseline. A backend passes the design it chose from the page's packages."""
+    return resolve(_resolve(page).to_node(), select_design(design))
+
+
+def tree_json(page: Page, design: Design | str | None = None) -> str:
     """The authored tree as a JSON string (serve at ``GET {base}/tree.json``)."""
-    return json.dumps(_resolve(page).to_node())
+    return json.dumps(tree_node(page, design))
 
 
-def tree_frame(page: Page, *, id: str = "spa-tree") -> bytes:
+def tree_frame(page: Page, *, id: str = "spa-tree", design: Design | str | None = None) -> bytes:
     """The authored tree as a transports Snapshot frame (serve at ``GET {base}/tree`` for ``tree="frame"``)
     — the same length-prefixed, codec-tagged envelope transports uses for model state, so the UI tree and
     the model data ride one wire."""
-    return encode_frame(json.dumps(_resolve(page).to_node()), id, "snapshot", 0, "application/json")
+    return encode_frame(json.dumps(tree_node(page, design)), id, "snapshot", 0, "application/json")
 
 
 def _package_head(packages: Sequence[ComponentPackage], base: str, nonce: str | None = None) -> str:

--- a/spaday/component.py
+++ b/spaday/component.py
@@ -336,16 +336,30 @@ class Component:
         self._events[event] = action.to_dict()
         return self
 
-    def bind(self, prop: str, field: str, *, mode: str = "one-way") -> "Component":
+    def bind(self, prop: str, field: str, *, mode: str = "one-way", event: str | None = None, methods: tuple[str, str] | None = None) -> "Component":
         """Reactively bind a ``prop`` to a state ``field`` in the runtime's signal store.
 
         ``mode="one-way"`` keeps the prop in sync with the field; ``"two-way"`` also writes the field
         back when the control changes (for value-like controls). The binding is data interpreted in the
         browser — the field's value flows to the prop with no round-trip to Python.
+
+        A two-way binding writes back on ``change`` / ``input``; ``event`` names the event instead, for
+        a control that reports its changes otherwise (a Lion control's ``model-value-changed``).
+        ``methods`` — ``("open", "close")`` — drives the prop by calling those methods on the element
+        as the field turns truthy / falsy instead of setting it, for an overlay that opens by method
+        (``bind("open", "confirm", mode="two-way", event="close", methods=("showModal", "close"))`` on
+        a ``<dialog>``); the prop then names the element's own state, read back on ``event``.
         """
         if mode not in ("one-way", "two-way"):
             raise ValueError(f"bind mode must be 'one-way' or 'two-way', not {mode!r}")
-        self._bindings[prop] = {"field": field, "mode": mode}
+        binding: dict[str, Any] = {"field": field, "mode": mode}
+        if event is not None:
+            binding["event"] = event
+        if methods is not None:
+            if len(methods) != 2 or not all(isinstance(m, str) and m for m in methods):
+                raise ValueError("bind methods must be an (open, close) pair of method names")
+            binding["methods"] = list(methods)
+        self._bindings[prop] = binding
         return self
 
     def compute(self, prop: str, expr: Expr) -> "Component":

--- a/spaday/packages.py
+++ b/spaday/packages.py
@@ -12,6 +12,7 @@ from pathlib import Path, PurePosixPath
 from .catalog import ComponentSchema
 from .component import Component
 from .semver import parse_range, parse_version, satisfies
+from .ui.design import Design
 
 ENTRY_POINT_GROUP = "spaday.component_packages"
 _PACKAGE_NAME = re.compile(r"[a-z0-9][a-z0-9._-]*\Z")
@@ -44,6 +45,9 @@ class ComponentPackage:
     ``provides`` records the JS libraries the package puts on the page, by npm
     name, with the exact version it serves (``{"@awesome.me/webawesome": "3.1.0"}``);
     a package's build writes them, so the Python side knows what the browser gets.
+    ``design`` publishes the package's :class:`~spaday.ui.design.Design` — how it renders the
+    generic controls of :mod:`spaday.ui` — which a page selecting the package renders with.
+
     ``requires`` records libraries the package's own bundle imports without
     shipping, with the npm version range it was built against
     (``{"@awesome.me/webawesome": "^3.1.0"}``). :func:`resolve_component_packages`
@@ -61,8 +65,11 @@ class ComponentPackage:
     imports: Sequence[tuple[str, str]] = ()
     provides: Mapping[str, str] | Sequence[tuple[str, str]] = ()
     requires: Mapping[str, str] | Sequence[tuple[str, str]] = ()
+    design: Design | None = None
 
     def __post_init__(self) -> None:
+        if self.design is not None and not isinstance(self.design, Design):
+            raise TypeError(f"component package design must be a spaday.ui.Design, got {type(self.design).__name__}")
         if not _PACKAGE_NAME.fullmatch(self.name):
             raise ValueError("component package name must contain only lowercase letters, digits, '.', '_', or '-'")
         normalized = []

--- a/spaday/render.py
+++ b/spaday/render.py
@@ -21,14 +21,15 @@ import html
 from typing import Any
 
 from .component import DEFAULT_SLOT, Component
+from .ui.design import Design, resolve, select_design
 
 #: Raw-HTML void elements (no close tag). Web components are never void.
 _VOID = {"area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"}
 
 
-def render_html(tree: Component | dict) -> str:
+def render_html(tree: Component | dict, design: Design | str | None = None) -> str:
     """Render a component (or an already-built node dict) to a light-DOM HTML string for hydration."""
-    return _render(tree.to_node() if isinstance(tree, Component) else tree, None)
+    return _render(resolve(tree.to_node() if isinstance(tree, Component) else tree, select_design(design)), None)
 
 
 def _render(node: dict, slot: str) -> str:

--- a/spaday/tests/test_ui.py
+++ b/spaday/tests/test_ui.py
@@ -1,0 +1,253 @@
+import json
+
+import pytest
+
+import spaday
+from spaday import (
+    Button,
+    Checkbox,
+    ComponentPackage,
+    Design,
+    Dialog,
+    Select,
+    TextInput,
+    ToggleSwitch,
+    ValidationError,
+    element,
+    field,
+    render_html,
+    validate,
+)
+from spaday.bootstrap import tree_json
+from spaday.components.shell import Column
+from spaday.ui import NATIVE, ControlSpec, Open, Options, Part, Value, Wrap, conformance, resolve, select_design
+from spaday.ui.controls import CONTROLS, Switch
+from spaday.worker import WorkerApp
+
+
+def _plain(node: dict) -> dict:
+    """Props untagged throughout, for readable assertions."""
+    from spaday.ui.design import _plain as plain
+
+    out = {**node, "props": {k: plain(v) for k, v in node.get("props", {}).items()}}
+    if "slots" in node:
+        out["slots"] = {slot: [_plain(c) if isinstance(c, dict) else c for c in children] for slot, children in node["slots"].items()}
+    return out
+
+
+def test_controls_serialize_to_generic_nodes_with_schemas():
+    assert set(CONTROLS) == {"button", "input", "checkbox", "switch", "select", "dialog"}
+    assert ToggleSwitch is Switch
+    node = Button(label="Save", intent="primary").to_node()
+    assert node == {"tag": "ui-button", "props": {"label": {"Str": "Save"}, "intent": {"Str": "primary"}}}
+    with pytest.raises(TypeError, match="expects kind 'enum'"):
+        Button(intent=3)
+    # validate() knows the generic vocabulary, and hints at it
+    with pytest.raises(ValidationError, match="<ui-button> unknown prop 'intnet'"):
+        validate(Column(Button(label="x", intnet="primary")))
+
+
+def test_native_button_and_dialog():
+    button = _plain(resolve(Button(label="Save", intent="primary", appearance="outline", size="lg", disabled=True, id="b").to_node(), NATIVE))
+    assert button["tag"] == "button"
+    assert button["props"] == {
+        "type": "button",
+        "data-ui": "button",
+        "textContent": "Save",
+        "data-intent": "primary",
+        "data-appearance": "outline",
+        "data-size": "lg",
+        "disabled": True,
+        "id": "b",
+    }
+    dialog = _plain(resolve(Dialog(element("p"), label="Confirm", id="d").bind("open", "open", mode="two-way").to_node(), NATIVE))
+    assert dialog["tag"] == "dialog"
+    assert [c["tag"] for c in dialog["slots"]["default"]] == ["h2", "p"]  # the title leads the content
+    assert dialog["bindings"] == {"open": {"field": "open", "mode": "two-way", "event": "close", "methods": ["showModal", "close"]}}
+
+
+def test_native_field_wraps_the_control_with_its_parts():
+    node = _plain(
+        resolve(
+            TextInput(id="name", label="Name", help="Hint", error="Bad", placeholder="Ada", type="email")
+            .bind("value", "name", mode="two-way")
+            .to_node(),
+            NATIVE,
+        )
+    )
+    assert node["tag"] == "label" and node["props"] == {"data-ui": "field"}
+    label, control, help_, error = node["slots"]["default"]
+    assert (label["props"]["textContent"], help_["props"]["textContent"], error["props"]["textContent"]) == ("Name", "Hint", "Bad")
+    assert control["props"] == {"data-ui": "input", "data-invalid": True, "id": "name", "placeholder": "Ada", "type": "email"}
+    assert control["bindings"] == {"value": {"field": "name", "mode": "two-way"}}
+    # a toggle's value is its checked state, and its label follows it
+    box = _plain(resolve(Checkbox(label="Agree", value=True).bind("value", "agree", mode="two-way").to_node(), NATIVE))
+    control, label = box["slots"]["default"]
+    assert control["props"] == {"type": "checkbox", "data-ui": "checkbox", "checked": True}
+    assert control["bindings"] == {"checked": {"field": "agree", "mode": "two-way"}}
+    assert label["props"]["textContent"] == "Agree"
+
+
+def test_native_select_renders_options_as_children_and_preselects_the_value():
+    node = _plain(resolve(Select(label="Plan", options=["a", {"value": "b", "label": "B"}], value="b", placeholder="Pick").to_node(), NATIVE))
+    select = node["slots"]["default"][1]
+    assert select["tag"] == "select" and "placeholder" not in select["props"]  # unsupported here, dropped
+    assert [(o["props"]["value"], o["props"]["textContent"], o["props"].get("selected")) for o in select["slots"]["default"]] == [
+        ("a", "a", None),
+        ("b", "B", True),
+    ]
+    with pytest.raises(ValueError, match="binds its options, which design 'native' renders as child elements"):
+        resolve(Select(label="Plan").bind("options", "plans").to_node(), NATIVE)
+
+
+def _design(**controls) -> Design:
+    return Design(name="test", controls=controls)
+
+
+def test_a_design_maps_names_values_parts_events_and_bindings():
+    design = _design(
+        button=ControlSpec(
+            tag="x-button",
+            label=Part(kind="text"),
+            props={"intent": "variant", "size": None},
+            values={"intent": {"primary": "brand"}},
+            events={"click": "x-press"},
+        ),
+        input=ControlSpec(
+            tag="x-input",
+            label=Part(kind="attr", name="label"),
+            help=Part(kind="slot", name="hint"),
+            error=Part(kind="attr", name="error-message"),
+            invalid={"invalid": True},
+            value=Value(prop="text", event="x-changed"),
+        ),
+    )
+    button = _plain(resolve(Button(label="Go", intent="primary", size="lg").on("click", spaday.SetField("x", 1)).to_node(), design))
+    assert button["props"] == {"textContent": "Go", "variant": "brand"}  # size is unsupported: dropped, not leaked
+    assert list(button["events"]) == ["x-press"]
+    text = _plain(
+        resolve(TextInput(label="Name", help="Hint", error="Bad").bind("value", "name", mode="two-way").bind("label", "caption").to_node(), design)
+    )
+    assert text["props"] == {"label": "Name", "error-message": "Bad", "invalid": True}
+    assert text["slots"] == {"hint": [{"tag": "span", "props": {"slot": "hint", "textContent": "Hint"}}]}
+    assert text["bindings"] == {"text": {"field": "name", "mode": "two-way", "event": "x-changed"}, "label": {"field": "caption", "mode": "one-way"}}
+
+
+def test_options_as_a_property_and_a_wrapped_child_list():
+    by_prop = _design(select=ControlSpec(tag="x-select", options=Options(kind="prop", name="items", value="key", label="text")))
+    node = _plain(resolve(Select(options=["a", {"value": "b", "label": "B"}]).bind("options", "plans").to_node(), by_prop))
+    assert node["props"]["items"] == [{"key": "a", "text": "a"}, {"key": "b", "text": "B"}]
+    assert node["bindings"] == {"items": {"field": "plans", "mode": "one-way"}}
+    wrapped = _design(select=ControlSpec(tag="x-dropdown", options=Options(kind="children", tag="x-option", wrap="x-listbox", label="label")))
+    node = _plain(resolve(Select(options=["a"]).to_node(), wrapped))
+    listbox = node["slots"]["default"][0]
+    assert listbox["tag"] == "x-listbox" and listbox["slots"]["default"][0]["props"] == {"value": "a", "label": "a"}
+
+
+def test_a_wrapped_design_keeps_key_outside_and_id_on_the_control():
+    design = _design(
+        input=ControlSpec(
+            tag="x-input",
+            wrap=Wrap(tag="x-field", props={"layout": "above"}, control={"slot": "input"}),
+            label=Part(kind="sibling", tag="x-label", props={"slot": "label"}),
+        )
+    )
+    node = _plain(resolve(TextInput(id="name", label="Name", key="k1").to_node(), design))
+    assert node["tag"] == "x-field" and node["key"] == "k1" and node["props"] == {"layout": "above"}
+    label, control = node["slots"]["default"]
+    assert label["props"] == {"slot": "label", "textContent": "Name"}
+    assert control["props"] == {"id": "name", "slot": "input"}
+    with pytest.raises(ValueError, match="declares no wrap"):
+        resolve(TextInput(label="x").to_node(), _design(input=ControlSpec(tag="x-input", label=Part(kind="sibling"))))
+
+
+def test_a_missing_control_falls_back_to_native_and_says_so():
+    node = _plain(resolve(Button(label="Go").to_node(), _design()))
+    assert node["tag"] == "button" and node["props"]["data-ui-fallback"] == "native"
+    with pytest.raises(ValueError, match="not a generic control"):
+        resolve({"tag": "ui-slider"}, _design())
+
+
+def test_for_design_sets_a_designs_own_props():
+    design = _design(button=ControlSpec(tag="x-button", label=Part(kind="text"), props={"intent": "variant"}))
+    button = Button(label="Go", intent="primary").for_design("test", pill=True, variant="loud").for_design("other", tone="x")
+    assert _plain(resolve(button.to_node(), design))["props"] == {"textContent": "Go", "variant": "loud", "pill": True}
+    assert "ui:overrides" not in _plain(resolve(button.to_node(), NATIVE))["props"]
+
+
+def test_overlays_open_by_method_and_report_their_own_close():
+    design = _design(
+        dialog=ControlSpec(
+            tag="x-dialog", label=Part(kind="attr", name="heading"), open=Open(prop="opened", event="x-closed", methods=("show", "hide"))
+        )
+    )
+    node = _plain(resolve(Dialog(label="Hi", open=True).bind("open", "o", mode="two-way").to_node(), design))
+    assert node["props"] == {"heading": "Hi", "opened": True}
+    assert node["bindings"] == {"opened": {"field": "o", "mode": "two-way", "event": "x-closed", "methods": ["show", "hide"]}}
+
+
+def test_bind_carries_event_and_methods_through_the_core():
+    node = element("dialog").bind("open", "o", mode="two-way", event="close", methods=("showModal", "close"))
+    assert node.to_node()["bindings"]["open"] == {"field": "o", "mode": "two-way", "event": "close", "methods": ["showModal", "close"]}
+    patch = spaday.diff(element("dialog").to_json(), node.to_json())
+    assert json.loads(spaday.apply(element("dialog").to_json(), patch)) == node.to_node()
+    with pytest.raises(ValueError, match="pair of method names"):
+        element("dialog").bind("open", "o", methods=("show",))
+
+
+def test_select_design_follows_the_selected_packages():
+    design = _design(button=ControlSpec(tag="x-button"))
+    with_design = ComponentPackage("x", ".", (), design=design)
+    other = ComponentPackage("y", ".", (), design=_design())
+    plain = ComponentPackage("z", ".", ())
+    assert select_design(None, [plain]) is NATIVE
+    assert select_design(None, [plain, with_design]) is design
+    assert select_design("x", [with_design]) is design
+    assert select_design("native", [with_design]) is NATIVE
+    assert select_design(design, []) is design
+    with pytest.raises(ValueError, match="several selected packages publish a design \\('x', 'y'\\)"):
+        select_design(None, [with_design, other])
+    with pytest.raises(ValueError, match="no selected package publishes the design 'q'"):
+        select_design("q", [with_design])
+    with pytest.raises(TypeError, match="must be a spaday.ui.Design"):
+        ComponentPackage("x", ".", (), design={"name": "x"})
+
+
+def test_a_design_round_trips_as_data():
+    dumped = NATIVE.model_dump_json()
+    assert Design.model_validate_json(dumped) == NATIVE
+    with pytest.raises(ValueError):
+        ControlSpec(tag="x", labl=Part())  # a typo in a spec is an error, not a silently dropped mapping
+
+
+def test_every_serving_path_resolves_generic_controls():
+    page = Column(Button(label="Go"), TextInput(label="Name"))
+    assert "ui-" not in tree_json(page)
+    assert json.loads(tree_json(page))["slots"]["default"][0]["tag"] == "button"
+    html = render_html(page)
+    assert "<button" in html and "ui-button" not in html
+    worker = WorkerApp(lambda: page, lambda _intent: None)
+    assert worker.start()["tree"]["slots"]["default"][0]["tag"] == "button"
+
+
+def test_the_conformance_page_covers_every_control():
+    node = conformance.page().to_node()
+    tags = set()
+
+    def walk(n):
+        tags.add(n["tag"])
+        for children in n.get("slots", {}).values():
+            for child in children:
+                walk(child)
+
+    walk(node)
+    assert {f"ui-{kind}" for kind in CONTROLS} <= tags
+    assert set(conformance.store()) == {"name", "agree", "dark", "plan", "saved", "open"}
+    assert "ui-" not in json.dumps(resolve(node, NATIVE))
+
+
+def test_bound_state_reaches_a_designs_value_prop_untouched_by_value_maps():
+    """A bound intent is not mapped (its value is only known in the browser); a bound value is renamed."""
+    design = _design(button=ControlSpec(tag="x-button", props={"intent": "variant"}, values={"intent": {"primary": "brand"}}))
+    node = _plain(resolve(Button().compute("intent", field("tone")).to_node(), design))
+    assert "variant" in node["bindings"] and node["bindings"]["variant"]["compute"]["expr"] == "field"

--- a/spaday/tests/test_ui.py
+++ b/spaday/tests/test_ui.py
@@ -251,3 +251,62 @@ def test_bound_state_reaches_a_designs_value_prop_untouched_by_value_maps():
     design = _design(button=ControlSpec(tag="x-button", props={"intent": "variant"}, values={"intent": {"primary": "brand"}}))
     node = _plain(resolve(Button().compute("intent", field("tone")).to_node(), design))
     assert "variant" in node["bindings"] and node["bindings"]["variant"]["compute"]["expr"] == "field"
+
+
+def test_the_conformance_server_serves_the_page_with_the_chosen_design(monkeypatch):
+    import uvicorn
+
+    started = []
+    monkeypatch.setattr(uvicorn, "run", lambda app, **options: started.append((app, options)))
+    conformance.main(["8123", "--design", "native"])
+    app, options = started[0]
+    assert options == {"host": "127.0.0.1", "port": 8123, "log_level": "warning"}
+    from starlette.testclient import TestClient
+
+    tree = TestClient(app).get("/tree.json").json()
+    assert tree["props"]["id"] == {"Str": "conformance"} and "ui-" not in json.dumps(tree)
+
+
+def test_a_plain_dict_tree_resolves_too():
+    """A tree authored as dicts carries untagged values; they pass through the same mapping."""
+    node = resolve({"tag": "ui-button", "props": {"label": "Go", "intent": "danger", "disabled": True}}, NATIVE, fallback=NATIVE)
+    assert _plain(node)["props"] == {"type": "button", "data-ui": "button", "textContent": "Go", "data-intent": "danger", "disabled": True}
+
+
+def test_bound_parts_and_unsupported_bindings():
+    design = _design(
+        button=ControlSpec(tag="x-button", label=Part(kind="text"), props={"size": None}),
+        input=ControlSpec(tag="x-input", help=Part(kind="slot", name="hint"), error=Part(kind="none")),
+    )
+    button = _plain(resolve(Button().bind("label", "caption").bind("size", "sz").bind("readonly", "ro").to_node(), design))
+    # a bound label lands on the text; a binding the design maps to nothing, or does not know, is dropped
+    assert button["bindings"] == {"textContent": {"field": "caption", "mode": "one-way"}}
+    text = _plain(resolve(TextInput(error="Bad").bind("help", "hint").to_node(), design))
+    assert "error" not in text["props"]  # the design has nowhere to show it
+    assert text["slots"]["hint"][0]["bindings"] == {"textContent": {"field": "hint", "mode": "one-way"}}
+
+
+def test_options_bound_only_and_a_dialog_opened_one_way():
+    design = _design(
+        select=ControlSpec(tag="x-select", options=Options(kind="prop", name="items")),
+        dialog=ControlSpec(tag="x-dialog", open=Open(prop="opened", event="x-closed", methods=("show", "hide"))),
+    )
+    select = _plain(resolve(Select().bind("options", "plans").to_node(), design))
+    assert "items" not in select["props"] and select["bindings"] == {"items": {"field": "plans", "mode": "one-way"}}
+    dialog = _plain(resolve(Dialog(open=True).to_node(), design))
+    assert dialog["props"] == {"opened": True} and "bindings" not in dialog
+    one_way = _plain(resolve(Dialog().bind("open", "o").to_node(), design))
+    # one-way: driven by the methods, but the close event has nothing to write back to
+    assert one_way["bindings"] == {"opened": {"field": "o", "mode": "one-way", "methods": ["show", "hide"]}}
+
+
+def test_named_slots_pass_through_and_a_bare_wrap_has_no_props():
+    design = _design(
+        dialog=ControlSpec(tag="x-dialog", label=Part(kind="child", tag="h1", after=True)),
+        input=ControlSpec(tag="x-input", wrap=Wrap(tag="x-field"), label=Part(kind="sibling")),
+    )
+    dialog = _plain(resolve(Dialog(element("p"), label="Title").child_in("footer", Button(label="OK")).to_node(), design))
+    assert [c["tag"] for c in dialog["slots"]["default"]] == ["p", "h1"]  # `after` puts the title last
+    assert dialog["slots"]["footer"][0]["tag"] == "button"  # a generic child in a named slot resolves too
+    field = resolve(TextInput(label="Name").to_node(), design)
+    assert field["tag"] == "x-field" and "props" not in field

--- a/spaday/ui/__init__.py
+++ b/spaday/ui/__init__.py
@@ -1,0 +1,45 @@
+"""Generic controls and the designs that render them.
+
+::
+
+    from spaday.ui import Button, TextInput, Select, Dialog
+
+    page = Column(
+        TextInput(label="Name").bind("value", "name", mode="two-way"),
+        Select(label="Plan", options=["basic", "plus"]).bind("value", "plan", mode="two-way"),
+        Button(label="Save", intent="primary").on("click", SetField("saved", True)),
+    )
+    serve(page, packages=["webawesome"])   # rendered with WebAwesome's design
+    serve(page)                            # rendered with the native baseline
+
+See :mod:`spaday.ui.controls` for the vocabulary and :mod:`spaday.ui.design` for how a design
+describes its elements.
+"""
+
+from .controls import APPEARANCES, CONTROLS, INTENTS, SIZES, Button, Checkbox, Control, Dialog, Select, Switch, TextInput
+from .design import ControlSpec, Design, Open, Options, Part, Value, Wrap, resolve, select_design
+from .native import NATIVE
+
+__all__ = [
+    "APPEARANCES",
+    "CONTROLS",
+    "INTENTS",
+    "NATIVE",
+    "SIZES",
+    "Button",
+    "Checkbox",
+    "Control",
+    "ControlSpec",
+    "Design",
+    "Dialog",
+    "Open",
+    "Options",
+    "Part",
+    "Select",
+    "Switch",
+    "TextInput",
+    "Value",
+    "Wrap",
+    "resolve",
+    "select_design",
+]

--- a/spaday/ui/conformance.py
+++ b/spaday/ui/conformance.py
@@ -1,0 +1,74 @@
+"""The conformance page: one page using every generic control, for checking that a design renders
+them with the same behavior as the native baseline.
+
+:func:`page` and :func:`store` build it; ``python -m spaday.ui.conformance PORT [--package NAME …]
+[--design NAME]`` serves it, so a design-system package's browser tests can drive the same page
+rendered with its design (spaday's own ``js/tests/ui.spec.js`` drives it with the baseline). The
+page reports its store in ``#state`` as ``name|agree|dark|plan|saved|open``, so a test reads state
+back from the DOM whichever elements a design used.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from ..actions import Sequence, SetField, concat, field
+from ..component import Component, Paragraph, element
+from ..components.shell import Column, Row
+from .controls import Button, Checkbox, Dialog, Select, Switch, TextInput
+
+PLANS = [{"value": "basic", "label": "Basic"}, {"value": "plus", "label": "Plus"}, {"value": "premium", "label": "Premium"}]
+
+
+def page() -> Component:
+    """Every generic control, wired to the store :func:`store` seeds."""
+    return Column(
+        Row(
+            Button(id="save", label="Save", intent="primary").on("click", SetField("saved", True)),
+            Button(id="reset", label="Reset", appearance="outline").on("click", Sequence(SetField("name", ""), SetField("saved", False))),
+            Button(id="never", label="Disabled", disabled=True),
+            gap=".5rem",
+        ),
+        TextInput(id="name", label="Name", help="Your name", placeholder="Ada").bind("value", "name", mode="two-way"),
+        TextInput(id="email", label="Email", error="Required", type="email"),
+        Checkbox(id="agree", label="Agree").bind("value", "agree", mode="two-way"),
+        Switch(id="dark", label="Dark").bind("value", "dark", mode="two-way"),
+        Select(id="plan", label="Plan", options=PLANS).bind("value", "plan", mode="two-way"),
+        Button(id="open", label="Open dialog").on("click", SetField("open", True)),
+        Dialog(
+            Paragraph("Confirm?"),
+            Button(id="close", label="Close").on("click", SetField("open", False)),
+            id="dialog",
+            label="Confirm",
+        ).bind("open", "open", mode="two-way"),
+        element("output", id="state").compute(
+            "textContent",
+            concat(field("name"), "|", field("agree"), "|", field("dark"), "|", field("plan"), "|", field("saved"), "|", field("open")),
+        ),
+        gap="1rem",
+        id="conformance",
+    )
+
+
+def store() -> dict:
+    """The store the page's bindings read and write."""
+    return {"name": "", "agree": False, "dark": False, "plan": "basic", "saved": False, "open": False}
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Serve the generic-control conformance page.")
+    parser.add_argument("port", type=int)
+    parser.add_argument("--package", action="append", default=[], help="a component package to select (entry-point name or module:attribute)")
+    parser.add_argument("--design", default=None, help="the design to render with (a selected package's name, or 'native')")
+    args = parser.parse_args(argv)
+
+    import uvicorn
+
+    from ..backends.starlette import serve
+
+    app = serve(page, packages=args.package, design=args.design, store=store(), title="spaday ui conformance")
+    uvicorn.run(app, host="127.0.0.1", port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/spaday/ui/controls.py
+++ b/spaday/ui/controls.py
@@ -1,0 +1,346 @@
+"""Generic controls: a button, a text input, a checkbox, a switch, a select and a dialog that any
+design system renders.
+
+An application authors these once — ``Button(label="Save", intent="primary")`` — and the page's
+:class:`~spaday.ui.design.Design` decides which element that becomes: a ``wa-button``, a
+``ui5-button``, a ``vaadin-button``, or the native baseline's ``<button>``. The controls share one
+vocabulary, sized to what every design can express:
+
+- ``label`` (a button's text, a field's caption, a dialog's title), ``help`` (a hint under a
+  field) and ``error`` (a validation message, which also marks the field invalid);
+- ``disabled``, ``required``, ``readonly``, ``name``;
+- ``intent`` — ``neutral`` / ``primary`` / ``info`` / ``success`` / ``warning`` / ``danger`` — the
+  same tones the shell palette carries; ``appearance`` — ``filled`` / ``outline`` / ``plain``;
+  ``size`` — ``sm`` / ``md`` / ``lg``;
+- ``value``, the one prop to bind: a string for an input or a select, a boolean for a checkbox
+  or a switch (``bind("value", "agree", mode="two-way")`` reaches whatever property the design's
+  element uses, ``checked`` included); ``open`` for a dialog.
+
+A control serializes to a ``ui-*`` node carrying that vocabulary; :func:`spaday.ui.resolve` turns it
+into the design's elements before the tree leaves Python, so the browser only ever sees concrete
+tags. A design that lacks a control falls back to the native baseline. What a design cannot express
+is dropped rather than half-rendered; :meth:`Control.for_design` sets a design's own props on one
+control where that matters.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+
+from ..catalog import ComponentSchema, PropertySchema
+from ..component import Child, Component
+from .design import OVERRIDES_PROP
+
+INTENTS = ("neutral", "primary", "info", "success", "warning", "danger")
+APPEARANCES = ("filled", "outline", "plain")
+SIZES = ("sm", "md", "lg")
+INPUT_TYPES = ("text", "password", "email", "number", "search", "tel", "url")
+
+Intent = Literal["neutral", "primary", "info", "success", "warning", "danger"]
+Appearance = Literal["filled", "outline", "plain"]
+Size = Literal["sm", "md", "lg"]
+
+
+def _prop(name: str, kind: str, description: str, choices: tuple[str, ...] = (), type_text: str | None = None) -> PropertySchema:
+    return PropertySchema(name=name, kind=kind, choices=choices, description=description, type_text=type_text)
+
+
+_LABEL = _prop("label", "string", "The control's caption: a button's text, a field's label, a dialog's title.")
+_HELP = _prop("help", "string", "Help text shown with the control.")
+_ERROR = _prop("error", "string", "A validation message; while set, the control shows as invalid.")
+_DISABLED = _prop("disabled", "boolean", "Whether the control takes input.")
+_REQUIRED = _prop("required", "boolean", "Whether a value is required.")
+_READONLY = _prop("readonly", "boolean", "Whether the value can be edited.")
+_NAME = _prop("name", "string", "The control's form name.")
+_INTENT = _prop("intent", "enum", "The tone: neutral, primary, or one of the shell palette's info / success / warning / danger.", INTENTS)
+_APPEARANCE = _prop("appearance", "enum", "How the tone is drawn: filled, outline, or plain.", APPEARANCES)
+_SIZE = _prop("size", "enum", "The control's size.", SIZES)
+_OVERRIDES = _prop(OVERRIDES_PROP, "json", "Per-design props, set with for_design().", type_text="Record<string, Record<string, unknown>>")
+
+
+class Control(Component):
+    """Base of the generic controls: a ``ui-<kind>`` node any design renders."""
+
+    kind: ClassVar[str] = ""
+
+    def __init__(self, *children: Child, key: str | None = None, props: dict[str, Any] | None = None, **attrs: Any) -> None:
+        super().__init__(*children, key=key, props=props, **attrs)
+
+    def for_design(self, design: str, **props: Any) -> Control:
+        """Props set on the element only when ``design`` renders this control — the design's own
+        spelling for what the generic vocabulary leaves out (``for_design("webawesome", pill=True)``).
+        Applied after the generic props, so they can also override one."""
+        overrides = dict(self._props.get(OVERRIDES_PROP) or {})
+        overrides[design] = {**overrides.get(design, {}), **{k: v for k, v in props.items() if v is not None}}
+        self._props[OVERRIDES_PROP] = overrides
+        return self
+
+
+class Button(Control):
+    """A button. Its ``label`` is its text; attach behavior with ``.on("click", …)``.
+
+    ``Button(label="Save", intent="primary").on("click", SetField("saved", True))``
+    """
+
+    kind = "button"
+    tag = "ui-button"
+    schema = ComponentSchema(
+        tag="ui-button",
+        class_name="Button",
+        summary="A button any design renders.",
+        props=(_LABEL, _INTENT, _APPEARANCE, _SIZE, _DISABLED, _NAME, _OVERRIDES),
+        events=("click",),
+        slots=("",),
+    )
+
+    def __init__(
+        self,
+        *children: Child,
+        label: str | None = None,
+        intent: Intent | None = None,
+        appearance: Appearance | None = None,
+        size: Size | None = None,
+        disabled: bool | None = None,
+        name: str | None = None,
+        key: str | None = None,
+        **props: Any,
+    ) -> None:
+        super().__init__(
+            *children,
+            key=key,
+            props={"label": label, "intent": intent, "appearance": appearance, "size": size, "disabled": disabled, "name": name},
+            **props,
+        )
+
+
+class TextInput(Control):
+    """A single-line text input. Bind ``value`` (a string) two-way to a store field.
+
+    ``TextInput(label="Name", placeholder="Ada").bind("value", "name", mode="two-way")``
+    """
+
+    kind = "input"
+    tag = "ui-input"
+    schema = ComponentSchema(
+        tag="ui-input",
+        class_name="TextInput",
+        summary="A text input any design renders.",
+        props=(
+            _LABEL,
+            _HELP,
+            _ERROR,
+            _prop("value", "string", "The text; bind it two-way to a store field."),
+            _prop("placeholder", "string", "Text shown while empty."),
+            _prop("type", "enum", "The input type.", INPUT_TYPES),
+            _DISABLED,
+            _REQUIRED,
+            _READONLY,
+            _NAME,
+            _SIZE,
+            _OVERRIDES,
+        ),
+        events=("change", "input"),
+        slots=(),
+    )
+
+    def __init__(
+        self,
+        *,
+        label: str | None = None,
+        help: str | None = None,
+        error: str | None = None,
+        value: str | None = None,
+        placeholder: str | None = None,
+        type: Literal["text", "password", "email", "number", "search", "tel", "url"] | None = None,
+        disabled: bool | None = None,
+        required: bool | None = None,
+        readonly: bool | None = None,
+        name: str | None = None,
+        size: Size | None = None,
+        key: str | None = None,
+        **props: Any,
+    ) -> None:
+        super().__init__(
+            key=key,
+            props={
+                "label": label,
+                "help": help,
+                "error": error,
+                "value": value,
+                "placeholder": placeholder,
+                "type": type,
+                "disabled": disabled,
+                "required": required,
+                "readonly": readonly,
+                "name": name,
+                "size": size,
+            },
+            **props,
+        )
+
+
+class _Toggle(Control):
+    def __init__(
+        self,
+        *,
+        label: str | None = None,
+        help: str | None = None,
+        error: str | None = None,
+        value: bool | None = None,
+        disabled: bool | None = None,
+        required: bool | None = None,
+        name: str | None = None,
+        size: Size | None = None,
+        key: str | None = None,
+        **props: Any,
+    ) -> None:
+        super().__init__(
+            key=key,
+            props={
+                "label": label,
+                "help": help,
+                "error": error,
+                "value": value,
+                "disabled": disabled,
+                "required": required,
+                "name": name,
+                "size": size,
+            },
+            **props,
+        )
+
+
+_TOGGLE_PROPS = (
+    _LABEL,
+    _HELP,
+    _ERROR,
+    _prop("value", "boolean", "Whether it is on; bind it two-way to a store field."),
+    _DISABLED,
+    _REQUIRED,
+    _NAME,
+    _SIZE,
+    _OVERRIDES,
+)
+
+
+class Checkbox(_Toggle):
+    """A checkbox. Its ``value`` is a boolean; bind it two-way.
+
+    ``Checkbox(label="Agree").bind("value", "agree", mode="two-way")``
+    """
+
+    kind = "checkbox"
+    tag = "ui-checkbox"
+    schema = ComponentSchema(
+        tag="ui-checkbox", class_name="Checkbox", summary="A checkbox any design renders.", props=_TOGGLE_PROPS, events=("change",), slots=()
+    )
+
+
+class Switch(_Toggle):
+    """An on/off switch. Its ``value`` is a boolean; bind it two-way. (Exported at the top level as
+    ``ToggleSwitch``, beside the shell's ``Switch`` router.)
+
+    ``Switch(label="Dark theme").bind("value", "dark", mode="two-way")``
+    """
+
+    kind = "switch"
+    tag = "ui-switch"
+    schema = ComponentSchema(
+        tag="ui-switch", class_name="Switch", summary="A switch any design renders.", props=_TOGGLE_PROPS, events=("change",), slots=()
+    )
+
+
+class Select(Control):
+    """A single-choice select over ``options`` — a list of values, or of ``{"value": …, "label": …}``.
+    Bind ``value`` two-way.
+
+    ``Select(label="Plan", options=["basic", "plus"]).bind("value", "plan", mode="two-way")``
+
+    A design renders the options as child elements or as a property; binding ``options`` to a store
+    field is only possible with a design that takes them as a property.
+    """
+
+    kind = "select"
+    tag = "ui-select"
+    schema = ComponentSchema(
+        tag="ui-select",
+        class_name="Select",
+        summary="A select any design renders.",
+        props=(
+            _LABEL,
+            _HELP,
+            _ERROR,
+            _prop("options", "json", "The choices: values, or {value, label} objects.", type_text="Array<string | {value: string, label: string}>"),
+            _prop("value", "string", "The chosen value; bind it two-way to a store field."),
+            _prop("placeholder", "string", "Text shown while nothing is chosen."),
+            _DISABLED,
+            _REQUIRED,
+            _NAME,
+            _SIZE,
+            _OVERRIDES,
+        ),
+        events=("change",),
+        slots=(),
+    )
+
+    def __init__(
+        self,
+        *,
+        label: str | None = None,
+        help: str | None = None,
+        error: str | None = None,
+        options: list[Any] | None = None,
+        value: str | None = None,
+        placeholder: str | None = None,
+        disabled: bool | None = None,
+        required: bool | None = None,
+        name: str | None = None,
+        size: Size | None = None,
+        key: str | None = None,
+        **props: Any,
+    ) -> None:
+        super().__init__(
+            key=key,
+            props={
+                "label": label,
+                "help": help,
+                "error": error,
+                "options": list(options) if options is not None else None,
+                "value": value,
+                "placeholder": placeholder,
+                "disabled": disabled,
+                "required": required,
+                "name": name,
+                "size": size,
+            },
+            **props,
+        )
+
+
+class Dialog(Control):
+    """A modal dialog whose children are its content and whose ``label`` is its title. Bind ``open``
+    two-way: the field opens and closes it, and a close the dialog does itself (Escape) writes the
+    field back.
+
+    ``Dialog(Paragraph("Saved."), Button(label="OK").on("click", SetField("open", False)), label="Done").bind("open", "open", mode="two-way")``
+    """
+
+    kind = "dialog"
+    tag = "ui-dialog"
+    schema = ComponentSchema(
+        tag="ui-dialog",
+        class_name="Dialog",
+        summary="A dialog any design renders.",
+        props=(_LABEL, _prop("open", "boolean", "Whether it is open; bind it two-way to a store field."), _OVERRIDES),
+        events=("close",),
+        slots=("",),
+    )
+
+    def __init__(self, *children: Child, label: str | None = None, open: bool | None = None, key: str | None = None, **props: Any) -> None:
+        super().__init__(*children, key=key, props={"label": label, "open": open}, **props)
+
+
+CONTROLS: dict[str, type[Control]] = {cls.kind: cls for cls in (Button, TextInput, Checkbox, Switch, Select, Dialog)}
+"""Every generic control by kind — the keys a :class:`~spaday.ui.design.Design` describes."""
+
+__all__ = ["APPEARANCES", "CONTROLS", "INTENTS", "SIZES", "Button", "Checkbox", "Control", "Dialog", "Select", "Switch", "TextInput"]

--- a/spaday/ui/design.py
+++ b/spaday/ui/design.py
@@ -1,0 +1,374 @@
+"""Designs: how a design system renders the generic controls, as data.
+
+A :class:`Design` maps each generic control (see :mod:`spaday.ui.controls`) to one
+:class:`ControlSpec` — the element a design renders it as and how the control's generic surface lands
+on it: which attribute takes the label (or which slot, or a wrapper element around the control), what
+an ``intent`` of ``"primary"`` is called there, which property carries the value and which event
+reports a change, whether a dialog opens by property or by method. Everything in it is plain data,
+so a design round-trips through JSON: a design-system package publishes one on its
+:class:`~spaday.packages.ComponentPackage`, an application can ship its own, and a runtime could
+apply the same mapping without Python.
+
+:func:`resolve` applies a design to a serialized tree, replacing every generic ``ui-*`` node with the
+concrete elements the design describes, before the tree leaves Python. Controls a design does not
+describe fall back to the native baseline (:data:`spaday.ui.native.NATIVE`) and are marked
+``data-ui-fallback``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..component import DEFAULT_SLOT, _tag
+
+#: The generic node tags carry the control's kind: ``ui-button``, ``ui-input``, …
+GENERIC_PREFIX = "ui-"
+#: The prop a per-design override rides on (see ``Control.for_design``): design name → concrete props.
+OVERRIDES_PROP = "ui:overrides"
+#: The text parts every control may carry, resolved through a :class:`Part` each.
+PARTS = ("label", "help", "error")
+#: Generic props a design maps through ``ControlSpec.props``; one it leaves unmapped is dropped, so a
+#: control never leaks a spelling its design does not know.
+GENERIC_PROPS = frozenset({"intent", "appearance", "size", "disabled", "required", "readonly", "placeholder", "name", "type", "multiple"})
+
+
+class _Data(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class Part(_Data):
+    """Where a control's text part (its label, help text or error message) lands.
+
+    ``attr`` sets an attribute named ``name``; ``slot`` adds an element (``tag``, with ``props``) to
+    the control's slot ``name``; ``text`` sets the control's own text content; ``child`` adds the
+    element inside the control, before its other children (``after`` puts it last); ``sibling`` adds
+    it next to the control inside the design's :class:`Wrap`; ``none`` drops the part.
+    """
+
+    kind: Literal["attr", "slot", "text", "child", "sibling", "none"] = "attr"
+    name: str = ""
+    tag: str = "span"
+    props: dict[str, Any] = Field(default_factory=dict)
+    after: bool = False
+
+
+class Wrap(_Data):
+    """An element wrapped around the control, for designs that label controls from outside (a
+    ``bp-field``, a ``fluent-field``, a plain ``<label>``). ``control`` props are set on the control
+    inside it (a ``slot="input"``)."""
+
+    tag: str
+    props: dict[str, Any] = Field(default_factory=dict)
+    control: dict[str, Any] = Field(default_factory=dict)
+
+
+class Options(_Data):
+    """How a select's ``options`` land: as child elements (``tag`` each, the value on attribute
+    ``value``, the label as text or on attribute ``label``, optionally inside one ``wrap`` element), or
+    as a list on property ``name`` (each item ``{value: …, label: …}`` under those keys)."""
+
+    kind: Literal["children", "prop"] = "children"
+    tag: str = "option"
+    value: str = "value"
+    label: str = "text"
+    name: str = "items"
+    wrap: str = ""
+
+
+class Value(_Data):
+    """The property carrying a control's value (``checked`` for a toggle) and, for a two-way binding,
+    the event it changes on when that is not the runtime's default ``change``/``input``."""
+
+    prop: str = "value"
+    event: str | None = None
+
+
+class Open(_Data):
+    """How an overlay opens: property ``prop`` holds its state; ``methods`` — ``(open, close)`` — are
+    called instead of setting it when the element opens by method; ``event`` reports a close the
+    element did itself (Escape, a backdrop click), so a two-way binding follows."""
+
+    prop: str = "open"
+    event: str | None = None
+    methods: tuple[str, str] | None = None
+
+
+class ControlSpec(_Data):
+    """One generic control as one design renders it."""
+
+    #: the element rendered
+    tag: str
+    #: props always set on it (``type="button"``)
+    fixed: dict[str, Any] = Field(default_factory=dict)
+    #: generic prop → the attribute it becomes; ``None`` drops it as unsupported
+    props: dict[str, str | None] = Field(default_factory=dict)
+    #: generic prop → {generic value: the design's value}; an unlisted value passes through
+    values: dict[str, dict[str, str]] = Field(default_factory=dict)
+    label: Part = Field(default_factory=lambda: Part(kind="attr", name="label"))
+    help: Part = Field(default_factory=lambda: Part(kind="none"))
+    error: Part = Field(default_factory=lambda: Part(kind="none"))
+    #: props set while ``error`` is non-empty (``invalid``, ``value-state="Negative"``)
+    invalid: dict[str, Any] = Field(default_factory=dict)
+    wrap: Wrap | None = None
+    value: Value = Field(default_factory=Value)
+    options: Options | None = None
+    open: Open | None = None
+    #: generic event → the design's event name (``change`` → ``model-value-changed``)
+    events: dict[str, str] = Field(default_factory=dict)
+
+
+class Design(_Data):
+    """A design system's realizations of the generic controls, by control kind (``"button"``,
+    ``"input"``, ``"checkbox"``, ``"switch"``, ``"select"``, ``"dialog"``)."""
+
+    name: str
+    controls: dict[str, ControlSpec] = Field(default_factory=dict)
+
+
+def _plain(value: Any) -> Any:
+    """A core-tagged value back to Python (the inverse of ``component._tag``)."""
+    if value == "Null":
+        return None
+    if isinstance(value, dict) and len(value) == 1:
+        ((kind, inner),) = value.items()
+        if kind == "List":
+            return [_plain(v) for v in inner]
+        if kind == "Map":
+            return {k: _plain(v) for k, v in inner.items()}
+        if kind in ("Bool", "Int", "Float", "Str"):
+            return inner
+    return value
+
+
+def _element(tag: str, props: dict[str, Any], text: Any = None, binding: dict | None = None) -> dict:
+    node: dict = {"tag": tag, "props": {k: _tag(v) for k, v in props.items() if v is not None}}
+    if text is not None:
+        node["props"]["textContent"] = _tag(str(text))
+    if binding is not None:
+        node["bindings"] = {"textContent": binding}
+    return node
+
+
+def _describe(node: dict) -> str:
+    ident = _plain(node.get("props", {}).get("id", "Null"))
+    return f"<{node['tag']}{f' id={ident!r}' if ident else ''}>"
+
+
+def _option_items(options: Any) -> list[dict[str, Any]]:
+    items = []
+    for option in options or ():
+        if isinstance(option, dict):
+            items.append({"value": option.get("value"), "label": option.get("label", option.get("value"))})
+        else:
+            items.append({"value": option, "label": option})
+    return items
+
+
+class _Resolver:
+    def __init__(self, design: Design, fallback: Design) -> None:
+        self.design, self.fallback = design, fallback
+
+    def node(self, node: dict) -> dict:
+        if node.get("tag", "").startswith(GENERIC_PREFIX):
+            return self.control(node)
+        if node.get("slots"):
+            node = {
+                **node,
+                "slots": {slot: [self.node(c) if isinstance(c, dict) else c for c in children] for slot, children in node["slots"].items()},
+            }
+        return node
+
+    def control(self, node: dict) -> dict:
+        kind = node["tag"][len(GENERIC_PREFIX) :]
+        spec = self.design.controls.get(kind)
+        fallback = spec is None
+        if fallback:
+            spec = self.fallback.controls.get(kind)
+            if spec is None:
+                raise ValueError(f"{_describe(node)} is not a generic control that design {self.design.name!r} or the fallback describes")
+        props = {name: _plain(v) for name, v in node.get("props", {}).items()}
+        bindings = dict(node.get("bindings", {}))
+        overrides = (props.pop(OVERRIDES_PROP, None) or {}).get(self.design.name, {})
+        out: dict[str, Any] = dict(spec.fixed)
+        before: list[dict] = []  # parts placed inside the control ahead of its content
+        after: list[dict] = []
+        siblings_before: list[dict] = []
+        siblings_after: list[dict] = []
+        slots: dict[str, list] = {}
+        if fallback:
+            out["data-ui-fallback"] = self.fallback.name
+
+        for part in PARTS:
+            literal = props.pop(part, None)
+            binding = bindings.pop(part, None)
+            if literal is None and binding is None:
+                continue
+            where: Part = getattr(spec, part)
+            if where.kind == "attr":
+                out[where.name] = literal
+                if binding:
+                    bindings[where.name] = binding
+            elif where.kind == "text":
+                out["textContent"] = literal
+                if binding:
+                    bindings["textContent"] = binding
+            elif where.kind == "none":
+                continue
+            else:
+                element = _element(where.tag, {**where.props, **({"slot": where.name} if where.kind == "slot" else {})}, literal, binding)
+                if where.kind == "slot":
+                    slots.setdefault(where.name, []).append(element)
+                elif where.kind == "child":
+                    (after if where.after else before).append(element)
+                else:
+                    if spec.wrap is None:
+                        raise ValueError(f"design {self.design.name!r} places the {part} of {kind!r} beside the control but declares no wrap")
+                    (siblings_after if where.after else siblings_before).append(element)
+            if part == "error" and literal:
+                out.update(spec.invalid)
+
+        options = props.pop("options", None)
+        options_binding = bindings.pop("options", None)
+        value = props.pop("value", None)
+        if spec.options is not None and (options is not None or options_binding is not None):
+            if spec.options.kind == "prop":
+                if options is not None:
+                    out[spec.options.name] = [
+                        {spec.options.value: item["value"], spec.options.label: item["label"]} for item in _option_items(options)
+                    ]
+                if options_binding is not None:
+                    bindings[spec.options.name] = options_binding
+            else:
+                if options_binding is not None:
+                    raise ValueError(
+                        f"{_describe(node)} binds its options, which design {self.design.name!r} renders as child elements; "
+                        "pass a literal list, or a design that takes options as a property"
+                    )
+                children = []
+                for item in _option_items(options):
+                    option_props = {spec.options.value: item["value"]}
+                    if item["value"] == value and value is not None:
+                        option_props["selected"] = True  # a value set before its options exist selects nothing
+                    if spec.options.label == "text":
+                        children.append(_element(spec.options.tag, option_props, item["label"]))
+                    else:
+                        children.append(_element(spec.options.tag, {**option_props, spec.options.label: item["label"]}))
+                if spec.options.wrap:
+                    children = [{"tag": spec.options.wrap, "slots": {DEFAULT_SLOT: children}}]
+                after.extend(children)
+        if value is not None:
+            out[spec.value.prop] = value
+        if "value" in bindings:
+            binding = bindings.pop("value")
+            if binding.get("mode") == "two-way" and spec.value.event:
+                binding = {**binding, "event": spec.value.event}
+            bindings[spec.value.prop] = binding
+
+        opened = props.pop("open", None)
+        open_binding = bindings.pop("open", None)
+        if spec.open is not None:
+            if opened is not None:
+                out[spec.open.prop] = opened
+            if open_binding is not None:
+                binding = dict(open_binding)
+                if spec.open.event and binding.get("mode") == "two-way":
+                    binding["event"] = spec.open.event
+                if spec.open.methods:
+                    binding["methods"] = list(spec.open.methods)
+                bindings[spec.open.prop] = binding
+
+        for name, v in props.items():
+            if name in spec.props:
+                target = spec.props[name]
+                if target is None:
+                    continue
+                out[target] = spec.values.get(name, {}).get(v, v) if isinstance(v, str) else v
+            elif name not in GENERIC_PROPS:
+                out[name] = v  # id, class, style, data-*, aria-* and other generic element props
+        for name in list(bindings):
+            if name in spec.props:
+                target = spec.props[name]
+                binding = bindings.pop(name)
+                if target is not None:
+                    bindings[target] = binding
+            elif name in GENERIC_PROPS:
+                bindings.pop(name)
+        out.update(overrides)
+
+        control: dict[str, Any] = {"tag": spec.tag}
+        control_props = {k: v for k, v in out.items() if v is not None}
+        if spec.wrap is not None:
+            control_props.update(spec.wrap.control)
+        if control_props:
+            control["props"] = {k: _tag(v) for k, v in control_props.items()}
+        content = [self.node(c) if isinstance(c, dict) else c for c in node.get("slots", {}).get(DEFAULT_SLOT, [])]
+        default = [*before, *content, *after]
+        if default:
+            slots[DEFAULT_SLOT] = default
+        for slot, children in node.get("slots", {}).items():
+            if slot != DEFAULT_SLOT:
+                slots.setdefault(slot, []).extend(self.node(c) if isinstance(c, dict) else c for c in children)
+        if slots:
+            control["slots"] = slots
+        if node.get("events"):
+            control["events"] = {spec.events.get(event, event): action for event, action in node["events"].items()}
+        if bindings:
+            control["bindings"] = bindings
+
+        if spec.wrap is None:
+            outer = control
+        else:
+            outer = {
+                "tag": spec.wrap.tag,
+                "props": {k: _tag(v) for k, v in spec.wrap.props.items()},
+                "slots": {DEFAULT_SLOT: [*siblings_before, control, *siblings_after]},
+            }
+            if not outer["props"]:
+                del outer["props"]
+        if "key" in node:
+            outer["key"] = node["key"]
+        return outer
+
+
+def resolve(node: dict, design: Design, *, fallback: Design | None = None) -> dict:
+    """The serialized tree ``node`` with every generic control replaced by what ``design`` renders it
+    as. A control the design does not describe is rendered by ``fallback`` (the native baseline when
+    not given) and marked ``data-ui-fallback``."""
+    if fallback is None:
+        from .native import NATIVE
+
+        fallback = NATIVE
+    return _Resolver(design, fallback).node(node)
+
+
+def select_design(design: Design | str | None, packages: Any = ()) -> Design:
+    """The design a page renders its generic controls with.
+
+    A :class:`Design` is used as given. ``None`` takes the one design the selected ``packages``
+    publish, or the native baseline when none does; several is an error naming them, since one page
+    renders with one design. A name selects a package's design by the package's name, or
+    ``"native"`` for the baseline.
+    """
+    from .native import NATIVE
+
+    if isinstance(design, Design):
+        return design
+    published = [(package.name, package.design) for package in packages if getattr(package, "design", None) is not None]
+    if design is None:
+        if not published:
+            return NATIVE
+        if len(published) > 1:
+            names = ", ".join(repr(name) for name, _ in published)
+            raise ValueError(f"several selected packages publish a design ({names}); pass design= to choose one")
+        return published[0][1]
+    if design == NATIVE.name:
+        return NATIVE
+    for name, found in published:
+        if name == design:
+            return found
+    available = ", ".join(repr(name) for name, _ in published) or "none selected"
+    raise ValueError(
+        f"no selected package publishes the design {design!r} (packages with a design: {available}); select its package, or pass a Design"
+    )

--- a/spaday/ui/native.py
+++ b/spaday/ui/native.py
@@ -1,0 +1,81 @@
+"""The native baseline: the generic controls as plain HTML form elements.
+
+What a page gets with no design-system package selected, and the fallback for a control a design
+does not describe. The runtime styles the elements (marked ``data-ui``) from the ``--spa-*`` shell
+palette, so they follow the page mode and any app-level theme; see ``js/src/ts/ui.ts``.
+"""
+
+from __future__ import annotations
+
+from .design import ControlSpec, Design, Open, Options, Part, Value, Wrap
+
+_FIELD = Wrap(tag="label", props={"data-ui": "field"})
+_INLINE = Wrap(tag="label", props={"data-ui": "field", "data-inline": True})
+_LABEL = Part(kind="sibling", tag="span", props={"data-ui": "label"})
+_HELP = Part(kind="sibling", tag="span", props={"data-ui": "help"}, after=True)
+_ERROR = Part(kind="sibling", tag="span", props={"data-ui": "error"}, after=True)
+_FIELD_PROPS = {"disabled": "disabled", "required": "required", "readonly": "readonly", "name": "name", "size": "data-size"}
+
+NATIVE = Design(
+    name="native",
+    controls={
+        "button": ControlSpec(
+            tag="button",
+            fixed={"type": "button", "data-ui": "button"},
+            label=Part(kind="text"),
+            props={"intent": "data-intent", "appearance": "data-appearance", "size": "data-size", "disabled": "disabled", "name": "name"},
+        ),
+        "input": ControlSpec(
+            tag="input",
+            fixed={"data-ui": "input"},
+            wrap=_FIELD,
+            label=_LABEL,
+            help=_HELP,
+            error=_ERROR,
+            invalid={"data-invalid": True},
+            props={**_FIELD_PROPS, "placeholder": "placeholder", "type": "type"},
+        ),
+        "checkbox": ControlSpec(
+            tag="input",
+            fixed={"type": "checkbox", "data-ui": "checkbox"},
+            wrap=_INLINE,
+            label=Part(kind="sibling", tag="span", props={"data-ui": "label"}, after=True),
+            help=_HELP,
+            error=_ERROR,
+            invalid={"data-invalid": True},
+            props=_FIELD_PROPS,
+            value=Value(prop="checked"),
+        ),
+        "switch": ControlSpec(
+            tag="input",
+            fixed={"type": "checkbox", "role": "switch", "data-ui": "switch"},
+            wrap=_INLINE,
+            label=Part(kind="sibling", tag="span", props={"data-ui": "label"}, after=True),
+            help=_HELP,
+            error=_ERROR,
+            invalid={"data-invalid": True},
+            props=_FIELD_PROPS,
+            value=Value(prop="checked"),
+        ),
+        "select": ControlSpec(
+            tag="select",
+            fixed={"data-ui": "select"},
+            wrap=_FIELD,
+            label=_LABEL,
+            help=_HELP,
+            error=_ERROR,
+            invalid={"data-invalid": True},
+            props={**_FIELD_PROPS, "placeholder": None},
+            options=Options(kind="children", tag="option", value="value", label="text"),
+        ),
+        "dialog": ControlSpec(
+            tag="dialog",
+            fixed={"data-ui": "dialog"},
+            label=Part(kind="child", tag="h2", props={"data-ui": "title"}),
+            open=Open(prop="open", event="close", methods=("showModal", "close")),
+        ),
+    },
+)
+"""The native design."""
+
+__all__ = ["NATIVE"]

--- a/spaday/widget.py
+++ b/spaday/widget.py
@@ -23,6 +23,7 @@ import anywidget
 import traitlets
 
 from .component import Component
+from .ui.design import Design, resolve, select_design
 
 _EXT = Path(__file__).parent / "extension"
 _ESM = _EXT / "cdn" / "widget.js"
@@ -30,8 +31,8 @@ _ESM = _EXT / "cdn" / "widget.js"
 Tree = Component | dict
 
 
-def _to_node(tree: Tree) -> dict:
-    return tree.to_node() if isinstance(tree, Component) else tree
+def _to_node(tree: Tree, design: Design | str | None) -> dict:
+    return resolve(tree.to_node() if isinstance(tree, Component) else tree, select_design(design))
 
 
 class Widget(anywidget.AnyWidget):
@@ -43,16 +44,17 @@ class Widget(anywidget.AnyWidget):
     # two-way-bound control updates Python here, and a Python-side change updates the bound props.
     _state = traitlets.Dict().tag(sync=True)
 
-    def __init__(self, tree: Tree, state: dict | None = None, **kwargs: Any) -> None:
+    def __init__(self, tree: Tree, state: dict | None = None, *, design: Design | str | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._tree = _to_node(tree)
+        self._design = design  # renders the tree's generic controls (spaday.ui); None is the native baseline
+        self._tree = _to_node(tree, design)
         self._state = dict(state or {})
         self._intent_handlers: list[Callable[[dict], None]] = []
         self.on_msg(self._on_msg)
 
     def update(self, tree: Tree) -> None:
         """Replace the rendered tree; the browser applies a minimal diff to the live DOM."""
-        self._tree = _to_node(tree)
+        self._tree = _to_node(tree, self._design)
 
     @property
     def state(self) -> dict:

--- a/spaday/worker.py
+++ b/spaday/worker.py
@@ -9,26 +9,28 @@ from collections.abc import Callable
 
 from .component import Component
 from .spaday import diff
+from .ui.design import Design, resolve, select_design
 
 Tree = Component | dict
 Intent = dict
 
 
-def _node(tree: Tree) -> dict:
-    return tree.to_node() if isinstance(tree, Component) else tree
+def _node(tree: Tree, design: Design | str | None) -> dict:
+    return resolve(tree.to_node() if isinstance(tree, Component) else tree, select_design(design))
 
 
 class WorkerApp:
     """Adapt a render function and intent handler to spaday's worker message protocol."""
 
-    def __init__(self, render: Callable[[], Tree], on_intent: Callable[[Intent], None]) -> None:
+    def __init__(self, render: Callable[[], Tree], on_intent: Callable[[Intent], None], *, design: Design | str | None = None) -> None:
         self._render = render
+        self._design = design  # renders the tree's generic controls (spaday.ui); None is the native baseline
         self._on_intent = on_intent
         self._tree: str | None = None
 
     def start(self) -> dict:
         """Render and return the initial tree snapshot message."""
-        tree = _node(self._render())
+        tree = _node(self._render(), self._design)
         self._tree = json.dumps(tree)
         return {"type": "snapshot", "tree": tree}
 
@@ -41,7 +43,7 @@ class WorkerApp:
 
         old = self._tree
         self._on_intent(intent)
-        self._tree = json.dumps(_node(self._render()))
+        self._tree = json.dumps(_node(self._render(), self._design))
         patch = json.loads(diff(old, self._tree))
         return {"type": "patch", "patch": patch}
 


### PR DESCRIPTION
Adds `spaday.ui`: generic controls an application writes once and any design system renders, so a page is not tied to one catalog's classes and a user can swap the design — including one of their own.

**Controls.** `Button`, `TextInput`, `Checkbox`, `Switch` (exported at the top level as `ToggleSwitch`, beside the shell's `Switch` router), `Select` and `Dialog`, with one vocabulary sized to what every design can express: `label` / `help` / `error`, `disabled` / `required` / `readonly`, `intent` (`neutral` / `primary` / `info` / `success` / `warning` / `danger`), `appearance` (`filled` / `outline` / `plain`), `size` (`sm` / `md` / `lg`), and `value` to bind on every control — a string or a boolean — plus `open` on a dialog. Each carries a schema, so `validate()` and the prop-kind checks cover them. A control serializes to a `ui-*` node.

**Designs as data.** A `Design` maps each control kind to a `ControlSpec`: the element, fixed props, generic prop → attribute names with value maps (`intent: primary` → `variant: brand`), where the label / help / error land (`Part`: an attribute, a slotted element, the control's text, a child, or a sibling inside a `Wrap` around the control), the value property and its change event (`Value`), how options render (`Options`: child elements, optionally wrapped, or a list property), and how an overlay opens (`Open`: property, or a method pair plus the event of a self-close). Everything is pydantic data that round-trips through JSON, so a design-system package publishes one on `ComponentPackage(design=…)`, an application can ship its own, and a runtime could apply the same mapping later.

**Resolution in Python.** `resolve(node, design)` rewrites a serialized tree's generic nodes into the design's elements before the tree leaves Python, so the browser only sees concrete tags and the existing catalog validation still applies. Every serving path resolves: the tree routes of all four backends, `render_html`, `Widget` and `WorkerApp` take `design=`; a backend chooses the design from the selected packages (`select_design`: the one package that publishes a design, `"native"`, or an error naming several). A control the design lacks renders with the native baseline and is marked `data-ui-fallback`; a bound `options` with a design that renders options as children is an authoring-time error. `for_design(name, **props)` sets a design's own props on one control.

**Native baseline.** `NATIVE` renders the controls as plain `<button>`, `<input>`, `<select>` and `<dialog>` elements marked `data-ui`, styled by the runtime from the `--spa-*` palette, so a generic app runs with no design system installed and every realization has one reference behavior.

**Runtime.** Two binding features designs rely on, in the Rust `Binding` and the runtime: `event` names the event a two-way binding writes back on (a Lion control's `model-value-changed`), and `methods: [open, close]` drives a prop by calling those methods as the field turns truthy / falsy (a `<dialog>`'s `showModal()` / `close()`, a popover's `showPopover()`), skipping a call the element is already in the state for and reading the prop back on the event so a self-close reaches the store. `Component.bind()` exposes both.

**Conformance.** `spaday.ui.conformance` builds a page using every control, wired to a store it reports in the DOM, and serves it (`python -m spaday.ui.conformance PORT --package NAME`), so a design-system package can drive the same page with its design; `js/tests/ui.spec.js` drives it with the baseline (round-trips through the store, the select, the dialog opening from state / closing from a button / reporting its own Escape, labels, help, errors, disabled) and covers the two runtime features.

Docs: a section in the components how-to, the design contract in the customizing guide, and the API reference.
